### PR TITLE
chore: comment out code signing config in win build settings

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -27,8 +27,8 @@ extraResources:
 asarUnpack:
     - resources/**
 win:
-    cscLink: nahida-desktop.pfx
-    cscKeyPassword: password
+    # cscLink: nahida-desktop.pfx
+    # cscKeyPassword: password
     executableName: Nahida Desktop
 nsis:
     artifactName: Nahida Desktop Setup ${version}.${ext}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled Windows code signing configuration for application builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->