### PR TITLE
Release 2.45.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahida-desktop",
-  "version": "2.44.0",
+  "version": "2.45.0",
   "description": "Native app for nahida.live",
   "homepage": "https://nahida.live",
   "author": "nahida.live",

--- a/src/main/internal/db/client.ts
+++ b/src/main/internal/db/client.ts
@@ -292,7 +292,7 @@ export class DatabaseClient {
     public readonly gamePaths = {
         getByGame: async (game: string) => {
             const row = this.get<GamePathRow>(
-                `SELECT "game", "modFolderPath", "importer", "linkedModFolderPath",
+                `SELECT "game", "modFolderPath", "importer", "linkedModFolderPath", "gameInstallPath", "gameExecutablePath",
                         CASE
                             WHEN "order" = 0 THEN rowid
                             ELSE "order"
@@ -304,7 +304,7 @@ export class DatabaseClient {
         },
         list: async () =>
             this.all<GamePathRow>(
-                `SELECT "game", "modFolderPath", "importer", "linkedModFolderPath",
+                `SELECT "game", "modFolderPath", "importer", "linkedModFolderPath", "gameInstallPath", "gameExecutablePath",
                         CASE
                             WHEN "order" = 0 THEN rowid
                             ELSE "order"
@@ -319,7 +319,7 @@ export class DatabaseClient {
             ),
         findByGameOrModFolderPath: async (game: string, modFolderPath: string) => {
             const row = this.get<GamePathRow>(
-                `SELECT "game", "modFolderPath", "importer", "linkedModFolderPath", "order"
+                `SELECT "game", "modFolderPath", "importer", "linkedModFolderPath", "gameInstallPath", "gameExecutablePath", "order"
                  FROM "game_paths"
                  WHERE "game" = ? OR "modFolderPath" = ? OR "linkedModFolderPath" = ?
                  LIMIT 1`,
@@ -329,7 +329,7 @@ export class DatabaseClient {
         },
         findByModFolderPathOtherGame: async (game: string, modFolderPath: string) => {
             const row = this.get<GamePathRow>(
-                `SELECT "game", "modFolderPath", "importer", "linkedModFolderPath", "order"
+                `SELECT "game", "modFolderPath", "importer", "linkedModFolderPath", "gameInstallPath", "gameExecutablePath", "order"
                  FROM "game_paths"
                  WHERE ("modFolderPath" = ? OR "linkedModFolderPath" = ?) AND "game" <> ?
                  LIMIT 1`,
@@ -350,33 +350,66 @@ export class DatabaseClient {
                 )?.maxOrder ?? 0;
 
             this.run(
-                `INSERT INTO "game_paths" ("game", "modFolderPath", "importer", "linkedModFolderPath", "order")
-                 VALUES (?, ?, ?, ?, ?)`,
-                [row.game, row.modFolderPath, row.importer, row.linkedModFolderPath, maxOrder + 1],
+                `INSERT INTO "game_paths" ("game", "modFolderPath", "importer", "linkedModFolderPath", "gameInstallPath", "gameExecutablePath", "order")
+                 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+                [
+                    row.game,
+                    row.modFolderPath,
+                    row.importer,
+                    row.linkedModFolderPath,
+                    row.gameInstallPath,
+                    row.gameExecutablePath,
+                    maxOrder + 1,
+                ],
             );
         },
         upsert: async (row: GamePathRow) => {
             this.run(
-                `INSERT INTO "game_paths" ("game", "modFolderPath", "importer", "linkedModFolderPath", "order")
-                 VALUES (?, ?, ?, ?, ?)
+                `INSERT INTO "game_paths" ("game", "modFolderPath", "importer", "linkedModFolderPath", "gameInstallPath", "gameExecutablePath", "order")
+                 VALUES (?, ?, ?, ?, ?, ?, ?)
                  ON CONFLICT("game") DO UPDATE
                  SET "modFolderPath" = excluded."modFolderPath",
                      "importer" = excluded."importer",
                      "linkedModFolderPath" = excluded."linkedModFolderPath",
+                     "gameInstallPath" = excluded."gameInstallPath",
+                     "gameExecutablePath" = excluded."gameExecutablePath",
                      "order" = excluded."order"`,
-                [row.game, row.modFolderPath, row.importer, row.linkedModFolderPath, row.order],
+                [
+                    row.game,
+                    row.modFolderPath,
+                    row.importer,
+                    row.linkedModFolderPath,
+                    row.gameInstallPath,
+                    row.gameExecutablePath,
+                    row.order,
+                ],
             );
         },
         update: async (
             game: string,
-            updates: Pick<GamePathRow, "modFolderPath" | "importer" | "linkedModFolderPath">,
+            updates: Pick<
+                GamePathRow,
+                "modFolderPath" | "importer" | "linkedModFolderPath" | "gameInstallPath"
+            >,
         ) => {
             this.run(
                 `UPDATE "game_paths"
-                 SET "modFolderPath" = ?, "importer" = ?, "linkedModFolderPath" = ?
+                 SET "modFolderPath" = ?, "importer" = ?, "linkedModFolderPath" = ?, "gameInstallPath" = ?
                  WHERE "game" = ?`,
-                [updates.modFolderPath, updates.importer, updates.linkedModFolderPath, game],
+                [
+                    updates.modFolderPath,
+                    updates.importer,
+                    updates.linkedModFolderPath,
+                    updates.gameInstallPath,
+                    game,
+                ],
             );
+        },
+        setGameExecutablePath: async (game: string, gameExecutablePath: string) => {
+            this.run(`UPDATE "game_paths" SET "gameExecutablePath" = ? WHERE "game" = ?`, [
+                gameExecutablePath,
+                game,
+            ]);
         },
         reorder: async (games: string[]) => {
             const statement = this.prepare(`UPDATE "game_paths" SET "order" = ? WHERE "game" = ?`);

--- a/src/main/internal/db/client.ts
+++ b/src/main/internal/db/client.ts
@@ -389,18 +389,23 @@ export class DatabaseClient {
             game: string,
             updates: Pick<
                 GamePathRow,
-                "modFolderPath" | "importer" | "linkedModFolderPath" | "gameInstallPath"
+                | "modFolderPath"
+                | "importer"
+                | "linkedModFolderPath"
+                | "gameInstallPath"
+                | "gameExecutablePath"
             >,
         ) => {
             this.run(
                 `UPDATE "game_paths"
-                 SET "modFolderPath" = ?, "importer" = ?, "linkedModFolderPath" = ?, "gameInstallPath" = ?
+                 SET "modFolderPath" = ?, "importer" = ?, "linkedModFolderPath" = ?, "gameInstallPath" = ?, "gameExecutablePath" = ?
                  WHERE "game" = ?`,
                 [
                     updates.modFolderPath,
                     updates.importer,
                     updates.linkedModFolderPath,
                     updates.gameInstallPath,
+                    updates.gameExecutablePath,
                     game,
                 ],
             );

--- a/src/main/internal/db/client.ts
+++ b/src/main/internal/db/client.ts
@@ -292,7 +292,7 @@ export class DatabaseClient {
     public readonly gamePaths = {
         getByGame: async (game: string) => {
             const row = this.get<GamePathRow>(
-                `SELECT "game", "modFolderPath", "importer",
+                `SELECT "game", "modFolderPath", "importer", "linkedModFolderPath",
                         CASE
                             WHEN "order" = 0 THEN rowid
                             ELSE "order"
@@ -304,7 +304,7 @@ export class DatabaseClient {
         },
         list: async () =>
             this.all<GamePathRow>(
-                `SELECT "game", "modFolderPath", "importer",
+                `SELECT "game", "modFolderPath", "importer", "linkedModFolderPath",
                         CASE
                             WHEN "order" = 0 THEN rowid
                             ELSE "order"
@@ -319,21 +319,21 @@ export class DatabaseClient {
             ),
         findByGameOrModFolderPath: async (game: string, modFolderPath: string) => {
             const row = this.get<GamePathRow>(
-                `SELECT "game", "modFolderPath", "importer", "order"
+                `SELECT "game", "modFolderPath", "importer", "linkedModFolderPath", "order"
                  FROM "game_paths"
-                 WHERE "game" = ? OR "modFolderPath" = ?
+                 WHERE "game" = ? OR "modFolderPath" = ? OR "linkedModFolderPath" = ?
                  LIMIT 1`,
-                [game, modFolderPath],
+                [game, modFolderPath, modFolderPath],
             );
             return row ?? null;
         },
         findByModFolderPathOtherGame: async (game: string, modFolderPath: string) => {
             const row = this.get<GamePathRow>(
-                `SELECT "game", "modFolderPath", "importer", "order"
+                `SELECT "game", "modFolderPath", "importer", "linkedModFolderPath", "order"
                  FROM "game_paths"
-                 WHERE "modFolderPath" = ? AND "game" <> ?
+                 WHERE ("modFolderPath" = ? OR "linkedModFolderPath" = ?) AND "game" <> ?
                  LIMIT 1`,
-                [modFolderPath, game],
+                [modFolderPath, modFolderPath, game],
             );
             return row ?? null;
         },
@@ -350,26 +350,32 @@ export class DatabaseClient {
                 )?.maxOrder ?? 0;
 
             this.run(
-                `INSERT INTO "game_paths" ("game", "modFolderPath", "importer", "order")
-                 VALUES (?, ?, ?, ?)`,
-                [row.game, row.modFolderPath, row.importer, maxOrder + 1],
+                `INSERT INTO "game_paths" ("game", "modFolderPath", "importer", "linkedModFolderPath", "order")
+                 VALUES (?, ?, ?, ?, ?)`,
+                [row.game, row.modFolderPath, row.importer, row.linkedModFolderPath, maxOrder + 1],
             );
         },
         upsert: async (row: GamePathRow) => {
             this.run(
-                `INSERT INTO "game_paths" ("game", "modFolderPath", "importer", "order")
-                 VALUES (?, ?, ?, ?)
+                `INSERT INTO "game_paths" ("game", "modFolderPath", "importer", "linkedModFolderPath", "order")
+                 VALUES (?, ?, ?, ?, ?)
                  ON CONFLICT("game") DO UPDATE
                  SET "modFolderPath" = excluded."modFolderPath",
                      "importer" = excluded."importer",
+                     "linkedModFolderPath" = excluded."linkedModFolderPath",
                      "order" = excluded."order"`,
-                [row.game, row.modFolderPath, row.importer, row.order],
+                [row.game, row.modFolderPath, row.importer, row.linkedModFolderPath, row.order],
             );
         },
-        update: async (game: string, updates: Pick<GamePathRow, "modFolderPath" | "importer">) => {
+        update: async (
+            game: string,
+            updates: Pick<GamePathRow, "modFolderPath" | "importer" | "linkedModFolderPath">,
+        ) => {
             this.run(
-                `UPDATE "game_paths" SET "modFolderPath" = ?, "importer" = ? WHERE "game" = ?`,
-                [updates.modFolderPath, updates.importer, game],
+                `UPDATE "game_paths"
+                 SET "modFolderPath" = ?, "importer" = ?, "linkedModFolderPath" = ?
+                 WHERE "game" = ?`,
+                [updates.modFolderPath, updates.importer, updates.linkedModFolderPath, game],
             );
         },
         reorder: async (games: string[]) => {

--- a/src/main/internal/db/schema.ts
+++ b/src/main/internal/db/schema.ts
@@ -13,6 +13,7 @@ export type GamePathRow = {
     game: string;
     modFolderPath: string;
     importer: string | null;
+    linkedModFolderPath: string | null;
     order: number;
 };
 
@@ -141,6 +142,7 @@ export const TABLE_SPECS: TableSpec[] = [
             { name: "game", type: "TEXT", primaryKey: true, notNull: true },
             { name: "modFolderPath", type: "TEXT", notNull: true },
             { name: "importer", type: "TEXT" },
+            { name: "linkedModFolderPath", type: "TEXT" },
             { name: "order", type: "INTEGER", notNull: true, defaultSql: "0" },
         ],
     },

--- a/src/main/internal/db/schema.ts
+++ b/src/main/internal/db/schema.ts
@@ -14,6 +14,8 @@ export type GamePathRow = {
     modFolderPath: string;
     importer: string | null;
     linkedModFolderPath: string | null;
+    gameInstallPath: string | null;
+    gameExecutablePath: string | null;
     order: number;
 };
 
@@ -143,6 +145,8 @@ export const TABLE_SPECS: TableSpec[] = [
             { name: "modFolderPath", type: "TEXT", notNull: true },
             { name: "importer", type: "TEXT" },
             { name: "linkedModFolderPath", type: "TEXT" },
+            { name: "gameInstallPath", type: "TEXT" },
+            { name: "gameExecutablePath", type: "TEXT" },
             { name: "order", type: "INTEGER", notNull: true, defaultSql: "0" },
         ],
     },

--- a/src/main/ipc/handlers/mod.ts
+++ b/src/main/ipc/handlers/mod.ts
@@ -34,8 +34,17 @@ export function registerModHandlers(desktop: NahidaDesktop) {
             path: string,
             importer: string | null,
             linkedModFolderPath: string | null = null,
+            gameInstallPath: string | null = null,
+            gameExecutablePath: string | null = null,
         ) => {
-            return await desktop.service.mod.fn.addGame(game, path, importer, linkedModFolderPath);
+            return await desktop.service.mod.fn.addGame(
+                game,
+                path,
+                importer,
+                linkedModFolderPath,
+                gameInstallPath,
+                gameExecutablePath,
+            );
         },
     );
 
@@ -51,6 +60,7 @@ export function registerModHandlers(desktop: NahidaDesktop) {
                 modFolderPath: string;
                 importer: string | null;
                 linkedModFolderPath: string | null;
+                gameInstallPath: string | null;
             },
         ) => {
             return await desktop.service.mod.fn.updateGame(game, updates);
@@ -59,6 +69,27 @@ export function registerModHandlers(desktop: NahidaDesktop) {
 
     rh("mod:resolveNteInstallPath", async (installPath: string) => {
         return await desktop.service.mod.get.resolveNteInstallPath(installPath);
+    });
+
+    rh("mod:pickExecutable", async () => {
+        const result = await dialog.showOpenDialog({
+            properties: ["openFile"],
+            filters: [{ name: "Launcher", extensions: ["exe"] }],
+        });
+
+        if (result.canceled || result.filePaths.length === 0) {
+            return null;
+        }
+
+        return result.filePaths[0];
+    });
+
+    rh("mod:setGameExecutablePath", async (game: string, executablePath: string) => {
+        return await desktop.service.mod.fn.setGameExecutablePath(game, executablePath);
+    });
+
+    rh("mod:startNteGame", async (game: string) => {
+        return await desktop.service.mod.fn.startNteGame(game);
     });
 
     rh("mod:reorderGames", async (games: string[]) => {
@@ -81,8 +112,8 @@ export function registerModHandlers(desktop: NahidaDesktop) {
         return await desktop.service.mod.get.characters(game, searchModPreview);
     });
 
-    rh("mod:resolveDownloadTarget", async (input: string) => {
-        return await desktop.service.mod.get.resolveDownloadTarget(input);
+    rh("mod:resolveDownloadTarget", async (input: string, gameFilter?: string) => {
+        return await desktop.service.mod.get.resolveDownloadTarget(input, gameFilter);
     });
 
     rh("mod:getSubGroups", async (folderPath: string, searchModPreview?: boolean) => {

--- a/src/main/ipc/handlers/mod.ts
+++ b/src/main/ipc/handlers/mod.ts
@@ -61,6 +61,7 @@ export function registerModHandlers(desktop: NahidaDesktop) {
                 importer: string | null;
                 linkedModFolderPath: string | null;
                 gameInstallPath: string | null;
+                gameExecutablePath: string | null;
             },
         ) => {
             return await desktop.service.mod.fn.updateGame(game, updates);

--- a/src/main/ipc/handlers/mod.ts
+++ b/src/main/ipc/handlers/mod.ts
@@ -27,9 +27,17 @@ export function registerModHandlers(desktop: NahidaDesktop) {
         return await desktop.service.mod.get.games();
     });
 
-    rh("mod:addGame", async (game: string, path: string, importer: string | null) => {
-        return await desktop.service.mod.fn.addGame(game, path, importer);
-    });
+    rh(
+        "mod:addGame",
+        async (
+            game: string,
+            path: string,
+            importer: string | null,
+            linkedModFolderPath: string | null = null,
+        ) => {
+            return await desktop.service.mod.fn.addGame(game, path, importer, linkedModFolderPath);
+        },
+    );
 
     rh("mod:removeGame", async (game: string) => {
         return await desktop.service.mod.fn.removeGame(game);
@@ -42,11 +50,16 @@ export function registerModHandlers(desktop: NahidaDesktop) {
             updates: {
                 modFolderPath: string;
                 importer: string | null;
+                linkedModFolderPath: string | null;
             },
         ) => {
             return await desktop.service.mod.fn.updateGame(game, updates);
         },
     );
+
+    rh("mod:resolveNteInstallPath", async (installPath: string) => {
+        return await desktop.service.mod.get.resolveNteInstallPath(installPath);
+    });
 
     rh("mod:reorderGames", async (games: string[]) => {
         return await desktop.service.mod.fn.reorderGames(games);

--- a/src/main/lib/custom-downloader/index.ts
+++ b/src/main/lib/custom-downloader/index.ts
@@ -366,6 +366,7 @@ export class CustomDownloader {
         const result = await this.desktop.lib.pathSelector.getSelectedPathWithModeModal(
             suggestedFileName,
             downloadFilePayload.categoryName,
+            downloadFilePayload.importerKey ?? undefined,
         );
         if (!result.path) return "canceled";
         const destinationPath = result.path;

--- a/src/main/lib/path-selector.ts
+++ b/src/main/lib/path-selector.ts
@@ -14,6 +14,7 @@ export interface PendingPathSelection {
     id: string;
     suggestedName?: string;
     downloadTargetName?: string;
+    downloadImporterKey?: string;
     resolve: (result: PathSelectorResult) => void;
     reject: (error: Error) => void;
 }
@@ -29,6 +30,7 @@ export class PathSelector {
     public async getSelectedPathWithModeModal(
         suggestedName?: string,
         downloadTargetName?: string,
+        downloadImporterKey?: string,
     ): Promise<PathSelectorResult> {
         return new Promise((resolve, reject) => {
             const selectionId = nanoid();
@@ -37,6 +39,7 @@ export class PathSelector {
                 id: selectionId,
                 suggestedName,
                 downloadTargetName,
+                downloadImporterKey,
                 resolve,
                 reject,
             });
@@ -52,17 +55,28 @@ export class PathSelector {
                                     selectionId,
                                     suggestedName,
                                     downloadTargetName,
+                                    downloadImporterKey,
                                 );
                             }, 500);
                         });
                     } else {
                         this.desktop.window.main.focus();
-                        this.showSelectionModal(selectionId, suggestedName, downloadTargetName);
+                        this.showSelectionModal(
+                            selectionId,
+                            suggestedName,
+                            downloadTargetName,
+                            downloadImporterKey,
+                        );
                     }
                 });
             } else {
                 this.desktop.window.main.focus();
-                this.showSelectionModal(selectionId, suggestedName, downloadTargetName);
+                this.showSelectionModal(
+                    selectionId,
+                    suggestedName,
+                    downloadTargetName,
+                    downloadImporterKey,
+                );
             }
         });
     }
@@ -71,6 +85,7 @@ export class PathSelector {
         selectionId: string,
         suggestedName?: string,
         downloadTargetName?: string,
+        downloadImporterKey?: string,
     ) {
         const mainWindow = this.desktop.window.main.window;
         if (!mainWindow) {
@@ -86,6 +101,7 @@ export class PathSelector {
             selectionId,
             suggestedName,
             downloadTargetName,
+            downloadImporterKey,
         });
     }
 

--- a/src/main/services/gamebanana/index.ts
+++ b/src/main/services/gamebanana/index.ts
@@ -1,4 +1,5 @@
 import { focus, getDefaultWebPreferences } from "@main/windows/utils";
+import { NTE_GAMEBANANA_ID } from "@shared/mod";
 import { BrowserWindow } from "electron";
 import ky, { type Input, type Options } from "ky";
 import { z, ZodError, type ZodType } from "zod";
@@ -25,6 +26,7 @@ export const gameBananaGames = {
     zz: 19567,
     ww: 20357,
     ef: 21842,
+    nte: NTE_GAMEBANANA_ID,
 } as const;
 
 export type GameBananaGameKey = keyof typeof gameBananaGames;

--- a/src/main/services/gamebanana/index.ts
+++ b/src/main/services/gamebanana/index.ts
@@ -1,5 +1,5 @@
 import { focus, getDefaultWebPreferences } from "@main/windows/utils";
-import { NTE_GAMEBANANA_ID } from "@shared/mod";
+import { getImporterForGameBananaId, NTE_GAMEBANANA_ID } from "@shared/mod";
 import { BrowserWindow } from "electron";
 import ky, { type Input, type Options } from "ky";
 import { z, ZodError, type ZodType } from "zod";
@@ -1039,6 +1039,7 @@ export class GameBananaService {
             fileUrl: file._sDownloadUrl,
             title: file._sFile,
             categoryName: profile._aCategory._sName,
+            importerKey: getImporterForGameBananaId(profile._aGame._idRow),
             previewUrl: this.getModPreviewUrl(profile),
             modId: profile._idRow,
             modPageUrl: profile._sProfileUrl,

--- a/src/main/services/gamebanana/model.ts
+++ b/src/main/services/gamebanana/model.ts
@@ -71,6 +71,7 @@ const BasicCategorySchema = z
 
 const GameSchema = z
     .object({
+        _idRow: NumericId,
         _sName: z.string(),
     })
     .catchall(z.unknown());

--- a/src/main/services/mod-manager/index.ts
+++ b/src/main/services/mod-manager/index.ts
@@ -54,6 +54,8 @@ export class ModManager {
         updateGame: ModLibraryService["updateGame"];
         reorderGames: ModLibraryService["reorderGames"];
         removeGame: ModLibraryService["removeGame"];
+        setGameExecutablePath: ModLibraryService["setGameExecutablePath"];
+        startNteGame: ModLibraryService["startNteGame"];
         setLastGame: ModLibraryService["setLastGame"];
         setExpandedGroups: ModLibraryService["setExpandedGroups"];
         setManualSubGroup: ModLibraryService["setManualSubGroup"];
@@ -112,6 +114,8 @@ export class ModManager {
             updateGame: this.library.updateGame.bind(this.library),
             reorderGames: this.library.reorderGames.bind(this.library),
             removeGame: this.library.removeGame.bind(this.library),
+            setGameExecutablePath: this.library.setGameExecutablePath.bind(this.library),
+            startNteGame: this.library.startNteGame.bind(this.library),
             setLastGame: this.library.setLastGame.bind(this.library),
             setExpandedGroups: this.library.setExpandedGroups.bind(this.library),
             setManualSubGroup: this.library.setManualSubGroup.bind(this.library),

--- a/src/main/services/mod-manager/index.ts
+++ b/src/main/services/mod-manager/index.ts
@@ -33,6 +33,7 @@ export class ModManager {
         previousFocusedGame: ModLibraryService["previousFocusedGame"];
         gamePid: ModLibraryService["gamePid"];
         resolveDownloadTarget: ModLibraryService["resolveDownloadTarget"];
+        resolveNteInstallPath: ModLibraryService["resolveNteInstallPath"];
     };
 
     public readonly fn: {
@@ -90,6 +91,7 @@ export class ModManager {
             previousFocusedGame: this.library.previousFocusedGame.bind(this.library),
             gamePid: this.library.gamePid.bind(this.library),
             resolveDownloadTarget: this.library.resolveDownloadTarget.bind(this.library),
+            resolveNteInstallPath: this.library.resolveNteInstallPath.bind(this.library),
         };
 
         this.fn = {

--- a/src/main/services/mod-manager/library.ts
+++ b/src/main/services/mod-manager/library.ts
@@ -1,10 +1,20 @@
 import path from "node:path";
 import { getCharactersFolder, getMods } from "@native/mod-manager";
 import { findBestFuzzyMatch } from "@shared/fuzzy-match";
+import { isNteImporter } from "@shared/mod";
 import type { FolderGroup, Preset } from "@shared/types";
 import { GAME_MATCH_CASES } from "@shared/xxmi-match";
 import fse from "fs-extra";
 import type { NahidaDesktop } from "../..";
+import {
+    configureNteModFolder,
+    findNteGameByPath,
+    getNteCharacters,
+    getNteMods,
+    getNteRoots,
+    getNteSubGroups,
+    resolveNteInstallPath,
+} from "./nte";
 import {
     folderHasAnyFile,
     manualSubGroupPathExists,
@@ -29,9 +39,13 @@ export class ModLibraryService {
     }
 
     public async characters(game: string, searchModPreview?: boolean): Promise<FolderGroup[]> {
-        const modFolderPath = await this.gamePath(game);
-        if (!modFolderPath) {
+        const gameConfig = await this.desktop.lib.db.gamePaths.getByGame(game);
+        if (!gameConfig?.modFolderPath) {
             throw new Error(`No mod folder path set for ${game}`);
+        }
+
+        if (isNteImporter(gameConfig.importer)) {
+            return await getNteCharacters(this.desktop, getNteRoots(gameConfig));
         }
 
         const shouldFallback =
@@ -41,7 +55,7 @@ export class ModLibraryService {
             return await this.addManualSubGroupFlags(
                 game,
                 "",
-                await getCharactersFolder(modFolderPath, shouldFallback),
+                await getCharactersFolder(gameConfig.modFolderPath, shouldFallback),
             );
         } catch (error) {
             this.desktop.logger.error(error, `Mod:characters:${game}`);
@@ -54,6 +68,10 @@ export class ModLibraryService {
             searchModPreview ?? (await this.desktop.setting.mod.getSearchModPreview());
         try {
             const game = await this.getGameByPath(folderPath);
+            if (game && isNteImporter(game.importer)) {
+                return await getNteSubGroups(this.desktop, getNteRoots(game), folderPath);
+            }
+
             const relativePath = game
                 ? manualSubGroupRelativePath(path.relative(game.modFolderPath, folderPath))
                 : "";
@@ -105,8 +123,12 @@ export class ModLibraryService {
 
     public async mods(groupPath: string): Promise<FolderGroup> {
         try {
-            const group = await getMods(groupPath);
             const game = await this.getGameByPath(groupPath);
+            if (game && isNteImporter(game.importer)) {
+                return await getNteMods(this.desktop, getNteRoots(game), groupPath);
+            }
+
+            const group = await getMods(groupPath);
             if (!game) return group;
 
             const relativePath = manualSubGroupRelativePath(
@@ -299,29 +321,47 @@ export class ModLibraryService {
             game,
             modFolderPath,
             importer: null,
+            linkedModFolderPath: null,
             order: existing?.order ?? 0,
         });
     }
 
-    public async addGame(game: string, modFolderPath: string, importer: string | null) {
+    public async addGame(
+        game: string,
+        modFolderPath: string,
+        importer: string | null,
+        linkedModFolderPath: string | null = null,
+    ) {
         if (!game || !modFolderPath) {
             throw new Error("INVALID_PARAMS");
         }
 
-        const exists = await this.desktop.lib.db.gamePaths.findByGameOrModFolderPath(
-            game,
-            modFolderPath,
-        );
+        const exists =
+            (await this.desktop.lib.db.gamePaths.findByGameOrModFolderPath(game, modFolderPath)) ??
+            (linkedModFolderPath
+                ? await this.desktop.lib.db.gamePaths.findByGameOrModFolderPath(
+                      game,
+                      linkedModFolderPath,
+                  )
+                : null);
 
         if (exists) {
             if (exists.game === game) {
                 throw new Error("DUPLICATE_GAME_NAME");
-            } else if (exists.modFolderPath === modFolderPath) {
-                throw new Error("DUPLICATE_MOD_FOLDER_PATH");
             }
+            throw new Error("DUPLICATE_MOD_FOLDER_PATH");
         }
 
-        await this.desktop.lib.db.gamePaths.insert({ game, modFolderPath, importer });
+        if (isNteImporter(importer)) {
+            await configureNteModFolder(modFolderPath, linkedModFolderPath);
+        }
+
+        await this.desktop.lib.db.gamePaths.insert({
+            game,
+            modFolderPath,
+            importer,
+            linkedModFolderPath: isNteImporter(importer) ? linkedModFolderPath : null,
+        });
     }
 
     public async updateGame(
@@ -329,6 +369,7 @@ export class ModLibraryService {
         updates: {
             modFolderPath: string;
             importer: string | null;
+            linkedModFolderPath: string | null;
         },
     ) {
         if (!game || !updates.modFolderPath) {
@@ -341,16 +382,37 @@ export class ModLibraryService {
             throw new Error(`Game ${game} not found`);
         }
 
-        const duplicatePath = await this.desktop.lib.db.gamePaths.findByModFolderPathOtherGame(
-            game,
-            updates.modFolderPath,
-        );
+        const duplicatePath =
+            (await this.desktop.lib.db.gamePaths.findByModFolderPathOtherGame(
+                game,
+                updates.modFolderPath,
+            )) ??
+            (updates.linkedModFolderPath
+                ? await this.desktop.lib.db.gamePaths.findByModFolderPathOtherGame(
+                      game,
+                      updates.linkedModFolderPath,
+                  )
+                : null);
 
         if (duplicatePath) {
             throw new Error("DUPLICATE_MOD_FOLDER_PATH");
         }
 
-        await this.desktop.lib.db.gamePaths.update(game, updates);
+        if (isNteImporter(updates.importer)) {
+            await configureNteModFolder(updates.modFolderPath, updates.linkedModFolderPath);
+        }
+
+        await this.desktop.lib.db.gamePaths.update(game, {
+            modFolderPath: updates.modFolderPath,
+            importer: updates.importer,
+            linkedModFolderPath: isNteImporter(updates.importer)
+                ? updates.linkedModFolderPath
+                : null,
+        });
+    }
+
+    public async resolveNteInstallPath(installPath: string) {
+        return await resolveNteInstallPath(installPath);
     }
 
     public async removeGame(game: string) {
@@ -417,6 +479,9 @@ export class ModLibraryService {
 
     private async getGameByPath(targetPath: string) {
         const resolvedTargetPath = path.resolve(targetPath);
+        const nteGame = findNteGameByPath(await this.games(), resolvedTargetPath);
+        if (nteGame) return nteGame;
+
         const matches = (await this.games()).filter((game) => {
             const relativePath = path.relative(
                 path.resolve(game.modFolderPath),

--- a/src/main/services/mod-manager/library.ts
+++ b/src/main/services/mod-manager/library.ts
@@ -1,4 +1,6 @@
+import { spawn } from "node:child_process";
 import path from "node:path";
+import type { GamePathRow } from "@main/internal/db/schema";
 import { getCharactersFolder, getMods } from "@native/mod-manager";
 import { findBestFuzzyMatch } from "@shared/fuzzy-match";
 import { isNteImporter } from "@shared/mod";
@@ -7,7 +9,9 @@ import { GAME_MATCH_CASES } from "@shared/xxmi-match";
 import fse from "fs-extra";
 import type { NahidaDesktop } from "../..";
 import {
+    cleanupNteModFolder,
     configureNteModFolder,
+    deriveNteGameInstallPath,
     findNteGameByPath,
     getNteCharacters,
     getNteMods,
@@ -165,19 +169,37 @@ export class ModLibraryService {
     }
 
     public async games() {
-        return await this.desktop.lib.db.gamePaths.list();
+        const rows = await this.desktop.lib.db.gamePaths.list();
+        return rows.map((row) => this.enrichGameConfig(row));
     }
 
-    public async resolveDownloadTarget(input: string): Promise<{
+    private enrichGameConfig(row: GamePathRow) {
+        if (!isNteImporter(row.importer) || row.gameInstallPath) {
+            return row;
+        }
+
+        return {
+            ...row,
+            gameInstallPath: deriveNteGameInstallPath(row.linkedModFolderPath ?? row.modFolderPath),
+        };
+    }
+
+    public async resolveDownloadTarget(
+        input: string,
+        gameFilter?: string,
+    ): Promise<{
         game: string;
         group: FolderGroup;
         score: number;
     } | null> {
+        const allGames = await this.games();
+        const gamesToSearch = gameFilter
+            ? allGames.filter((game) => game.game === gameFilter)
+            : allGames;
+
         const candidates = (
             await Promise.all(
-                (
-                    await this.games()
-                ).map(async (game) =>
+                gamesToSearch.map(async (game) =>
                     (
                         await Promise.all(
                             (
@@ -322,6 +344,8 @@ export class ModLibraryService {
             modFolderPath,
             importer: null,
             linkedModFolderPath: null,
+            gameInstallPath: null,
+            gameExecutablePath: null,
             order: existing?.order ?? 0,
         });
     }
@@ -331,10 +355,15 @@ export class ModLibraryService {
         modFolderPath: string,
         importer: string | null,
         linkedModFolderPath: string | null = null,
+        gameInstallPath: string | null = null,
+        gameExecutablePath: string | null = null,
     ) {
         if (!game || !modFolderPath) {
             throw new Error("INVALID_PARAMS");
         }
+
+        const resolvedGameInstallPath = isNteImporter(importer) ? gameInstallPath : null;
+        const resolvedGameExecutablePath = isNteImporter(importer) ? gameExecutablePath : null;
 
         const exists =
             (await this.desktop.lib.db.gamePaths.findByGameOrModFolderPath(game, modFolderPath)) ??
@@ -361,6 +390,8 @@ export class ModLibraryService {
             modFolderPath,
             importer,
             linkedModFolderPath: isNteImporter(importer) ? linkedModFolderPath : null,
+            gameInstallPath: resolvedGameInstallPath,
+            gameExecutablePath: resolvedGameExecutablePath,
         });
     }
 
@@ -370,6 +401,7 @@ export class ModLibraryService {
             modFolderPath: string;
             importer: string | null;
             linkedModFolderPath: string | null;
+            gameInstallPath: string | null;
         },
     ) {
         if (!game || !updates.modFolderPath) {
@@ -398,6 +430,10 @@ export class ModLibraryService {
             throw new Error("DUPLICATE_MOD_FOLDER_PATH");
         }
 
+        if (isNteImporter(existingGame.importer) && !isNteImporter(updates.importer)) {
+            await cleanupNteModFolder(existingGame.modFolderPath, existingGame.linkedModFolderPath);
+        }
+
         if (isNteImporter(updates.importer)) {
             await configureNteModFolder(updates.modFolderPath, updates.linkedModFolderPath);
         }
@@ -408,6 +444,7 @@ export class ModLibraryService {
             linkedModFolderPath: isNteImporter(updates.importer)
                 ? updates.linkedModFolderPath
                 : null,
+            gameInstallPath: isNteImporter(updates.importer) ? updates.gameInstallPath : null,
         });
     }
 
@@ -415,7 +452,45 @@ export class ModLibraryService {
         return await resolveNteInstallPath(installPath);
     }
 
+    public async setGameExecutablePath(game: string, executablePath: string) {
+        const trimmedPath = executablePath.trim();
+        if (!trimmedPath || !(await fse.pathExists(trimmedPath))) {
+            throw new Error("INVALID_EXECUTABLE_PATH");
+        }
+
+        const existingGame = await this.desktop.lib.db.gamePaths.getByGame(game);
+        if (!existingGame) {
+            throw new Error(`Game ${game} not found`);
+        }
+
+        await this.desktop.lib.db.gamePaths.setGameExecutablePath(game, trimmedPath);
+    }
+
+    public async startNteGame(game: string) {
+        const existingGame = await this.desktop.lib.db.gamePaths.getByGame(game);
+        if (!existingGame?.gameExecutablePath) {
+            throw new Error("NTE_EXECUTABLE_PATH_NOT_SET");
+        }
+
+        const executablePath = existingGame.gameExecutablePath;
+        if (!(await fse.pathExists(executablePath))) {
+            throw new Error("NTE_EXECUTABLE_PATH_NOT_FOUND");
+        }
+
+        spawn(executablePath, [], {
+            cwd: path.dirname(executablePath),
+            detached: true,
+            stdio: "ignore",
+        }).unref();
+    }
+
     public async removeGame(game: string) {
+        const existingGame = await this.desktop.lib.db.gamePaths.getByGame(game);
+
+        if (existingGame && isNteImporter(existingGame.importer)) {
+            await cleanupNteModFolder(existingGame.modFolderPath, existingGame.linkedModFolderPath);
+        }
+
         await this.desktop.lib.db.gamePaths.delete(game);
     }
 

--- a/src/main/services/mod-manager/library.ts
+++ b/src/main/services/mod-manager/library.ts
@@ -340,6 +340,11 @@ export class ModLibraryService {
 
     public async setGamePath(game: string, modFolderPath: string) {
         const existing = await this.desktop.lib.db.gamePaths.getByGame(game);
+
+        if (existing && isNteImporter(existing.importer)) {
+            await cleanupNteModFolder(existing.modFolderPath, existing.linkedModFolderPath);
+        }
+
         await this.desktop.lib.db.gamePaths.upsert({
             game,
             modFolderPath,
@@ -462,7 +467,8 @@ export class ModLibraryService {
 
     public async setGameExecutablePath(game: string, executablePath: string) {
         const trimmedPath = executablePath.trim();
-        if (!trimmedPath || !(await fse.pathExists(trimmedPath))) {
+        const executableStat = trimmedPath ? await fse.stat(trimmedPath).catch(() => null) : null;
+        if (!executableStat?.isFile()) {
             throw new Error("INVALID_EXECUTABLE_PATH");
         }
 
@@ -481,15 +487,20 @@ export class ModLibraryService {
         }
 
         const executablePath = existingGame.gameExecutablePath;
-        if (!(await fse.pathExists(executablePath))) {
+        const executableStat = await fse.stat(executablePath).catch(() => null);
+        if (!executableStat?.isFile()) {
             throw new Error("NTE_EXECUTABLE_PATH_NOT_FOUND");
         }
 
-        spawn(executablePath, [], {
+        const child = spawn(executablePath, [], {
             cwd: path.dirname(executablePath),
             detached: true,
             stdio: "ignore",
-        }).unref();
+        });
+        child.once("error", (error) => {
+            this.desktop.logger.error(error, `Mod:startNteGame:${game}`);
+        });
+        child.unref();
     }
 
     public async removeGame(game: string) {

--- a/src/main/services/mod-manager/library.ts
+++ b/src/main/services/mod-manager/library.ts
@@ -402,6 +402,7 @@ export class ModLibraryService {
             importer: string | null;
             linkedModFolderPath: string | null;
             gameInstallPath: string | null;
+            gameExecutablePath: string | null;
         },
     ) {
         if (!game || !updates.modFolderPath) {
@@ -445,6 +446,7 @@ export class ModLibraryService {
                 ? updates.linkedModFolderPath
                 : null,
             gameInstallPath: isNteImporter(updates.importer) ? updates.gameInstallPath : null,
+            gameExecutablePath: isNteImporter(updates.importer) ? updates.gameExecutablePath : null,
         });
     }
 

--- a/src/main/services/mod-manager/library.ts
+++ b/src/main/services/mod-manager/library.ts
@@ -13,6 +13,7 @@ import {
     configureNteModFolder,
     deriveNteGameInstallPath,
     findNteGameByPath,
+    hasNtePathChanges,
     getNteCharacters,
     getNteMods,
     getNteRoots,
@@ -431,7 +432,12 @@ export class ModLibraryService {
             throw new Error("DUPLICATE_MOD_FOLDER_PATH");
         }
 
-        if (isNteImporter(existingGame.importer) && !isNteImporter(updates.importer)) {
+        if (
+            (isNteImporter(existingGame.importer) && !isNteImporter(updates.importer)) ||
+            (isNteImporter(existingGame.importer) &&
+                isNteImporter(updates.importer) &&
+                hasNtePathChanges(existingGame, updates))
+        ) {
             await cleanupNteModFolder(existingGame.modFolderPath, existingGame.linkedModFolderPath);
         }
 

--- a/src/main/services/mod-manager/library.ts
+++ b/src/main/services/mod-manager/library.ts
@@ -391,14 +391,23 @@ export class ModLibraryService {
             await configureNteModFolder(modFolderPath, linkedModFolderPath);
         }
 
-        await this.desktop.lib.db.gamePaths.insert({
-            game,
-            modFolderPath,
-            importer,
-            linkedModFolderPath: isNteImporter(importer) ? linkedModFolderPath : null,
-            gameInstallPath: resolvedGameInstallPath,
-            gameExecutablePath: resolvedGameExecutablePath,
-        });
+        try {
+            await this.desktop.lib.db.gamePaths.insert({
+                game,
+                modFolderPath,
+                importer,
+                linkedModFolderPath: isNteImporter(importer) ? linkedModFolderPath : null,
+                gameInstallPath: resolvedGameInstallPath,
+                gameExecutablePath: resolvedGameExecutablePath,
+            });
+        } catch (err) {
+            if (isNteImporter(importer)) {
+                await cleanupNteModFolder(modFolderPath, linkedModFolderPath).catch((error) => {
+                    this.desktop.logger.error(error, `Mod:addGame:rollback:${game}`);
+                });
+            }
+            throw err;
+        }
     }
 
     public async updateGame(
@@ -437,28 +446,51 @@ export class ModLibraryService {
             throw new Error("DUPLICATE_MOD_FOLDER_PATH");
         }
 
-        if (
+        const shouldCleanupExisting =
             (isNteImporter(existingGame.importer) && !isNteImporter(updates.importer)) ||
             (isNteImporter(existingGame.importer) &&
                 isNteImporter(updates.importer) &&
-                hasNtePathChanges(existingGame, updates))
-        ) {
-            await cleanupNteModFolder(existingGame.modFolderPath, existingGame.linkedModFolderPath);
-        }
+                hasNtePathChanges(existingGame, updates));
+        const diskRollbacks: Array<() => Promise<void>> = [];
 
-        if (isNteImporter(updates.importer)) {
-            await configureNteModFolder(updates.modFolderPath, updates.linkedModFolderPath);
-        }
+        try {
+            if (shouldCleanupExisting) {
+                await cleanupNteModFolder(
+                    existingGame.modFolderPath,
+                    existingGame.linkedModFolderPath,
+                );
+                if (isNteImporter(existingGame.importer)) {
+                    diskRollbacks.push(() =>
+                        configureNteModFolder(
+                            existingGame.modFolderPath,
+                            existingGame.linkedModFolderPath,
+                        ),
+                    );
+                }
+            }
 
-        await this.desktop.lib.db.gamePaths.update(game, {
-            modFolderPath: updates.modFolderPath,
-            importer: updates.importer,
-            linkedModFolderPath: isNteImporter(updates.importer)
-                ? updates.linkedModFolderPath
-                : null,
-            gameInstallPath: isNteImporter(updates.importer) ? updates.gameInstallPath : null,
-            gameExecutablePath: isNteImporter(updates.importer) ? updates.gameExecutablePath : null,
-        });
+            if (isNteImporter(updates.importer)) {
+                await configureNteModFolder(updates.modFolderPath, updates.linkedModFolderPath);
+                diskRollbacks.push(() =>
+                    cleanupNteModFolder(updates.modFolderPath, updates.linkedModFolderPath),
+                );
+            }
+
+            await this.desktop.lib.db.gamePaths.update(game, {
+                modFolderPath: updates.modFolderPath,
+                importer: updates.importer,
+                linkedModFolderPath: isNteImporter(updates.importer)
+                    ? updates.linkedModFolderPath
+                    : null,
+                gameInstallPath: isNteImporter(updates.importer) ? updates.gameInstallPath : null,
+                gameExecutablePath: isNteImporter(updates.importer)
+                    ? updates.gameExecutablePath
+                    : null,
+            });
+        } catch (err) {
+            await this.rollbackNteDiskChanges(diskRollbacks);
+            throw err;
+        }
     }
 
     public async resolveNteInstallPath(installPath: string) {
@@ -735,5 +767,13 @@ export class ModLibraryService {
             );
             return !manualChildPaths.has(fullRelativePath);
         });
+    }
+
+    private async rollbackNteDiskChanges(rollbacks: Array<() => Promise<void>>) {
+        for (const rollback of rollbacks.toReversed()) {
+            await rollback().catch((error) => {
+                this.desktop.logger.error(error, "Mod:rollbackNteDiskChanges");
+            });
+        }
     }
 }

--- a/src/main/services/mod-manager/mod-actions.ts
+++ b/src/main/services/mod-manager/mod-actions.ts
@@ -1,7 +1,17 @@
 import path from "node:path";
+import { isNteImporter } from "@shared/mod";
+import type { GameConfig } from "@shared/types";
 import { retry, trim } from "es-toolkit";
 import fg from "fast-glob";
 import type { NahidaDesktop } from "../..";
+import {
+    findNteGameByPath,
+    getNteGroupRelativePath,
+    getNteRoots,
+    hasNteDirectPak,
+    isNteModEnabled,
+    setNteModEnabled,
+} from "./nte";
 import {
     DISABLED_PREFIX_REGEX,
     normalizeModPath,
@@ -19,6 +29,13 @@ export class ModActionsService {
     ) {}
 
     public async enable(modPath: string): Promise<string> {
+        const nteGame = findNteGameByPath(await this.desktop.service.mod.get.games(), modPath);
+        if (nteGame) {
+            if (!(await isNteModEnabled(modPath)))
+                return await setNteModEnabled(this.desktop, modPath, true);
+            return modPath;
+        }
+
         const folderName = path.basename(modPath);
 
         if (DISABLED_PREFIX_REGEX.test(folderName)) {
@@ -52,6 +69,13 @@ export class ModActionsService {
     }
 
     public async disable(modPath: string): Promise<string> {
+        const nteGame = findNteGameByPath(await this.desktop.service.mod.get.games(), modPath);
+        if (nteGame) {
+            if (await isNteModEnabled(modPath))
+                return await setNteModEnabled(this.desktop, modPath, false);
+            return modPath;
+        }
+
         const folderName = path.basename(modPath);
 
         if (!DISABLED_PREFIX_REGEX.test(folderName)) {
@@ -95,6 +119,11 @@ export class ModActionsService {
     }
 
     public async exclusiveToggle(modPath: string): Promise<string> {
+        const nteGame = findNteGameByPath(await this.desktop.service.mod.get.games(), modPath);
+        if (nteGame && isNteImporter(nteGame.importer)) {
+            return await this.exclusiveToggleNte(modPath, nteGame);
+        }
+
         const folderName = path.basename(modPath);
         const isEnabled = !DISABLED_PREFIX_REGEX.test(folderName);
 
@@ -175,6 +204,12 @@ export class ModActionsService {
     }
 
     public async enableAll(groupPath: string): Promise<void> {
+        const nteGame = findNteGameByPath(await this.desktop.service.mod.get.games(), groupPath);
+        if (nteGame) {
+            await this.setAllNte(groupPath, nteGame, true);
+            return;
+        }
+
         try {
             const modFolders = await fg("*", {
                 cwd: groupPath,
@@ -198,6 +233,12 @@ export class ModActionsService {
     }
 
     public async disableAll(groupPath: string): Promise<void> {
+        const nteGame = findNteGameByPath(await this.desktop.service.mod.get.games(), groupPath);
+        if (nteGame) {
+            await this.setAllNte(groupPath, nteGame, false);
+            return;
+        }
+
         try {
             const modFolders = await fg("*", {
                 cwd: groupPath,
@@ -245,5 +286,43 @@ export class ModActionsService {
     private isRetryableExclusiveToggleError(error: unknown): boolean {
         const code = (error as NodeJS.ErrnoException | undefined)?.code;
         return code === "EBUSY" || code === "EPERM" || code === "EACCES";
+    }
+
+    private async exclusiveToggleNte(modPath: string, game: GameConfig) {
+        const roots = getNteRoots(game);
+
+        if (!(await isNteModEnabled(modPath))) {
+            await this.setAllNte(
+                path.dirname(path.join(roots.modRoot, getNteGroupRelativePath(roots, modPath))),
+                game,
+                false,
+            );
+            return await setNteModEnabled(this.desktop, modPath, true);
+        }
+
+        return await setNteModEnabled(this.desktop, modPath, false);
+    }
+
+    private async setAllNte(groupPath: string, game: GameConfig, enabled: boolean) {
+        const roots = getNteRoots(game);
+        const groupDir = path.join(roots.modRoot, getNteGroupRelativePath(roots, groupPath));
+
+        if (!(await this.desktop.lib.fs.pathExists(groupDir))) return;
+
+        await Promise.all(
+            (await this.desktop.lib.fs.listDirectories(groupDir)).map(async (folderName) => {
+                const modPath = path.join(groupDir, folderName);
+                try {
+                    if (!(await hasNteDirectPak(modPath))) return;
+
+                    const currentlyEnabled = await isNteModEnabled(modPath);
+                    if (currentlyEnabled === enabled) return;
+
+                    await setNteModEnabled(this.desktop, modPath, enabled);
+                } catch (error) {
+                    this.desktop.logger.error(error, `Mod:setAllNte:${modPath}`);
+                }
+            }),
+        );
     }
 }

--- a/src/main/services/mod-manager/mod-actions.ts
+++ b/src/main/services/mod-manager/mod-actions.ts
@@ -99,8 +99,11 @@ export class ModActionsService {
     }
 
     public async toggle(modPath: string): Promise<string> {
-        const folderName = path.basename(modPath);
-        const isEnabled = !DISABLED_PREFIX_REGEX.test(folderName);
+        const nteGame = findNteGameByPath(await this.desktop.service.mod.get.games(), modPath);
+        const isEnabled =
+            nteGame && isNteImporter(nteGame.importer)
+                ? await isNteModEnabled(modPath)
+                : !DISABLED_PREFIX_REGEX.test(path.basename(modPath));
 
         let result: string;
 
@@ -119,15 +122,18 @@ export class ModActionsService {
     }
 
     public async exclusiveToggle(modPath: string): Promise<string> {
-        const nteGame = findNteGameByPath(await this.desktop.service.mod.get.games(), modPath);
-        if (nteGame && isNteImporter(nteGame.importer)) {
-            return await this.exclusiveToggleNte(modPath, nteGame);
-        }
-
         const folderName = path.basename(modPath);
         const isEnabled = !DISABLED_PREFIX_REGEX.test(folderName);
 
         try {
+            const nteGame = findNteGameByPath(await this.desktop.service.mod.get.games(), modPath);
+            if (nteGame && isNteImporter(nteGame.importer)) {
+                return await this.retryExclusiveToggleOperation(
+                    () => this.exclusiveToggleNte(modPath, nteGame),
+                    modPath,
+                );
+            }
+
             if (!isEnabled) {
                 const groupPath = path.dirname(modPath);
                 const modFolders = await fg("*", {

--- a/src/main/services/mod-manager/nte.ts
+++ b/src/main/services/mod-manager/nte.ts
@@ -1,0 +1,406 @@
+import path from "node:path";
+import type { FolderGroup, GameConfig, ModInfo } from "@shared/types";
+import fg from "fast-glob";
+import fse from "fs-extra";
+import type { NahidaDesktop } from "../..";
+import {
+    DISABLED_PREFIX_REGEX,
+    isSameOrChildPath,
+    normalizeModPath,
+    renameWithUniqueName,
+    stripDisabledPrefix,
+} from "./path-utils";
+
+const NTE_EXE_NAME = "HTGame.exe";
+const NTE_COMMON_EXE_RELATIVE_PATH = path.join(
+    "Neverness To Everness",
+    "Client",
+    "WindowsNoEditor",
+    "HT",
+    "Binaries",
+    "Win64",
+    NTE_EXE_NAME,
+);
+const NTE_MODS_RELATIVE_PATH = path.join("Content", "Paks", "Mods");
+const NTE_DEFAULT_MOD_SUBFOLDERS = ["Character", "UI", "Enemy", "NPC"] as const;
+const DISABLED_FILE_SUFFIX = ".disabled";
+const PREVIEW_FILE_REGEX = /^preview\.(jpeg|jpg|gif|png|webp|bmp|mp4|webm|ogg)$/i;
+
+export interface NtePathResolution {
+    gameRootPath: string;
+    executablePath: string;
+    modFolderPath: string;
+    linkedModFolderPath: string;
+}
+
+type NteGameRoots = {
+    modRoot: string;
+};
+
+export async function resolveNteInstallPath(inputPath: string): Promise<NtePathResolution | null> {
+    const trimmedPath = inputPath.trim();
+    if (!trimmedPath || !(await fse.pathExists(trimmedPath))) return null;
+
+    const executablePath = await findNteExecutable(trimmedPath);
+    if (!executablePath) return null;
+
+    const htRootPath = path.resolve(path.dirname(executablePath), "..", "..");
+    const modFolderPath = path.join(htRootPath, NTE_MODS_RELATIVE_PATH);
+
+    return {
+        gameRootPath: path.resolve(htRootPath, "..", "..", ".."),
+        executablePath,
+        modFolderPath,
+        linkedModFolderPath: modFolderPath,
+    };
+}
+
+export function getNteRoots(game: Pick<GameConfig, "modFolderPath">) {
+    return { modRoot: game.modFolderPath };
+}
+
+export async function ensureNteModFolders(modFolderPath: string) {
+    await fse.ensureDir(modFolderPath);
+    await Promise.all(
+        NTE_DEFAULT_MOD_SUBFOLDERS.map((name) => fse.ensureDir(path.join(modFolderPath, name))),
+    );
+}
+
+export async function configureNteModFolder(
+    modFolderPath: string,
+    linkedModFolderPath: string | null,
+) {
+    if (!linkedModFolderPath || isSameNtePath(modFolderPath, linkedModFolderPath)) {
+        await unlinkNteModsFolder(modFolderPath);
+        await ensureNteModFolders(modFolderPath);
+        return;
+    }
+
+    if (
+        isSameOrChildPath(linkedModFolderPath, modFolderPath) ||
+        isSameOrChildPath(modFolderPath, linkedModFolderPath)
+    ) {
+        throw new Error("NTE_CUSTOM_MOD_FOLDER_INSIDE_LINK_PATH");
+    }
+
+    await fse.ensureDir(modFolderPath);
+    await linkNteModsFolder(modFolderPath, linkedModFolderPath);
+    await ensureNteModFolders(modFolderPath);
+}
+
+export function findNteGameByPath(games: GameConfig[], targetPath: string) {
+    return games.find(
+        (game) =>
+            game.importer === "NTE" && isSameOrChildPath(getNteRoots(game).modRoot, targetPath),
+    );
+}
+
+export async function getNteCharacters(
+    desktop: NahidaDesktop,
+    roots: NteGameRoots,
+): Promise<FolderGroup[]> {
+    return await getNteSubGroups(desktop, roots, roots.modRoot);
+}
+
+export async function getNteSubGroups(
+    _desktop: NahidaDesktop,
+    roots: NteGameRoots,
+    groupPath: string,
+): Promise<FolderGroup[]> {
+    const relativePath = getNteRelativePath(roots, groupPath);
+    const groupDir = path.join(roots.modRoot, relativePath);
+    const groupNames = await listDirectoryNames(groupDir);
+
+    const groups = await Promise.all(
+        groupNames.map(async (groupName) => {
+            const nextPath = path.join(groupDir, groupName);
+
+            if (await hasDirectPak(nextPath)) return null;
+
+            const preview = await findPreview(nextPath);
+            return {
+                name: groupName,
+                path: nextPath,
+                mods: [],
+                ...(preview ? { preview } : {}),
+                modCount: await countDirectMods(nextPath),
+                hasManualSubGroups: false,
+            } satisfies FolderGroup;
+        }),
+    );
+
+    return groups.filter((group) => group !== null).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getNteMods(
+    desktop: NahidaDesktop,
+    roots: NteGameRoots,
+    groupPath: string,
+): Promise<FolderGroup> {
+    const relativePath = getNteRelativePath(roots, groupPath);
+    const groupDir = path.join(roots.modRoot, relativePath);
+    const modNames = await listDirectoryNames(groupDir);
+    const mods = (
+        await Promise.all(
+            modNames.map(async (modName) => {
+                const modPath = path.join(groupDir, modName);
+                if (!(await hasDirectPak(modPath))) return null;
+
+                return await createNteModInfo(desktop, modPath, await isNteModEnabled(modPath));
+            }),
+        )
+    )
+        .filter((mod) => mod !== null)
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+    const preview = await findPreview(groupDir);
+    return {
+        name: path.basename(groupPath),
+        path: groupDir,
+        mods,
+        ...(preview ? { preview } : {}),
+        modCount: mods.length,
+    };
+}
+
+export async function isNteModEnabled(modPath: string) {
+    return !DISABLED_PREFIX_REGEX.test(path.basename(modPath));
+}
+
+export async function setNteModEnabled(
+    desktop: NahidaDesktop,
+    modPath: string,
+    enabled: boolean,
+): Promise<string> {
+    const folderName = path.basename(modPath);
+    if ((await isNteModEnabled(modPath)) === enabled) return modPath;
+
+    const entries = (await fse.readdir(modPath, { withFileTypes: true })).filter((entry) =>
+        entry.isFile(),
+    );
+
+    if (enabled) {
+        await Promise.all(
+            entries
+                .filter((entry) => isDisabledFile(entry.name))
+                .map((entry) =>
+                    fse.rename(
+                        path.join(modPath, entry.name),
+                        path.join(modPath, entry.name.slice(0, -DISABLED_FILE_SUFFIX.length)),
+                    ),
+                ),
+        );
+        return await renameWithUniqueName(desktop.lib.fs, modPath, stripDisabledPrefix(folderName));
+    }
+
+    await Promise.all(
+        entries
+            .filter((entry) => !isDisabledFile(entry.name))
+            .map((entry) =>
+                fse.rename(
+                    path.join(modPath, entry.name),
+                    path.join(modPath, `${entry.name}${DISABLED_FILE_SUFFIX}`),
+                ),
+            ),
+    );
+    return await renameWithUniqueName(
+        desktop.lib.fs,
+        modPath,
+        `DISABLED ${stripDisabledPrefix(folderName)}`,
+    );
+}
+
+export async function hasNteDirectPak(dirPath: string) {
+    return await hasDirectPak(dirPath);
+}
+
+export function getNteGroupRelativePath(roots: NteGameRoots, groupPath: string) {
+    return getNteRelativePath(roots, groupPath);
+}
+
+async function findNteExecutable(inputPath: string) {
+    const commonPath = path.join(inputPath, NTE_COMMON_EXE_RELATIVE_PATH);
+    if (await fse.pathExists(commonPath)) return commonPath;
+
+    if (path.basename(inputPath).toLowerCase() === NTE_EXE_NAME.toLowerCase()) {
+        return inputPath;
+    }
+
+    const matches = await fg([`**/${NTE_EXE_NAME}`], {
+        cwd: inputPath,
+        absolute: true,
+        caseSensitiveMatch: false,
+        dot: false,
+        onlyFiles: true,
+        suppressErrors: true,
+    });
+
+    return matches.sort((a, b) => a.length - b.length)[0] ?? null;
+}
+
+async function linkNteModsFolder(targetPath: string, linkPath: string) {
+    await fse.ensureDir(path.dirname(linkPath));
+
+    if (await fse.pathExists(linkPath)) {
+        const stat = await fse.lstat(linkPath);
+        if (stat.isSymbolicLink()) {
+            if (isSameNtePath(await resolveLinkTarget(linkPath), targetPath)) return;
+            await fse.remove(linkPath);
+        } else {
+            await moveExistingNteModsFolder(linkPath, targetPath);
+        }
+    }
+
+    await fse.symlink(targetPath, linkPath, "junction");
+}
+
+async function unlinkNteModsFolder(modFolderPath: string) {
+    if (!(await fse.pathExists(modFolderPath))) return;
+
+    const stat = await fse.lstat(modFolderPath);
+    if (!stat.isSymbolicLink()) return;
+
+    const targetPath = await resolveLinkTarget(modFolderPath);
+    const shouldMoveTargetEntries =
+        (await fse.pathExists(targetPath)) && (await directoryHasAnyFile(targetPath));
+
+    await fse.remove(modFolderPath);
+    await fse.ensureDir(modFolderPath);
+
+    if (!shouldMoveTargetEntries) return;
+
+    await Promise.all(
+        (await fse.readdir(targetPath)).map((entry) =>
+            fse.move(path.join(targetPath, entry), path.join(modFolderPath, entry), {
+                overwrite: false,
+            }),
+        ),
+    );
+}
+
+async function moveExistingNteModsFolder(sourcePath: string, targetPath: string) {
+    if (!(await fse.stat(sourcePath)).isDirectory()) {
+        throw new Error("NTE_MODS_LINK_PATH_OCCUPIED");
+    }
+
+    if (!(await directoryHasAnyFile(sourcePath))) {
+        await fse.remove(sourcePath);
+        return;
+    }
+
+    if (await directoryHasAnyFile(targetPath)) {
+        throw new Error("NTE_MODS_LINK_CONFLICT");
+    }
+
+    await Promise.all(
+        (await fse.readdir(targetPath)).map((entry) => fse.remove(path.join(targetPath, entry))),
+    );
+
+    await Promise.all(
+        (await fse.readdir(sourcePath)).map((entry) =>
+            fse.move(path.join(sourcePath, entry), path.join(targetPath, entry), {
+                overwrite: false,
+            }),
+        ),
+    );
+    await fse.remove(sourcePath);
+}
+
+async function resolveLinkTarget(linkPath: string) {
+    const target = await fse.readlink(linkPath);
+    return path.isAbsolute(target) ? target : path.resolve(path.dirname(linkPath), target);
+}
+
+async function directoryHasAnyFile(dirPath: string): Promise<boolean> {
+    if (!(await fse.pathExists(dirPath))) return false;
+
+    const entries = await fse.readdir(dirPath, { withFileTypes: true });
+    return (
+        await Promise.all(
+            entries.map(async (entry) => {
+                if (entry.isFile()) return true;
+                if (!entry.isDirectory()) return true;
+                return await directoryHasAnyFile(path.join(dirPath, entry.name));
+            }),
+        )
+    ).some(Boolean);
+}
+
+function isSameNtePath(left: string, right: string) {
+    return normalizeModPath(path.resolve(left)) === normalizeModPath(path.resolve(right));
+}
+
+function getNteRelativePath(roots: NteGameRoots, targetPath: string) {
+    const relativePath = path.relative(roots.modRoot, targetPath);
+
+    return relativePath.startsWith("..") ? "" : relativePath;
+}
+
+async function listDirectoryNames(dirPath: string) {
+    if (!(await fse.pathExists(dirPath))) return [];
+
+    return (await fse.readdir(dirPath, { withFileTypes: true }))
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+        .sort((a, b) => a.localeCompare(b));
+}
+
+function isDisabledFile(fileName: string) {
+    return fileName.toLowerCase().endsWith(DISABLED_FILE_SUFFIX);
+}
+
+function isPakModFile(fileName: string) {
+    const baseName = isDisabledFile(fileName)
+        ? fileName.slice(0, -DISABLED_FILE_SUFFIX.length)
+        : fileName;
+
+    return baseName.toLowerCase().endsWith(".pak");
+}
+
+async function hasDirectPak(dirPath: string) {
+    if (!(await fse.pathExists(dirPath))) return false;
+
+    return (await fse.readdir(dirPath, { withFileTypes: true })).some(
+        (entry) => entry.isFile() && isPakModFile(entry.name),
+    );
+}
+
+async function countDirectMods(groupDir: string) {
+    return (
+        await Promise.all(
+            (
+                await listDirectoryNames(groupDir)
+            ).map(
+                async (name): Promise<number> =>
+                    (await hasDirectPak(path.join(groupDir, name))) ? 1 : 0,
+            ),
+        )
+    ).reduce((total, count) => total + count, 0);
+}
+
+async function findPreview(dirPath: string) {
+    if (!(await fse.pathExists(dirPath))) return undefined;
+
+    const preview = (await fse.readdir(dirPath)).find((entry) =>
+        PREVIEW_FILE_REGEX.test(
+            isDisabledFile(entry) ? entry.slice(0, -DISABLED_FILE_SUFFIX.length) : entry,
+        ),
+    );
+    return preview ? path.join(dirPath, preview) : undefined;
+}
+
+async function createNteModInfo(desktop: NahidaDesktop, modPath: string, isEnabled: boolean) {
+    const stat = await fse.stat(modPath);
+    const preview = await findPreview(modPath);
+
+    return {
+        id: modPath,
+        name: path.basename(modPath),
+        path: modPath,
+        isEnabled,
+        ...(preview ? { preview } : {}),
+        mtime: stat.mtimeMs,
+        size: await desktop.lib.fs.getFolderSize(modPath),
+        inis: [],
+    } satisfies ModInfo;
+}

--- a/src/main/services/mod-manager/nte.ts
+++ b/src/main/services/mod-manager/nte.ts
@@ -48,11 +48,16 @@ export async function resolveNteInstallPath(inputPath: string): Promise<NtePathR
     const modFolderPath = path.join(htRootPath, NTE_MODS_RELATIVE_PATH);
 
     return {
-        gameRootPath: path.resolve(htRootPath, "..", "..", ".."),
+        gameRootPath: path.resolve(htRootPath, "..", ".."),
         executablePath,
         modFolderPath,
         linkedModFolderPath: modFolderPath,
     };
+}
+
+export function deriveNteGameInstallPath(modOrLinkedPath: string) {
+    const htRootPath = path.resolve(modOrLinkedPath, "..", "..", "..");
+    return path.resolve(htRootPath, "..", "..");
 }
 
 export function getNteRoots(game: Pick<GameConfig, "modFolderPath">) {
@@ -163,8 +168,28 @@ export async function getNteMods(
     };
 }
 
+export async function cleanupNteModFolder(
+    modFolderPath: string,
+    linkedModFolderPath: string | null,
+) {
+    if (linkedModFolderPath && !isSameNtePath(linkedModFolderPath, modFolderPath)) {
+        await unlinkNteModsFolder(linkedModFolderPath);
+        return;
+    }
+
+    await unlinkNteModsFolder(modFolderPath);
+}
+
 export async function isNteModEnabled(modPath: string) {
-    return !DISABLED_PREFIX_REGEX.test(path.basename(modPath));
+    if (DISABLED_PREFIX_REGEX.test(path.basename(modPath))) return false;
+
+    const pakFiles = (await fse.readdir(modPath, { withFileTypes: true }))
+        .filter((entry) => entry.isFile())
+        .filter((entry) => isPakModFile(entry.name));
+
+    if (pakFiles.length === 0) return true;
+
+    return pakFiles.some((entry) => !isDisabledFile(entry.name));
 }
 
 export async function setNteModEnabled(

--- a/src/main/services/mod-manager/nte.ts
+++ b/src/main/services/mod-manager/nte.ts
@@ -35,6 +35,7 @@ export interface NtePathResolution {
 
 type NteGameRoots = {
     modRoot: string;
+    linkedRoot: string | null;
 };
 
 export async function resolveNteInstallPath(inputPath: string): Promise<NtePathResolution | null> {
@@ -60,8 +61,8 @@ export function deriveNteGameInstallPath(modOrLinkedPath: string) {
     return path.resolve(htRootPath, "..", "..");
 }
 
-export function getNteRoots(game: Pick<GameConfig, "modFolderPath">) {
-    return { modRoot: game.modFolderPath };
+export function getNteRoots(game: Pick<GameConfig, "modFolderPath" | "linkedModFolderPath">) {
+    return { modRoot: game.modFolderPath, linkedRoot: game.linkedModFolderPath };
 }
 
 export async function ensureNteModFolders(modFolderPath: string) {
@@ -94,10 +95,15 @@ export async function configureNteModFolder(
 }
 
 export function findNteGameByPath(games: GameConfig[], targetPath: string) {
-    return games.find(
-        (game) =>
-            game.importer === "NTE" && isSameOrChildPath(getNteRoots(game).modRoot, targetPath),
-    );
+    return games.find((game) => {
+        if (game.importer !== "NTE") return false;
+
+        const roots = getNteRoots(game);
+        if (isSameOrChildPath(roots.modRoot, targetPath)) return true;
+        if (roots.linkedRoot && isSameOrChildPath(roots.linkedRoot, targetPath)) return true;
+
+        return false;
+    });
 }
 
 export async function getNteCharacters(
@@ -168,6 +174,20 @@ export async function getNteMods(
     };
 }
 
+export function hasNtePathChanges(
+    existing: Pick<GameConfig, "modFolderPath" | "linkedModFolderPath">,
+    updates: Pick<GameConfig, "modFolderPath" | "linkedModFolderPath">,
+) {
+    if (!isSameNtePath(existing.modFolderPath, updates.modFolderPath)) return true;
+
+    const existingLinked = existing.linkedModFolderPath;
+    const updatedLinked = updates.linkedModFolderPath;
+    if (existingLinked === updatedLinked) return false;
+    if (!existingLinked || !updatedLinked) return true;
+
+    return !isSameNtePath(existingLinked, updatedLinked);
+}
+
 export async function cleanupNteModFolder(
     modFolderPath: string,
     linkedModFolderPath: string | null,
@@ -207,7 +227,7 @@ export async function setNteModEnabled(
     if (enabled) {
         await Promise.all(
             entries
-                .filter((entry) => isDisabledFile(entry.name))
+                .filter((entry) => isDisabledFile(entry.name) && isPakModFile(entry.name))
                 .map((entry) =>
                     fse.rename(
                         path.join(modPath, entry.name),
@@ -220,7 +240,7 @@ export async function setNteModEnabled(
 
     await Promise.all(
         entries
-            .filter((entry) => !isDisabledFile(entry.name))
+            .filter((entry) => !isDisabledFile(entry.name) && isPakModFile(entry.name))
             .map((entry) =>
                 fse.rename(
                     path.join(modPath, entry.name),
@@ -356,9 +376,19 @@ function isSameNtePath(left: string, right: string) {
 }
 
 function getNteRelativePath(roots: NteGameRoots, targetPath: string) {
-    const relativePath = path.relative(roots.modRoot, targetPath);
+    const relativeFromModRoot = path.relative(roots.modRoot, targetPath);
+    if (!relativeFromModRoot.startsWith("..") && !path.isAbsolute(relativeFromModRoot)) {
+        return relativeFromModRoot;
+    }
 
-    return relativePath.startsWith("..") ? "" : relativePath;
+    if (!roots.linkedRoot) return "";
+
+    const relativeFromLinkedRoot = path.relative(roots.linkedRoot, targetPath);
+    if (relativeFromLinkedRoot.startsWith("..") || path.isAbsolute(relativeFromLinkedRoot)) {
+        return "";
+    }
+
+    return relativeFromLinkedRoot;
 }
 
 async function listDirectoryNames(dirPath: string) {

--- a/src/renderer/src/components/download-confirmation-overlay.tsx
+++ b/src/renderer/src/components/download-confirmation-overlay.tsx
@@ -37,7 +37,7 @@ export function DownloadConfirmationOverlay() {
 
       setDownloadMode(null);
     } catch (error) {
-      toast.error("경로 선택에 실패했습니다.");
+      toast.error(t("components.download-confirmation-overlay.select_path_failed"));
       Logger.error(error, "DownloadConfirmationOverlay:handleConfirm");
     }
   };

--- a/src/renderer/src/components/mod/add-game-dialog.tsx
+++ b/src/renderer/src/components/mod/add-game-dialog.tsx
@@ -1,5 +1,4 @@
 // oxlint-disable react/no-children-prop
-import { Alert, AlertDescription } from "@renderer/components/ui/alert";
 import { Button } from "@renderer/components/ui/button";
 import {
   Dialog,
@@ -21,25 +20,49 @@ import {
   SelectValue,
 } from "@renderer/components/ui/select";
 import { useModStore } from "@renderer/store/mod";
+import { isNteImporter, NTE_IMPORTER_KEY } from "@shared/mod";
 import { useForm } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { FolderOpen, Plus } from "lucide-react";
-import { useEffect } from "react";
+import { FolderOpen, Plus, SaveIcon, XIcon } from "lucide-react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { Alert, AlertDescription } from "../ui/alert";
 
 const NO_IMPORTER_VALUE = "__none__";
 
 interface AddGameDialogProps {
   onPickFolder: () => Promise<string | null>;
-  onAddGame: (name: string, path: string, importer: string | null) => void;
+  onAddGame: (
+    name: string,
+    path: string,
+    importer: string | null,
+    linkedModFolderPath?: string | null,
+  ) => void;
+}
+
+interface NteResolution {
+  gameRootPath: string;
+  executablePath: string;
+  modFolderPath: string;
+  linkedModFolderPath: string;
+}
+
+function getNteGameName(language: string) {
+  if (language.startsWith("ko")) return "이환";
+  if (language.startsWith("zh")) return "异环";
+  return "NTE";
 }
 
 export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
   const formId = "add-game-dialog-form";
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const navi = useNavigate();
+  const [nteResolution, setNteResolution] = useState<NteResolution | null>(null);
+  const [isResolvingNte, setIsResolvingNte] = useState(false);
+  const [selectedImporter, setSelectedImporter] = useState(NO_IMPORTER_VALUE);
+  const isNteSelected = isNteImporter(selectedImporter);
 
   const isOpen = useModStore((s) => s.isAddGameDialogOpen);
   const setIsOpen = useModStore((s) => s.setIsAddGameDialogOpen);
@@ -49,17 +72,22 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
   });
 
   const enabledImporters = xxmiData?.enabledImporters ?? [];
+  const importers = [{ key: NTE_IMPORTER_KEY }, ...enabledImporters];
   const isXXMIConfigured = !!xxmiData?.xxmiPath;
 
   const form = useForm({
     defaultValues: {
       name: "",
       path: "",
+      customModFolderPath: "",
       importer: NO_IMPORTER_VALUE,
     },
     onSubmit: async ({ value }) => {
-      const name = value.name.trim();
+      const importer = value.importer === NO_IMPORTER_VALUE ? null : value.importer;
+      const isNte = isNteImporter(importer);
+      const name = isNte ? getNteGameName(i18n.language) : value.name.trim();
       const path = value.path.trim();
+      const customModFolderPath = value.customModFolderPath.trim();
 
       if (!name) {
         toast.warning(t("page.mod.dialog.add-game.#.0"));
@@ -71,13 +99,32 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
         return;
       }
 
-      onAddGame(name, path, value.importer === NO_IMPORTER_VALUE ? null : value.importer);
+      if (isNte) {
+        const resolution = nteResolution ?? (await resolveNtePath(path).catch(() => null));
+
+        if (!resolution) {
+          toast.warning(t("page.mod.dialog.add-game.nte_not_found", "NTE game not found."));
+          return;
+        }
+
+        onAddGame(
+          name,
+          customModFolderPath || resolution.modFolderPath,
+          importer,
+          customModFolderPath ? resolution.linkedModFolderPath : null,
+        );
+        return;
+      }
+
+      onAddGame(name, path, importer);
     },
   });
 
   useEffect(() => {
     if (!isOpen) {
       form.reset();
+      setNteResolution(null);
+      setSelectedImporter(NO_IMPORTER_VALUE);
     }
   }, [form, isOpen]);
 
@@ -85,6 +132,14 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
     const path = await onPickFolder();
     if (path) {
       form.setFieldValue("path", path);
+      setNteResolution(null);
+    }
+  };
+
+  const handlePickCustomModFolder = async () => {
+    const path = await onPickFolder();
+    if (path) {
+      form.setFieldValue("customModFolderPath", path);
     }
   };
 
@@ -92,12 +147,38 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
     setIsOpen(open);
     if (!open) {
       form.reset();
+      setNteResolution(null);
+      setSelectedImporter(NO_IMPORTER_VALUE);
     }
   };
 
   const handleOpenXXMISettings = () => {
     handleOpenChange(false);
     void navi({ to: "/setting/xxmi" });
+  };
+
+  const handleImporterChange = (value: string, onChange: (value: string) => void) => {
+    onChange(value);
+    setSelectedImporter(value);
+    setNteResolution(null);
+
+    if (isNteImporter(value)) {
+      form.setFieldValue("name", getNteGameName(i18n.language));
+    }
+  };
+
+  const resolveNtePath = async (installPath: string) => {
+    setIsResolvingNte(true);
+    try {
+      const resolution = await window.api.invoke("mod:resolveNteInstallPath", installPath);
+      setNteResolution(resolution);
+      if (!resolution) {
+        toast.warning(t("page.mod.dialog.add-game.nte_not_found", "NTE game not found."));
+      }
+      return resolution;
+    } finally {
+      setIsResolvingNte(false);
+    }
   };
 
   return (
@@ -134,6 +215,7 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
                 <Input
                   id={field.name}
                   value={field.state.value}
+                  readOnly={isNteSelected}
                   onBlur={field.handleBlur}
                   onChange={(e) => field.handleChange(e.target.value)}
                 />
@@ -153,20 +235,42 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
             children={(field) => (
               <Field>
                 <FieldLabel htmlFor={field.name}>
-                  {t("page.mod.dialog.add-game.path_input_placeholder")}
+                  {isNteSelected
+                    ? t("page.mod.dialog.add-game.nte_install_path", "NTE install folder")
+                    : t("page.mod.dialog.add-game.path_input_placeholder")}
                 </FieldLabel>
                 <div className="flex gap-2">
                   <Input
                     id={field.name}
                     value={field.state.value}
-                    readOnly
+                    readOnly={!isNteSelected}
                     hideFocusRing
                     onBlur={field.handleBlur}
+                    onChange={(e) => {
+                      field.handleChange(e.target.value);
+                      setNteResolution(null);
+                    }}
                   />
                   <Button type="button" variant="outline" size="icon" onClick={handlePickFolder}>
                     <FolderOpen className="size-4" />
                   </Button>
+                  {isNteSelected && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      disabled={isResolvingNte || !field.state.value.trim()}
+                      onClick={() => void resolveNtePath(field.state.value.trim())}
+                    >
+                      <SaveIcon className="size-4" />
+                    </Button>
+                  )}
                 </div>
+                {nteResolution && isNteSelected ? (
+                  <p className="text-xs text-muted-foreground break-all">
+                    {nteResolution.modFolderPath}
+                  </p>
+                ) : null}
                 {field.state.meta.isTouched && !field.state.meta.isValid ? (
                   <FieldError>{field.state.meta.errors.join(", ")}</FieldError>
                 ) : null}
@@ -174,12 +278,60 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
             )}
           />
 
+          {isNteSelected && (
+            <form.Field
+              name="customModFolderPath"
+              children={(field) => (
+                <Field>
+                  <FieldLabel>
+                    {t("page.mod.dialog.add-game.nte_custom_mod_folder", "Custom mod folder")}
+                  </FieldLabel>
+                  <div className="flex gap-2">
+                    <Input
+                      id={field.name}
+                      value={field.state.value}
+                      readOnly
+                      hideFocusRing
+                      onBlur={field.handleBlur}
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      onClick={handlePickCustomModFolder}
+                    >
+                      <FolderOpen className="size-4" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      disabled={!field.state.value}
+                      onClick={() => field.handleChange("")}
+                    >
+                      <XIcon className="size-4" />
+                    </Button>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {t(
+                      "page.mod.dialog.add-game.nte_custom_mod_folder_description",
+                      "Optional. The game Mods folder will be linked to this folder.",
+                    )}
+                  </p>
+                </Field>
+              )}
+            />
+          )}
+
           <form.Field
             name="importer"
             children={(field) => (
               <Field>
                 <FieldLabel>{t("page.mod.dialog.edit-game.importer_label")}</FieldLabel>
-                <Select value={field.state.value} onValueChange={field.handleChange}>
+                <Select
+                  value={field.state.value}
+                  onValueChange={(value) => handleImporterChange(value, field.handleChange)}
+                >
                   <SelectTrigger className="w-full">
                     <SelectValue placeholder={t("g.select")} />
                   </SelectTrigger>
@@ -188,7 +340,7 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
                       <SelectItem value={NO_IMPORTER_VALUE}>
                         {t("page.mod.dialog.edit-game.no_importer")}
                       </SelectItem>
-                      {enabledImporters.map((importer) => (
+                      {importers.map((importer) => (
                         <SelectItem key={importer.key} value={importer.key}>
                           {importer.key}
                         </SelectItem>
@@ -196,7 +348,7 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
                     </SelectGroup>
                   </SelectContent>
                 </Select>
-                {!isXXMIConfigured && (
+                {!isXXMIConfigured && !isNteImporter(field.state.value) && (
                   <Alert>
                     <AlertDescription>
                       <div className="flex flex-col gap-3">

--- a/src/renderer/src/components/mod/add-game-dialog.tsx
+++ b/src/renderer/src/components/mod/add-game-dialog.tsx
@@ -24,7 +24,7 @@ import { isNteImporter, NTE_IMPORTER_KEY } from "@shared/mod";
 import { useForm } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { FolderOpen, Plus, SaveIcon, XIcon } from "lucide-react";
+import { FolderOpen, Plus, XIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -39,6 +39,8 @@ interface AddGameDialogProps {
     path: string,
     importer: string | null,
     linkedModFolderPath?: string | null,
+    gameInstallPath?: string | null,
+    gameExecutablePath?: string | null,
   ) => void;
 }
 
@@ -49,15 +51,9 @@ interface NteResolution {
   linkedModFolderPath: string;
 }
 
-function getNteGameName(language: string) {
-  if (language.startsWith("ko")) return "이환";
-  if (language.startsWith("zh")) return "异环";
-  return "NTE";
-}
-
 export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
   const formId = "add-game-dialog-form";
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const navi = useNavigate();
   const [nteResolution, setNteResolution] = useState<NteResolution | null>(null);
   const [isResolvingNte, setIsResolvingNte] = useState(false);
@@ -72,7 +68,7 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
   });
 
   const enabledImporters = xxmiData?.enabledImporters ?? [];
-  const importers = [{ key: NTE_IMPORTER_KEY }, ...enabledImporters];
+  const importers = [...enabledImporters, { key: NTE_IMPORTER_KEY }];
   const isXXMIConfigured = !!xxmiData?.xxmiPath;
 
   const form = useForm({
@@ -85,7 +81,7 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
     onSubmit: async ({ value }) => {
       const importer = value.importer === NO_IMPORTER_VALUE ? null : value.importer;
       const isNte = isNteImporter(importer);
-      const name = isNte ? getNteGameName(i18n.language) : value.name.trim();
+      const name = isNte ? t("page.mod.dialog.add-game.nte_game_name") : value.name.trim();
       const path = value.path.trim();
       const customModFolderPath = value.customModFolderPath.trim();
 
@@ -103,7 +99,7 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
         const resolution = nteResolution ?? (await resolveNtePath(path).catch(() => null));
 
         if (!resolution) {
-          toast.warning(t("page.mod.dialog.add-game.nte_not_found", "NTE game not found."));
+          toast.warning(t("page.mod.dialog.add-game.nte_not_found"));
           return;
         }
 
@@ -112,6 +108,8 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
           customModFolderPath || resolution.modFolderPath,
           importer,
           customModFolderPath ? resolution.linkedModFolderPath : null,
+          resolution.gameRootPath,
+          resolution.executablePath,
         );
         return;
       }
@@ -130,9 +128,13 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
 
   const handlePickFolder = async () => {
     const path = await onPickFolder();
-    if (path) {
-      form.setFieldValue("path", path);
-      setNteResolution(null);
+    if (!path) return;
+
+    form.setFieldValue("path", path);
+    setNteResolution(null);
+
+    if (isNteSelected) {
+      await resolveNtePath(path);
     }
   };
 
@@ -158,12 +160,19 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
   };
 
   const handleImporterChange = (value: string, onChange: (value: string) => void) => {
+    const wasNte = isNteImporter(selectedImporter);
+    const nextIsNte = isNteImporter(value);
     onChange(value);
     setSelectedImporter(value);
     setNteResolution(null);
 
-    if (isNteImporter(value)) {
-      form.setFieldValue("name", getNteGameName(i18n.language));
+    if (wasNte && !nextIsNte) {
+      form.setFieldValue("path", "");
+      form.setFieldValue("customModFolderPath", "");
+    }
+
+    if (nextIsNte) {
+      form.setFieldValue("name", t("page.mod.dialog.add-game.nte_game_name"));
     }
   };
 
@@ -173,7 +182,7 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
       const resolution = await window.api.invoke("mod:resolveNteInstallPath", installPath);
       setNteResolution(resolution);
       if (!resolution) {
-        toast.warning(t("page.mod.dialog.add-game.nte_not_found", "NTE game not found."));
+        toast.warning(t("page.mod.dialog.add-game.nte_not_found"));
       }
       return resolution;
     } finally {
@@ -236,7 +245,7 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
               <Field>
                 <FieldLabel htmlFor={field.name}>
                   {isNteSelected
-                    ? t("page.mod.dialog.add-game.nte_install_path", "NTE install folder")
+                    ? t("page.mod.dialog.add-game.nte_install_path")
                     : t("page.mod.dialog.add-game.path_input_placeholder")}
                 </FieldLabel>
                 <div className="flex gap-2">
@@ -251,20 +260,15 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
                       setNteResolution(null);
                     }}
                   />
-                  <Button type="button" variant="outline" size="icon" onClick={handlePickFolder}>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    disabled={isNteSelected && isResolvingNte}
+                    onClick={() => void handlePickFolder()}
+                  >
                     <FolderOpen className="size-4" />
                   </Button>
-                  {isNteSelected && (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      disabled={isResolvingNte || !field.state.value.trim()}
-                      onClick={() => void resolveNtePath(field.state.value.trim())}
-                    >
-                      <SaveIcon className="size-4" />
-                    </Button>
-                  )}
                 </div>
                 {nteResolution && isNteSelected ? (
                   <p className="text-xs text-muted-foreground break-all">
@@ -283,9 +287,7 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
               name="customModFolderPath"
               children={(field) => (
                 <Field>
-                  <FieldLabel>
-                    {t("page.mod.dialog.add-game.nte_custom_mod_folder", "Custom mod folder")}
-                  </FieldLabel>
+                  <FieldLabel>{t("page.mod.dialog.add-game.nte_custom_mod_folder")}</FieldLabel>
                   <div className="flex gap-2">
                     <Input
                       id={field.name}
@@ -313,10 +315,7 @@ export function AddGameDialog({ onPickFolder, onAddGame }: AddGameDialogProps) {
                     </Button>
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    {t(
-                      "page.mod.dialog.add-game.nte_custom_mod_folder_description",
-                      "Optional. The game Mods folder will be linked to this folder.",
-                    )}
+                    {t("page.mod.dialog.add-game.nte_custom_mod_folder_description")}
                   </p>
                 </Field>
               )}

--- a/src/renderer/src/components/mod/custom-download-dialog.tsx
+++ b/src/renderer/src/components/mod/custom-download-dialog.tsx
@@ -3,7 +3,6 @@ import { Button } from "@renderer/components/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -83,12 +82,9 @@ export function CustomDownloadDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent showCloseButton={false}>
+      <DialogContent showCloseButton={false} aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>{t("page.mod.content-header.download_dialog.title")}</DialogTitle>
-          <DialogDescription>
-            {t("page.mod.content-header.download_dialog.description")}
-          </DialogDescription>
         </DialogHeader>
 
         <form

--- a/src/renderer/src/components/mod/edit-game-dialog.tsx
+++ b/src/renderer/src/components/mod/edit-game-dialog.tsx
@@ -118,14 +118,18 @@ export function EditGameDialog({
         }
 
         const linkedModFolderPath =
-          resolution.linkedModFolderPath ?? editingGame.linkedModFolderPath ?? path;
+          resolution.linkedModFolderPath ??
+          resolution.modFolderPath ??
+          editingGame.linkedModFolderPath ??
+          editingGame.modFolderPath ??
+          path;
 
         onUpdateGame(editingGame.game, {
           modFolderPath: customModFolderPath || linkedModFolderPath,
           importer,
           linkedModFolderPath: customModFolderPath ? linkedModFolderPath : null,
           gameInstallPath: resolution.gameRootPath,
-          gameExecutablePath: resolution.executablePath || editingGame.gameExecutablePath,
+          gameExecutablePath: editingGame.gameExecutablePath ?? resolution.executablePath,
         });
         return;
       }

--- a/src/renderer/src/components/mod/edit-game-dialog.tsx
+++ b/src/renderer/src/components/mod/edit-game-dialog.tsx
@@ -22,7 +22,7 @@ import { useModStore } from "@renderer/store/mod";
 import { isNteImporter, NTE_IMPORTER_KEY } from "@shared/mod";
 import type { GameConfig } from "@shared/types";
 import { useForm } from "@tanstack/react-form";
-import { ArrowDownIcon, ArrowUpIcon, FolderOpen, SaveIcon, Trash2Icon, XIcon } from "lucide-react";
+import { ArrowDownIcon, ArrowUpIcon, FolderOpen, Trash2Icon, XIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -39,6 +39,7 @@ interface EditGameDialogProps {
       modFolderPath: string;
       importer: string | null;
       linkedModFolderPath: string | null;
+      gameInstallPath: string | null;
     },
   ) => void;
   onDeleteGameClick: (game: string) => void;
@@ -86,7 +87,7 @@ export function EditGameDialog({
     : -1;
   const canMoveUp = currentGameIndex > 0;
   const canMoveDown = currentGameIndex >= 0 && currentGameIndex < games.length - 1;
-  const importers = [{ key: NTE_IMPORTER_KEY }, ...enabledImporters];
+  const importers = [...enabledImporters, { key: NTE_IMPORTER_KEY }];
 
   const form = useForm({
     defaultValues: {
@@ -109,7 +110,7 @@ export function EditGameDialog({
       }
 
       if (isNte && !nteResolution) {
-        toast.warning(t("page.mod.dialog.add-game.nte_not_found", "NTE game not found."));
+        toast.warning(t("page.mod.dialog.add-game.nte_not_found"));
         return;
       }
 
@@ -118,11 +119,12 @@ export function EditGameDialog({
         : "";
 
       onUpdateGame(editingGame.game, {
-        modFolderPath: isNte
-          ? customModFolderPath || linkedModFolderPath
-          : (nteResolution?.modFolderPath ?? path),
+        modFolderPath: isNte ? customModFolderPath || linkedModFolderPath : path,
         importer,
         linkedModFolderPath: isNte && customModFolderPath ? linkedModFolderPath : null,
+        gameInstallPath: isNte
+          ? (nteResolution?.gameRootPath ?? editingGame.gameInstallPath)
+          : null,
       });
     },
   });
@@ -140,7 +142,8 @@ export function EditGameDialog({
     }
 
     form.reset({
-      path: editingGame.linkedModFolderPath ?? editingGame.modFolderPath,
+      path:
+        editingGame.gameInstallPath ?? editingGame.linkedModFolderPath ?? editingGame.modFolderPath,
       customModFolderPath: editingGame.linkedModFolderPath ? editingGame.modFolderPath : "",
       importer: editingGame.importer ?? NO_IMPORTER_VALUE,
     });
@@ -148,7 +151,7 @@ export function EditGameDialog({
     setNteResolution(
       isNteImporter(editingGame.importer)
         ? {
-            gameRootPath: "",
+            gameRootPath: editingGame.gameInstallPath ?? "",
             executablePath: "",
             modFolderPath: editingGame.linkedModFolderPath ?? editingGame.modFolderPath,
             linkedModFolderPath: editingGame.linkedModFolderPath ?? editingGame.modFolderPath,
@@ -173,9 +176,13 @@ export function EditGameDialog({
 
   const handlePickFolder = async () => {
     const path = await onPickFolder();
-    if (path) {
-      form.setFieldValue("path", path);
-      setNteResolution(null);
+    if (!path) return;
+
+    form.setFieldValue("path", path);
+    setNteResolution(null);
+
+    if (isNteSelected) {
+      await resolveNtePath(path);
     }
   };
 
@@ -192,7 +199,7 @@ export function EditGameDialog({
       const resolution = await window.api.invoke("mod:resolveNteInstallPath", installPath);
       setNteResolution(resolution);
       if (!resolution) {
-        toast.warning(t("page.mod.dialog.add-game.nte_not_found", "NTE game not found."));
+        toast.warning(t("page.mod.dialog.add-game.nte_not_found"));
       }
     } finally {
       setIsResolvingNte(false);
@@ -243,7 +250,7 @@ export function EditGameDialog({
                   <Input
                     placeholder={
                       isNteSelected
-                        ? t("page.mod.dialog.add-game.nte_install_path", "NTE install folder")
+                        ? t("page.mod.dialog.add-game.nte_install_path")
                         : t("page.mod.dialog.add-game.path_input_placeholder")
                     }
                     value={field.state.value}
@@ -254,20 +261,15 @@ export function EditGameDialog({
                       setNteResolution(null);
                     }}
                   />
-                  <Button type="button" variant="outline" size="icon" onClick={handlePickFolder}>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    disabled={isNteSelected && isResolvingNte}
+                    onClick={() => void handlePickFolder()}
+                  >
                     <FolderOpen className="size-4" />
                   </Button>
-                  {isNteSelected && (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      disabled={isResolvingNte || !field.state.value.trim()}
-                      onClick={() => void resolveNtePath(field.state.value.trim())}
-                    >
-                      <SaveIcon className="size-4" />
-                    </Button>
-                  )}
                 </div>
                 {nteResolution && isNteSelected ? (
                   <p className="text-xs text-muted-foreground break-all">
@@ -289,9 +291,21 @@ export function EditGameDialog({
                 <Select
                   value={field.state.value}
                   onValueChange={(value) => {
+                    const wasNte = isNteImporter(field.state.value);
+                    const nextIsNte = isNteImporter(value);
                     field.handleChange(value);
                     setSelectedImporter(value);
                     setNteResolution(null);
+
+                    if (wasNte && !nextIsNte) {
+                      form.setFieldValue(
+                        "path",
+                        isNteImporter(editingGame?.importer)
+                          ? ""
+                          : (editingGame?.modFolderPath ?? ""),
+                      );
+                      form.setFieldValue("customModFolderPath", "");
+                    }
                   }}
                 >
                   <SelectTrigger className="w-full">
@@ -319,9 +333,7 @@ export function EditGameDialog({
               name="customModFolderPath"
               children={(field) => (
                 <Field>
-                  <FieldLabel>
-                    {t("page.mod.dialog.add-game.nte_custom_mod_folder", "Custom mod folder")}
-                  </FieldLabel>
+                  <FieldLabel>{t("page.mod.dialog.add-game.nte_custom_mod_folder")}</FieldLabel>
                   <div className="flex gap-2">
                     <Input
                       value={field.state.value}
@@ -348,10 +360,7 @@ export function EditGameDialog({
                     </Button>
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    {t(
-                      "page.mod.dialog.add-game.nte_custom_mod_folder_description",
-                      "Optional. The game Mods folder will be linked to this folder.",
-                    )}
+                    {t("page.mod.dialog.add-game.nte_custom_mod_folder_description")}
                   </p>
                 </Field>
               )}

--- a/src/renderer/src/components/mod/edit-game-dialog.tsx
+++ b/src/renderer/src/components/mod/edit-game-dialog.tsx
@@ -123,13 +123,17 @@ export function EditGameDialog({
           editingGame.linkedModFolderPath ??
           editingGame.modFolderPath ??
           path;
+        const installPathChanged =
+          resolution.gameRootPath.trim() !== (editingGame.gameInstallPath ?? "").trim();
 
         onUpdateGame(editingGame.game, {
           modFolderPath: customModFolderPath || linkedModFolderPath,
           importer,
           linkedModFolderPath: customModFolderPath ? linkedModFolderPath : null,
           gameInstallPath: resolution.gameRootPath,
-          gameExecutablePath: editingGame.gameExecutablePath ?? resolution.executablePath,
+          gameExecutablePath: installPathChanged
+            ? resolution.executablePath
+            : (editingGame.gameExecutablePath ?? resolution.executablePath),
         });
         return;
       }

--- a/src/renderer/src/components/mod/edit-game-dialog.tsx
+++ b/src/renderer/src/components/mod/edit-game-dialog.tsx
@@ -40,6 +40,7 @@ interface EditGameDialogProps {
       importer: string | null;
       linkedModFolderPath: string | null;
       gameInstallPath: string | null;
+      gameExecutablePath: string | null;
     },
   ) => void;
   onDeleteGameClick: (game: string) => void;
@@ -109,22 +110,32 @@ export function EditGameDialog({
         return;
       }
 
-      if (isNte && !nteResolution) {
-        toast.warning(t("page.mod.dialog.add-game.nte_not_found"));
+      if (isNte) {
+        const resolution = nteResolution ?? (await resolveNtePath(path).catch(() => null));
+        if (!resolution) {
+          toast.warning(t("page.mod.dialog.add-game.nte_not_found"));
+          return;
+        }
+
+        const linkedModFolderPath =
+          resolution.linkedModFolderPath ?? editingGame.linkedModFolderPath ?? path;
+
+        onUpdateGame(editingGame.game, {
+          modFolderPath: customModFolderPath || linkedModFolderPath,
+          importer,
+          linkedModFolderPath: customModFolderPath ? linkedModFolderPath : null,
+          gameInstallPath: resolution.gameRootPath,
+          gameExecutablePath: resolution.executablePath || editingGame.gameExecutablePath,
+        });
         return;
       }
 
-      const linkedModFolderPath = isNte
-        ? (nteResolution?.linkedModFolderPath ?? editingGame.linkedModFolderPath ?? path)
-        : "";
-
       onUpdateGame(editingGame.game, {
-        modFolderPath: isNte ? customModFolderPath || linkedModFolderPath : path,
+        modFolderPath: path,
         importer,
-        linkedModFolderPath: isNte && customModFolderPath ? linkedModFolderPath : null,
-        gameInstallPath: isNte
-          ? (nteResolution?.gameRootPath ?? editingGame.gameInstallPath)
-          : null,
+        linkedModFolderPath: null,
+        gameInstallPath: null,
+        gameExecutablePath: null,
       });
     },
   });
@@ -152,7 +163,7 @@ export function EditGameDialog({
       isNteImporter(editingGame.importer)
         ? {
             gameRootPath: editingGame.gameInstallPath ?? "",
-            executablePath: "",
+            executablePath: editingGame.gameExecutablePath ?? "",
             modFolderPath: editingGame.linkedModFolderPath ?? editingGame.modFolderPath,
             linkedModFolderPath: editingGame.linkedModFolderPath ?? editingGame.modFolderPath,
           }
@@ -201,6 +212,7 @@ export function EditGameDialog({
       if (!resolution) {
         toast.warning(t("page.mod.dialog.add-game.nte_not_found"));
       }
+      return resolution;
     } finally {
       setIsResolvingNte(false);
     }

--- a/src/renderer/src/components/mod/edit-game-dialog.tsx
+++ b/src/renderer/src/components/mod/edit-game-dialog.tsx
@@ -19,10 +19,11 @@ import {
   SelectValue,
 } from "@renderer/components/ui/select";
 import { useModStore } from "@renderer/store/mod";
+import { isNteImporter, NTE_IMPORTER_KEY } from "@shared/mod";
 import type { GameConfig } from "@shared/types";
 import { useForm } from "@tanstack/react-form";
-import { ArrowDownIcon, ArrowUpIcon, FolderOpen, Trash2Icon } from "lucide-react";
-import { useEffect } from "react";
+import { ArrowDownIcon, ArrowUpIcon, FolderOpen, SaveIcon, Trash2Icon, XIcon } from "lucide-react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -32,9 +33,23 @@ interface EditGameDialogProps {
   games: GameConfig[];
   enabledImporters: Array<{ key: string }>;
   onPickFolder: () => Promise<string | null>;
-  onUpdateGame: (game: string, updates: { modFolderPath: string; importer: string | null }) => void;
+  onUpdateGame: (
+    game: string,
+    updates: {
+      modFolderPath: string;
+      importer: string | null;
+      linkedModFolderPath: string | null;
+    },
+  ) => void;
   onDeleteGameClick: (game: string) => void;
   onReorderGames: (games: string[]) => void;
+}
+
+interface NteResolution {
+  gameRootPath: string;
+  executablePath: string;
+  modFolderPath: string;
+  linkedModFolderPath: string;
 }
 
 export function openEditGameDialog(
@@ -58,6 +73,10 @@ export function EditGameDialog({
 }: EditGameDialogProps) {
   const formId = "edit-game-dialog-form";
   const { t } = useTranslation();
+  const [nteResolution, setNteResolution] = useState<NteResolution | null>(null);
+  const [isResolvingNte, setIsResolvingNte] = useState(false);
+  const [selectedImporter, setSelectedImporter] = useState(NO_IMPORTER_VALUE);
+  const isNteSelected = isNteImporter(selectedImporter);
   const isOpen = useModStore((s) => s.isEditGameDialogOpen);
   const setIsOpen = useModStore((s) => s.setIsEditGameDialogOpen);
   const editingGame = useModStore((s) => s.editingGame);
@@ -67,10 +86,12 @@ export function EditGameDialog({
     : -1;
   const canMoveUp = currentGameIndex > 0;
   const canMoveDown = currentGameIndex >= 0 && currentGameIndex < games.length - 1;
+  const importers = [{ key: NTE_IMPORTER_KEY }, ...enabledImporters];
 
   const form = useForm({
     defaultValues: {
       path: "",
+      customModFolderPath: "",
       importer: NO_IMPORTER_VALUE,
     },
     onSubmit: async ({ value }) => {
@@ -79,14 +100,29 @@ export function EditGameDialog({
       }
 
       const path = value.path.trim();
+      const customModFolderPath = value.customModFolderPath.trim();
+      const importer = value.importer === NO_IMPORTER_VALUE ? null : value.importer;
+      const isNte = isNteImporter(importer);
       if (!path) {
         toast.warning(t("page.mod.dialog.add-game.#.1"));
         return;
       }
 
+      if (isNte && !nteResolution) {
+        toast.warning(t("page.mod.dialog.add-game.nte_not_found", "NTE game not found."));
+        return;
+      }
+
+      const linkedModFolderPath = isNte
+        ? (nteResolution?.linkedModFolderPath ?? editingGame.linkedModFolderPath ?? path)
+        : "";
+
       onUpdateGame(editingGame.game, {
-        modFolderPath: path,
-        importer: value.importer === NO_IMPORTER_VALUE ? null : value.importer,
+        modFolderPath: isNte
+          ? customModFolderPath || linkedModFolderPath
+          : (nteResolution?.modFolderPath ?? path),
+        importer,
+        linkedModFolderPath: isNte && customModFolderPath ? linkedModFolderPath : null,
       });
     },
   });
@@ -95,15 +131,30 @@ export function EditGameDialog({
     if (!isOpen || !editingGame) {
       form.reset({
         path: "",
+        customModFolderPath: "",
         importer: NO_IMPORTER_VALUE,
       });
+      setNteResolution(null);
+      setSelectedImporter(NO_IMPORTER_VALUE);
       return;
     }
 
     form.reset({
-      path: editingGame.modFolderPath,
+      path: editingGame.linkedModFolderPath ?? editingGame.modFolderPath,
+      customModFolderPath: editingGame.linkedModFolderPath ? editingGame.modFolderPath : "",
       importer: editingGame.importer ?? NO_IMPORTER_VALUE,
     });
+    setSelectedImporter(editingGame.importer ?? NO_IMPORTER_VALUE);
+    setNteResolution(
+      isNteImporter(editingGame.importer)
+        ? {
+            gameRootPath: "",
+            executablePath: "",
+            modFolderPath: editingGame.linkedModFolderPath ?? editingGame.modFolderPath,
+            linkedModFolderPath: editingGame.linkedModFolderPath ?? editingGame.modFolderPath,
+          }
+        : null,
+    );
   }, [editingGame, form, isOpen]);
 
   const handleOpenChange = (open: boolean) => {
@@ -112,8 +163,11 @@ export function EditGameDialog({
       setEditingGame(null);
       form.reset({
         path: "",
+        customModFolderPath: "",
         importer: NO_IMPORTER_VALUE,
       });
+      setNteResolution(null);
+      setSelectedImporter(NO_IMPORTER_VALUE);
     }
   };
 
@@ -121,6 +175,27 @@ export function EditGameDialog({
     const path = await onPickFolder();
     if (path) {
       form.setFieldValue("path", path);
+      setNteResolution(null);
+    }
+  };
+
+  const handlePickCustomModFolder = async () => {
+    const path = await onPickFolder();
+    if (path) {
+      form.setFieldValue("customModFolderPath", path);
+    }
+  };
+
+  const resolveNtePath = async (installPath: string) => {
+    setIsResolvingNte(true);
+    try {
+      const resolution = await window.api.invoke("mod:resolveNteInstallPath", installPath);
+      setNteResolution(resolution);
+      if (!resolution) {
+        toast.warning(t("page.mod.dialog.add-game.nte_not_found", "NTE game not found."));
+      }
+    } finally {
+      setIsResolvingNte(false);
     }
   };
 
@@ -166,15 +241,39 @@ export function EditGameDialog({
                 <FieldLabel>{t("page.mod.dialog.edit-game.path_label")}</FieldLabel>
                 <div className="flex gap-2">
                   <Input
-                    placeholder={t("page.mod.dialog.add-game.path_input_placeholder")}
+                    placeholder={
+                      isNteSelected
+                        ? t("page.mod.dialog.add-game.nte_install_path", "NTE install folder")
+                        : t("page.mod.dialog.add-game.path_input_placeholder")
+                    }
                     value={field.state.value}
-                    readOnly
+                    readOnly={!isNteSelected}
                     onBlur={field.handleBlur}
+                    onChange={(event) => {
+                      field.handleChange(event.target.value);
+                      setNteResolution(null);
+                    }}
                   />
                   <Button type="button" variant="outline" size="icon" onClick={handlePickFolder}>
                     <FolderOpen className="size-4" />
                   </Button>
+                  {isNteSelected && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      disabled={isResolvingNte || !field.state.value.trim()}
+                      onClick={() => void resolveNtePath(field.state.value.trim())}
+                    >
+                      <SaveIcon className="size-4" />
+                    </Button>
+                  )}
                 </div>
+                {nteResolution && isNteSelected ? (
+                  <p className="text-xs text-muted-foreground break-all">
+                    {nteResolution.modFolderPath}
+                  </p>
+                ) : null}
                 {field.state.meta.isTouched && !field.state.meta.isValid ? (
                   <FieldError>{field.state.meta.errors.join(", ")}</FieldError>
                 ) : null}
@@ -187,7 +286,14 @@ export function EditGameDialog({
             children={(field) => (
               <Field>
                 <FieldLabel>{t("page.mod.dialog.edit-game.importer_label")}</FieldLabel>
-                <Select value={field.state.value} onValueChange={field.handleChange}>
+                <Select
+                  value={field.state.value}
+                  onValueChange={(value) => {
+                    field.handleChange(value);
+                    setSelectedImporter(value);
+                    setNteResolution(null);
+                  }}
+                >
                   <SelectTrigger className="w-full">
                     <SelectValue placeholder={t("g.select")} />
                   </SelectTrigger>
@@ -196,7 +302,7 @@ export function EditGameDialog({
                       <SelectItem value={NO_IMPORTER_VALUE}>
                         {t("page.mod.dialog.edit-game.no_importer")}
                       </SelectItem>
-                      {enabledImporters.map((importer) => (
+                      {importers.map((importer) => (
                         <SelectItem key={importer.key} value={importer.key}>
                           {importer.key}
                         </SelectItem>
@@ -207,6 +313,50 @@ export function EditGameDialog({
               </Field>
             )}
           />
+
+          {isNteSelected && (
+            <form.Field
+              name="customModFolderPath"
+              children={(field) => (
+                <Field>
+                  <FieldLabel>
+                    {t("page.mod.dialog.add-game.nte_custom_mod_folder", "Custom mod folder")}
+                  </FieldLabel>
+                  <div className="flex gap-2">
+                    <Input
+                      value={field.state.value}
+                      readOnly
+                      hideFocusRing
+                      onBlur={field.handleBlur}
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      onClick={handlePickCustomModFolder}
+                    >
+                      <FolderOpen className="size-4" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      disabled={!field.state.value}
+                      onClick={() => field.handleChange("")}
+                    >
+                      <XIcon className="size-4" />
+                    </Button>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {t(
+                      "page.mod.dialog.add-game.nte_custom_mod_folder_description",
+                      "Optional. The game Mods folder will be linked to this folder.",
+                    )}
+                  </p>
+                </Field>
+              )}
+            />
+          )}
 
           <div className="space-y-2">
             <FieldLabel>{t("page.mod.dialog.edit-game.order_label")}</FieldLabel>

--- a/src/renderer/src/components/mod/game-preset-selector.tsx
+++ b/src/renderer/src/components/mod/game-preset-selector.tsx
@@ -42,6 +42,7 @@ interface GamePresetSelectorProps {
       importer: string | null;
       linkedModFolderPath: string | null;
       gameInstallPath: string | null;
+      gameExecutablePath: string | null;
     },
   ) => void;
   onReorderGames: (games: string[]) => void;

--- a/src/renderer/src/components/mod/game-preset-selector.tsx
+++ b/src/renderer/src/components/mod/game-preset-selector.tsx
@@ -10,6 +10,7 @@ import {
 } from "@renderer/components/ui/select";
 import { useEnabledImporters, usePresets } from "@renderer/hooks/use-mod-data";
 import { useModStore } from "@renderer/store/mod";
+import { isNteImporter } from "@shared/mod";
 import type { GameConfig } from "@shared/types";
 import { useLocation } from "@tanstack/react-router";
 import { PencilIcon, PlayIcon } from "lucide-react";
@@ -24,8 +25,20 @@ interface GamePresetSelectorProps {
   games: GameConfig[];
   onDeleteGameClick: (game: string) => void;
   onPickFolder: () => Promise<string | null>;
-  onAddGame: (name: string, path: string, importer: string | null) => void;
-  onUpdateGame: (game: string, updates: { modFolderPath: string; importer: string | null }) => void;
+  onAddGame: (
+    name: string,
+    path: string,
+    importer: string | null,
+    linkedModFolderPath?: string | null,
+  ) => void;
+  onUpdateGame: (
+    game: string,
+    updates: {
+      modFolderPath: string;
+      importer: string | null;
+      linkedModFolderPath: string | null;
+    },
+  ) => void;
   onReorderGames: (games: string[]) => void;
 }
 
@@ -75,7 +88,7 @@ export const GamePresetSelector = memo(function GamePresetSelector({
     <div className="flex flex-col items-center justify-center w-full p-2 border-t space-y-3">
       {location.pathname.startsWith("/mod") && (
         <div className="flex w-full space-x-1">
-          {selectedImporter && (
+          {selectedImporter && !isNteImporter(selectedImporter) && (
             <Button
               variant="outline"
               size="icon"

--- a/src/renderer/src/components/mod/game-preset-selector.tsx
+++ b/src/renderer/src/components/mod/game-preset-selector.tsx
@@ -12,7 +12,8 @@ import { useEnabledImporters, usePresets } from "@renderer/hooks/use-mod-data";
 import { useModStore } from "@renderer/store/mod";
 import { isNteImporter } from "@shared/mod";
 import type { GameConfig } from "@shared/types";
-import { useLocation } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { useLocation, useNavigate } from "@tanstack/react-router";
 import { PencilIcon, PlayIcon } from "lucide-react";
 import { memo, useEffect } from "react";
 import { useTranslation } from "react-i18next";
@@ -20,6 +21,7 @@ import { toast } from "sonner";
 import { AddGameDialog } from "./add-game-dialog";
 import { CreatePresetDialog } from "./create-preset-dialog";
 import { EditGameDialog, openEditGameDialog } from "./edit-game-dialog";
+import { NteLaunchDialog } from "./nte-launch-dialog";
 
 interface GamePresetSelectorProps {
   games: GameConfig[];
@@ -30,6 +32,8 @@ interface GamePresetSelectorProps {
     path: string,
     importer: string | null,
     linkedModFolderPath?: string | null,
+    gameInstallPath?: string | null,
+    gameExecutablePath?: string | null,
   ) => void;
   onUpdateGame: (
     game: string,
@@ -37,6 +41,7 @@ interface GamePresetSelectorProps {
       modFolderPath: string;
       importer: string | null;
       linkedModFolderPath: string | null;
+      gameInstallPath: string | null;
     },
   ) => void;
   onReorderGames: (games: string[]) => void;
@@ -52,6 +57,7 @@ export const GamePresetSelector = memo(function GamePresetSelector({
 }: GamePresetSelectorProps) {
   const { t } = useTranslation();
   const location = useLocation();
+  const navi = useNavigate();
   const selectedGame = useModStore((s) => s.selectedGame);
   const setSelectedGame = useModStore((s) => s.setSelectedGame);
   const selectedPreset = useModStore((s) => s.selectedPreset);
@@ -60,9 +66,14 @@ export const GamePresetSelector = memo(function GamePresetSelector({
   const isSelectedPresetDialogOpen = useModStore((s) => s.isSelectedPresetDialogOpen);
   const setEditingGame = useModStore((s) => s.setEditingGame);
   const setIsEditGameDialogOpen = useModStore((s) => s.setIsEditGameDialogOpen);
+  const setIsNteLaunchDialogOpen = useModStore((s) => s.setIsNteLaunchDialogOpen);
 
   const { data: presets = [] } = usePresets(selectedGame);
   const { data: enabledImporters = [] } = useEnabledImporters();
+  const { data: xxmiData } = useQuery({
+    queryKey: ["xxmi:getXXMIData"],
+    queryFn: () => window.api.invoke("xxmi:getXXMIData"),
+  });
   const selectedGameConfig = games.find((game) => game.game === selectedGame);
   const selectedImporter = selectedGameConfig?.importer ?? null;
 
@@ -84,20 +95,49 @@ export const GamePresetSelector = memo(function GamePresetSelector({
     });
   };
 
+  const handlePlayClick = async () => {
+    if (isNteImporter(selectedImporter)) {
+      if (selectedGameConfig?.gameExecutablePath) {
+        await window.api.invoke("mod:startNteGame", selectedGame).catch((error) => {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+
+          if (errorMessage.includes("NTE_EXECUTABLE_PATH_NOT_FOUND")) {
+            toast.error(t("page.mod.hooks.use-mod-mutations.start-nte-game.not-found"));
+            setIsNteLaunchDialogOpen(true);
+            return;
+          }
+
+          toast.error(errorMessage || t("page.mod.hooks.use-mod-mutations.start-nte-game.failed"));
+        });
+        return;
+      }
+
+      setIsNteLaunchDialogOpen(true);
+      return;
+    }
+
+    if (!xxmiData?.xxmiPath) {
+      toast.info(t("page.mod.dialog.add-game.xxmi_path_required"));
+      void navi({ to: "/setting/xxmi" });
+      return;
+    }
+
+    if (!selectedImporter) {
+      toast.warning(t("page.mod.play.no_importer"));
+      return;
+    }
+
+    await window.api.invoke("xxmi:startGame", selectedImporter).catch((err) => {
+      toast.error(err.toString());
+    });
+  };
+
   return (
     <div className="flex flex-col items-center justify-center w-full p-2 border-t space-y-3">
       {location.pathname.startsWith("/mod") && (
         <div className="flex w-full space-x-1">
-          {selectedImporter && !isNteImporter(selectedImporter) && (
-            <Button
-              variant="outline"
-              size="icon"
-              onClickPromise={() =>
-                window.api.invoke("xxmi:startGame", selectedImporter).catch((err) => {
-                  toast.error(err.toString());
-                })
-              }
-            >
+          {games.length > 0 && (
+            <Button variant="outline" size="icon" onClickPromise={handlePlayClick}>
               <PlayIcon className="size-4" />
             </Button>
           )}
@@ -187,6 +227,8 @@ export const GamePresetSelector = memo(function GamePresetSelector({
         onDeleteGameClick={onDeleteGameClick}
         onReorderGames={onReorderGames}
       />
+
+      <NteLaunchDialog />
     </div>
   );
 });

--- a/src/renderer/src/components/mod/mod-card.tsx
+++ b/src/renderer/src/components/mod/mod-card.tsx
@@ -91,7 +91,7 @@ export const ModCard = memo(function ModCard({
               onPaste={() => actions.openPastePreview(mod)}
             />
 
-            {mod.inis.length > 0 && (
+            {!actions.isNteGame && mod.inis.length > 0 && (
               <>
                 <div className="relative flex items-stretch">
                   <Separator orientation="vertical" />

--- a/src/renderer/src/components/mod/mod-context-menu.tsx
+++ b/src/renderer/src/components/mod/mod-context-menu.tsx
@@ -81,60 +81,67 @@ export function ModContextMenu({ mod, actions, children }: ModContextMenuProps) 
             <ContextMenuSeparator />
           </>
         )}
-        <ContextMenuGroup>
-          <ContextMenuLabel>Fix</ContextMenuLabel>
-          <ContextMenuSub>
-            <ContextMenuSubTrigger>Preset</ContextMenuSubTrigger>
-            <ContextMenuSubContent>
-              <ContextMenuGroup>
-                {actions.runner.presets.map((preset) => (
-                  <ContextMenuItem
-                    key={preset.id}
-                    onClick={() => void actions.runPreset(mod, preset.id)}
-                  >
-                    {preset.name}
-                  </ContextMenuItem>
-                ))}
-                {actions.runner.presets.length === 0 && (
-                  <ContextMenuItem disabled>No Presets</ContextMenuItem>
-                )}
-              </ContextMenuGroup>
-            </ContextMenuSubContent>
-          </ContextMenuSub>
-          <ContextMenuSub>
-            <ContextMenuSubTrigger>Fix Tool</ContextMenuSubTrigger>
-            <ContextMenuSubContent>
-              <ContextMenuGroup>
-                {actions.runner.fixTools.map((tool) => (
-                  <ContextMenuItem key={tool.id} onClick={() => void actions.runTool(mod, tool.id)}>
-                    {tool.name}
-                  </ContextMenuItem>
-                ))}
-                {actions.runner.fixTools.length === 0 && (
-                  <ContextMenuItem disabled>No Fix Tools</ContextMenuItem>
-                )}
-              </ContextMenuGroup>
-            </ContextMenuSubContent>
-          </ContextMenuSub>
-          {actions.runner.showWuwaFixer && (
+        {!actions.isNteGame && (
+          <>
+            <ContextMenuGroup>
+              <ContextMenuLabel>Fix</ContextMenuLabel>
+              <ContextMenuSub>
+                <ContextMenuSubTrigger>Preset</ContextMenuSubTrigger>
+                <ContextMenuSubContent>
+                  <ContextMenuGroup>
+                    {actions.runner.presets.map((preset) => (
+                      <ContextMenuItem
+                        key={preset.id}
+                        onClick={() => void actions.runPreset(mod, preset.id)}
+                      >
+                        {preset.name}
+                      </ContextMenuItem>
+                    ))}
+                    {actions.runner.presets.length === 0 && (
+                      <ContextMenuItem disabled>No Presets</ContextMenuItem>
+                    )}
+                  </ContextMenuGroup>
+                </ContextMenuSubContent>
+              </ContextMenuSub>
+              <ContextMenuSub>
+                <ContextMenuSubTrigger>Fix Tool</ContextMenuSubTrigger>
+                <ContextMenuSubContent>
+                  <ContextMenuGroup>
+                    {actions.runner.fixTools.map((tool) => (
+                      <ContextMenuItem
+                        key={tool.id}
+                        onClick={() => void actions.runTool(mod, tool.id)}
+                      >
+                        {tool.name}
+                      </ContextMenuItem>
+                    ))}
+                    {actions.runner.fixTools.length === 0 && (
+                      <ContextMenuItem disabled>No Fix Tools</ContextMenuItem>
+                    )}
+                  </ContextMenuGroup>
+                </ContextMenuSubContent>
+              </ContextMenuSub>
+              {actions.runner.showWuwaFixer && (
+                <ContextMenuItem
+                  disabled={actions.runner.isPreparing}
+                  onClick={() => void actions.openWuwaFixer(mod)}
+                >
+                  <img src={wuwaModFixerIcon} className="size-4" />
+                  Wuwa Mod Fixer
+                </ContextMenuItem>
+              )}
+            </ContextMenuGroup>
+            <ContextMenuSeparator />
             <ContextMenuItem
-              disabled={actions.runner.isPreparing}
-              onClick={() => void actions.openWuwaFixer(mod)}
+              onClick={() => {
+                void window.api.invoke("util:openCmd", mod.path);
+              }}
             >
-              <img src={wuwaModFixerIcon} className="size-4" />
-              Wuwa Mod Fixer
+              <TerminalSquareIcon className="mr-2 size-4" />
+              {t("page.mod.context-menu.open-cmd")}
             </ContextMenuItem>
-          )}
-        </ContextMenuGroup>
-        <ContextMenuSeparator />
-        <ContextMenuItem
-          onClick={() => {
-            void window.api.invoke("util:openCmd", mod.path);
-          }}
-        >
-          <TerminalSquareIcon className="mr-2 size-4" />
-          {t("page.mod.context-menu.open-cmd")}
-        </ContextMenuItem>
+          </>
+        )}
         <ContextMenuItem
           onClick={() => {
             void window.api.invoke("util:openPath", mod.path);
@@ -143,25 +150,31 @@ export function ModContextMenu({ mod, actions, children }: ModContextMenuProps) 
           <FolderIcon className="mr-2 size-4" />
           {t("page.mod.context-menu.open-folder")}
         </ContextMenuItem>
-        <ContextMenuItem onClick={() => void actions.markAsManualSubGroup(mod)}>
-          <FolderTreeIcon className="mr-2 size-4" />
-          {t("page.mod.context-menu.mark-manual-subgroup")}
-        </ContextMenuItem>
-        <ContextMenuItem
-          disabled={isConvertingModel}
-          onClick={() => void actions.openModelViewer(mod)}
-        >
-          {isConvertingModel ? (
-            <Loader2Icon className="mr-2 size-4 animate-spin" />
-          ) : (
-            <BoxIcon className="mr-2 size-4" />
-          )}
-          {t("page.tools.model_viewer.title")}
-        </ContextMenuItem>
-        <ContextMenuItem onClick={() => actions.openTextureResizeDialog(mod)}>
-          <ImageIcon className="mr-2 size-4" />
-          {t("page.tools.texture_resizer.title")}
-        </ContextMenuItem>
+        {!actions.isNteGame && (
+          <ContextMenuItem onClick={() => void actions.markAsManualSubGroup(mod)}>
+            <FolderTreeIcon className="mr-2 size-4" />
+            {t("page.mod.context-menu.mark-manual-subgroup")}
+          </ContextMenuItem>
+        )}
+        {!actions.isNteGame && (
+          <>
+            <ContextMenuItem
+              disabled={isConvertingModel}
+              onClick={() => void actions.openModelViewer(mod)}
+            >
+              {isConvertingModel ? (
+                <Loader2Icon className="mr-2 size-4 animate-spin" />
+              ) : (
+                <BoxIcon className="mr-2 size-4" />
+              )}
+              {t("page.tools.model_viewer.title")}
+            </ContextMenuItem>
+            <ContextMenuItem onClick={() => actions.openTextureResizeDialog(mod)}>
+              <ImageIcon className="mr-2 size-4" />
+              {t("page.tools.texture_resizer.title")}
+            </ContextMenuItem>
+          </>
+        )}
         <ContextMenuItem onClick={() => actions.openRenameDialog(mod)}>
           <PencilIcon className="mr-2 size-4" />
           {t("page.mod.context-menu.rename")}

--- a/src/renderer/src/components/mod/nte-launch-dialog.tsx
+++ b/src/renderer/src/components/mod/nte-launch-dialog.tsx
@@ -1,0 +1,111 @@
+import { Button } from "@renderer/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@renderer/components/ui/dialog";
+import { Field, FieldLabel } from "@renderer/components/ui/field";
+import { Input } from "@renderer/components/ui/input";
+import { useGameMutations } from "@renderer/hooks/use-mod-mutations";
+import { useModStore } from "@renderer/store/mod";
+import { FolderOpen } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+export function NteLaunchDialog() {
+  const { t } = useTranslation();
+  const selectedGame = useModStore((s) => s.selectedGame);
+  const isOpen = useModStore((s) => s.isNteLaunchDialogOpen);
+  const setIsOpen = useModStore((s) => s.setIsNteLaunchDialogOpen);
+  const [executablePath, setExecutablePath] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { setGameExecutablePathMutation } = useGameMutations();
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    if (!open) {
+      setExecutablePath("");
+      setIsSubmitting(false);
+    }
+  };
+
+  const handlePickExecutable = async () => {
+    const path = await window.api.invoke("mod:pickExecutable");
+    if (path) {
+      setExecutablePath(path);
+    }
+  };
+
+  const handleLaunch = async () => {
+    const path = executablePath.trim();
+    if (!path || !selectedGame) {
+      toast.warning(t("page.mod.dialog.nte-launch.path_required"));
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await setGameExecutablePathMutation.mutateAsync({
+        game: selectedGame,
+        executablePath: path,
+      });
+      await window.api.invoke("mod:startNteGame", selectedGame);
+      handleOpenChange(false);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
+      if (errorMessage.includes("NTE_EXECUTABLE_PATH_NOT_FOUND")) {
+        toast.error(t("page.mod.hooks.use-mod-mutations.start-nte-game.not-found"));
+        return;
+      }
+
+      if (errorMessage.includes("NTE_EXECUTABLE_PATH_NOT_SET")) {
+        toast.error(t("page.mod.hooks.use-mod-mutations.start-nte-game.not-set"));
+        return;
+      }
+
+      toast.error(errorMessage || t("page.mod.hooks.use-mod-mutations.start-nte-game.failed"));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="w-100">
+        <DialogHeader>
+          <DialogTitle>{t("page.mod.dialog.nte-launch.title")}</DialogTitle>
+        </DialogHeader>
+
+        <Field>
+          <FieldLabel>{t("page.mod.dialog.nte-launch.path_label")}</FieldLabel>
+          <div className="flex gap-2">
+            <Input value={executablePath} readOnly hideFocusRing />
+            <Button type="button" variant="outline" size="icon" onClick={handlePickExecutable}>
+              <FolderOpen className="size-4" />
+            </Button>
+          </div>
+        </Field>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="outline" disabled={isSubmitting}>
+              {t("g.cancel")}
+            </Button>
+          </DialogClose>
+          <Button
+            type="button"
+            disabled={!executablePath.trim() || isSubmitting}
+            onClick={() => void handleLaunch()}
+          >
+            {t("page.mod.dialog.nte-launch.launch")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/renderer/src/components/mod/sidebar.tsx
+++ b/src/renderer/src/components/mod/sidebar.tsx
@@ -128,6 +128,7 @@ export default function ModSidebar({
         importer: string | null;
         linkedModFolderPath: string | null;
         gameInstallPath: string | null;
+        gameExecutablePath: string | null;
       },
     ) => {
       updateGame({ game, updates });

--- a/src/renderer/src/components/mod/sidebar.tsx
+++ b/src/renderer/src/components/mod/sidebar.tsx
@@ -107,14 +107,21 @@ export default function ModSidebar({
   );
 
   const handleAddGame = useCallback(
-    (name: string, path: string, importer: string | null) => {
-      addGame({ name, path, importer });
+    (name: string, path: string, importer: string | null, linkedModFolderPath?: string | null) => {
+      addGame({ name, path, importer, linkedModFolderPath });
     },
     [addGame],
   );
 
   const handleUpdateGame = useCallback(
-    (game: string, updates: { modFolderPath: string; importer: string | null }) => {
+    (
+      game: string,
+      updates: {
+        modFolderPath: string;
+        importer: string | null;
+        linkedModFolderPath: string | null;
+      },
+    ) => {
       updateGame({ game, updates });
     },
     [updateGame],

--- a/src/renderer/src/components/mod/sidebar.tsx
+++ b/src/renderer/src/components/mod/sidebar.tsx
@@ -107,8 +107,15 @@ export default function ModSidebar({
   );
 
   const handleAddGame = useCallback(
-    (name: string, path: string, importer: string | null, linkedModFolderPath?: string | null) => {
-      addGame({ name, path, importer, linkedModFolderPath });
+    (
+      name: string,
+      path: string,
+      importer: string | null,
+      linkedModFolderPath?: string | null,
+      gameInstallPath?: string | null,
+      gameExecutablePath?: string | null,
+    ) => {
+      addGame({ name, path, importer, linkedModFolderPath, gameInstallPath, gameExecutablePath });
     },
     [addGame],
   );
@@ -120,6 +127,7 @@ export default function ModSidebar({
         modFolderPath: string;
         importer: string | null;
         linkedModFolderPath: string | null;
+        gameInstallPath: string | null;
       },
     ) => {
       updateGame({ game, updates });

--- a/src/renderer/src/components/path-selector-dialog.tsx
+++ b/src/renderer/src/components/path-selector-dialog.tsx
@@ -19,6 +19,7 @@ interface PathSelectorDialogProps {
   selectionId: string;
   suggestedName?: string;
   downloadTargetName?: string;
+  downloadImporterKey?: string;
 }
 
 export function PathSelectorDialog({
@@ -27,6 +28,7 @@ export function PathSelectorDialog({
   selectionId,
   suggestedName,
   downloadTargetName,
+  downloadImporterKey,
 }: PathSelectorDialogProps) {
   const { t } = useTranslation();
   const navi = useNavigate();
@@ -64,7 +66,12 @@ export function PathSelectorDialog({
 
   const handleModManagerSelect = () => {
     // Navigate to mod page with download mode set
-    setDownloadMode({ downloadId: selectionId, suggestedName, downloadTargetName });
+    setDownloadMode({
+      downloadId: selectionId,
+      suggestedName,
+      downloadTargetName,
+      downloadImporterKey,
+    });
     void navi({ to: "/mod" });
     closeWithoutCancel();
   };

--- a/src/renderer/src/components/sidebar.tsx
+++ b/src/renderer/src/components/sidebar.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from "@renderer/hooks/use-auth";
 import { cn } from "@renderer/lib/utils";
 import { viewStore } from "@renderer/store/drive";
+import { gameBananaStore } from "@renderer/store/gamebanana";
 import { useGlobalStore } from "@renderer/store/global";
 import { getAggregateTransferProgress } from "@shared/transfer-progress";
 import { useLocation, useNavigate } from "@tanstack/react-router";
@@ -146,6 +147,9 @@ export function Sidebar({ className }: { className?: string }) {
                 aria-current={isGameBananaPage ? "page" : undefined}
                 onPointerDown={handlePointerDown}
                 onClick={() => {
+                  if (isModPage) {
+                    gameBananaStore.getState().requestModGameSync();
+                  }
                   navi({ to: "/gamebanana" });
                 }}
               >
@@ -322,7 +326,10 @@ export function Sidebar({ className }: { className?: string }) {
                 size="icon-lg"
                 onPointerDown={handlePointerDown}
                 onClick={() => {
-                  void window.api.invoke("util:openExternal", "https://github.com/myparsleycat/nahida-desktop/issues");
+                  void window.api.invoke(
+                    "util:openExternal",
+                    "https://github.com/myparsleycat/nahida-desktop/issues",
+                  );
                 }}
               >
                 <BugIcon className={cn(iconSize)} />

--- a/src/renderer/src/hooks/use-global-events.ts
+++ b/src/renderer/src/hooks/use-global-events.ts
@@ -9,6 +9,7 @@ export function useGlobalEvents(
         selectionId: string;
         suggestedName?: string;
         downloadTargetName?: string;
+        downloadImporterKey?: string;
     }) => void,
 ) {
     const navi = useNavigate();

--- a/src/renderer/src/hooks/use-mod-actions.tsx
+++ b/src/renderer/src/hooks/use-mod-actions.tsx
@@ -23,10 +23,12 @@ import {
 } from "@renderer/components/ui/dialog";
 import { Input } from "@renderer/components/ui/input";
 import { useConfirmTrash } from "@renderer/hooks/use-confirm-trash";
+import { useGames } from "@renderer/hooks/use-mod-data";
 import { useModFixRunner } from "@renderer/hooks/use-mod-fix-runner";
 import { useModMutations } from "@renderer/hooks/use-mod-mutations";
 import { useModStore } from "@renderer/store/mod";
 import type { ModInfo } from "@renderer/types/mod";
+import { isNteImporter } from "@shared/mod";
 import type { QueryClient } from "@tanstack/react-query";
 import { useRouteContext } from "@tanstack/react-router";
 import { useEffect, useRef, useState, type FormEvent, type ReactNode } from "react";
@@ -71,6 +73,7 @@ function scheduleModelViewerCleanup(source: ModelViewerDialogSource | null) {
 export interface ModActionApi {
   overlays: ReactNode;
   runner: ReturnType<typeof useModFixRunner>;
+  isNteGame: boolean;
   convertingModelPath: string | null;
   openDeleteMod: (mod: ModInfo) => void;
   openDeletePreview: (mod: ModInfo) => void;
@@ -95,6 +98,8 @@ export function useModActions(selectedGroupPath?: string): ModActionApi {
   const { confirmTrash, confirmTrashDialog } = useConfirmTrash();
   const runner = useModFixRunner();
   const selectedGame = useModStore((s) => s.selectedGame);
+  const { data: games = [] } = useGames();
+  const isNteGame = isNteImporter(games.find((game) => game.game === selectedGame)?.importer);
 
   const [textureResizeMod, setTextureResizeMod] = useState<ModInfo | null>(null);
   const [renameDialogState, setRenameDialogState] = useState<{
@@ -340,6 +345,7 @@ export function useModActions(selectedGroupPath?: string): ModActionApi {
   return {
     overlays,
     runner,
+    isNteGame,
     convertingModelPath,
     openDeleteMod,
     openDeletePreview,

--- a/src/renderer/src/hooks/use-mod-events.ts
+++ b/src/renderer/src/hooks/use-mod-events.ts
@@ -1,6 +1,7 @@
 import { modStore } from "@renderer/store/mod";
 import type { QueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
 export function useModRefreshOnFocus(selectedGame: string | null, queryClient: QueryClient) {
@@ -23,6 +24,8 @@ export function useDownloadCompletionHandler(
     selectedGroupPath: string | undefined,
     queryClient: QueryClient,
 ) {
+    const { t } = useTranslation();
+
     useEffect(() => {
         const unsubscribe = window.api.on("download:completed", (data) => {
             const invalidations: Promise<unknown>[] = [];
@@ -47,14 +50,14 @@ export function useDownloadCompletionHandler(
             void Promise.all(invalidations);
 
             if (!data.disableToast) {
-                toast.success(`"${data.name}" 다운로드가 완료되었습니다.`);
+                toast.success(t("page.mod.download_completed", { name: data.name }));
             }
         });
 
         return () => {
             unsubscribe();
         };
-    }, [selectedGame, selectedGroupPath, queryClient]);
+    }, [selectedGame, selectedGroupPath, queryClient, t]);
 }
 
 export function useModWatcherEvents(

--- a/src/renderer/src/hooks/use-mod-mutations.ts
+++ b/src/renderer/src/hooks/use-mod-mutations.ts
@@ -156,6 +156,7 @@ export function useGameMutations() {
                 importer: string | null;
                 linkedModFolderPath: string | null;
                 gameInstallPath: string | null;
+                gameExecutablePath: string | null;
             };
         }) => window.api.invoke("mod:updateGame", game, updates),
         onSuccess: async (_, variables) => {

--- a/src/renderer/src/hooks/use-mod-mutations.ts
+++ b/src/renderer/src/hooks/use-mod-mutations.ts
@@ -40,11 +40,13 @@ export function useGameMutations() {
             name,
             path,
             importer,
+            linkedModFolderPath,
         }: {
             name: string;
             path: string;
             importer: string | null;
-        }) => window.api.invoke("mod:addGame", name, path, importer),
+            linkedModFolderPath?: string | null;
+        }) => window.api.invoke("mod:addGame", name, path, importer, linkedModFolderPath ?? null),
         onSuccess: () => {
             void queryClient.invalidateQueries({ queryKey: ["games"] });
             setIsAddGameDialogOpen(false);
@@ -71,6 +73,15 @@ export function useGameMutations() {
 
             if (errorMessage.includes("INVALID_PARAMS")) {
                 toast.error(t("page.mod.hooks.use-mod-mutations.add-game-mutation.invalid-params"));
+                return;
+            }
+
+            if (
+                errorMessage.includes("NTE_MODS_LINK_CONFLICT") ||
+                errorMessage.includes("NTE_MODS_LINK_PATH_OCCUPIED") ||
+                errorMessage.includes("NTE_CUSTOM_MOD_FOLDER_INSIDE_LINK_PATH")
+            ) {
+                toast.error(errorMessage);
                 return;
             }
 
@@ -122,7 +133,11 @@ export function useGameMutations() {
             updates,
         }: {
             game: string;
-            updates: { modFolderPath: string; importer: string | null };
+            updates: {
+                modFolderPath: string;
+                importer: string | null;
+                linkedModFolderPath: string | null;
+            };
         }) => window.api.invoke("mod:updateGame", game, updates),
         onSuccess: async (_, variables) => {
             void queryClient.invalidateQueries({ queryKey: ["games"] });
@@ -152,6 +167,15 @@ export function useGameMutations() {
 
             if (errorMessage.includes("INVALID_PARAMS")) {
                 toast.error(t("page.mod.hooks.use-mod-mutations.add-game-mutation.invalid-params"));
+                return;
+            }
+
+            if (
+                errorMessage.includes("NTE_MODS_LINK_CONFLICT") ||
+                errorMessage.includes("NTE_MODS_LINK_PATH_OCCUPIED") ||
+                errorMessage.includes("NTE_CUSTOM_MOD_FOLDER_INSIDE_LINK_PATH")
+            ) {
+                toast.error(errorMessage);
                 return;
             }
 

--- a/src/renderer/src/hooks/use-mod-mutations.ts
+++ b/src/renderer/src/hooks/use-mod-mutations.ts
@@ -41,12 +41,25 @@ export function useGameMutations() {
             path,
             importer,
             linkedModFolderPath,
+            gameInstallPath,
+            gameExecutablePath,
         }: {
             name: string;
             path: string;
             importer: string | null;
             linkedModFolderPath?: string | null;
-        }) => window.api.invoke("mod:addGame", name, path, importer, linkedModFolderPath ?? null),
+            gameInstallPath?: string | null;
+            gameExecutablePath?: string | null;
+        }) =>
+            window.api.invoke(
+                "mod:addGame",
+                name,
+                path,
+                importer,
+                linkedModFolderPath ?? null,
+                gameInstallPath ?? null,
+                gameExecutablePath ?? null,
+            ),
         onSuccess: () => {
             void queryClient.invalidateQueries({ queryKey: ["games"] });
             setIsAddGameDialogOpen(false);
@@ -81,7 +94,12 @@ export function useGameMutations() {
                 errorMessage.includes("NTE_MODS_LINK_PATH_OCCUPIED") ||
                 errorMessage.includes("NTE_CUSTOM_MOD_FOLDER_INSIDE_LINK_PATH")
             ) {
-                toast.error(errorMessage);
+                const nteErrorKey = errorMessage.includes("NTE_MODS_LINK_CONFLICT")
+                    ? "page.mod.hooks.use-mod-mutations.add-game-mutation.nte_mods_link_conflict"
+                    : errorMessage.includes("NTE_MODS_LINK_PATH_OCCUPIED")
+                      ? "page.mod.hooks.use-mod-mutations.add-game-mutation.nte_mods_link_path_occupied"
+                      : "page.mod.hooks.use-mod-mutations.add-game-mutation.nte_custom_mod_folder_inside_link_path";
+                toast.error(t(nteErrorKey));
                 return;
             }
 
@@ -137,6 +155,7 @@ export function useGameMutations() {
                 modFolderPath: string;
                 importer: string | null;
                 linkedModFolderPath: string | null;
+                gameInstallPath: string | null;
             };
         }) => window.api.invoke("mod:updateGame", game, updates),
         onSuccess: async (_, variables) => {
@@ -175,7 +194,12 @@ export function useGameMutations() {
                 errorMessage.includes("NTE_MODS_LINK_PATH_OCCUPIED") ||
                 errorMessage.includes("NTE_CUSTOM_MOD_FOLDER_INSIDE_LINK_PATH")
             ) {
-                toast.error(errorMessage);
+                const nteErrorKey = errorMessage.includes("NTE_MODS_LINK_CONFLICT")
+                    ? "page.mod.hooks.use-mod-mutations.add-game-mutation.nte_mods_link_conflict"
+                    : errorMessage.includes("NTE_MODS_LINK_PATH_OCCUPIED")
+                      ? "page.mod.hooks.use-mod-mutations.add-game-mutation.nte_mods_link_path_occupied"
+                      : "page.mod.hooks.use-mod-mutations.add-game-mutation.nte_custom_mod_folder_inside_link_path";
+                toast.error(t(nteErrorKey));
                 return;
             }
 
@@ -211,7 +235,33 @@ export function useGameMutations() {
         },
     });
 
-    return { addGameMutation, deleteGameMutation, updateGameMutation, reorderGamesMutation };
+    const setGameExecutablePathMutation = useMutation({
+        mutationFn: ({ game, executablePath }: { game: string; executablePath: string }) =>
+            window.api.invoke("mod:setGameExecutablePath", game, executablePath),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: ["games"] });
+        },
+        onError: (error) => {
+            const errorMessage = getMutationErrorMessage(error);
+
+            if (errorMessage.includes("INVALID_EXECUTABLE_PATH")) {
+                toast.error(
+                    t("page.mod.hooks.use-mod-mutations.set-game-executable-path.invalid-path"),
+                );
+                return;
+            }
+
+            toast.error(t("page.mod.hooks.use-mod-mutations.set-game-executable-path.failed"));
+        },
+    });
+
+    return {
+        addGameMutation,
+        deleteGameMutation,
+        updateGameMutation,
+        reorderGamesMutation,
+        setGameExecutablePathMutation,
+    };
 }
 
 export function useModMutations() {

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -189,6 +189,7 @@
         "title": "Add to {{name}}",
         "description": "Compressed files will be automatically extracted"
       },
+      "download_completed": "Downloaded \"{{name}}\".",
       "all_enabled": "Enable all",
       "all_disabled": "Disable all",
       "content-header": {
@@ -241,6 +242,9 @@
           "error": "Failed to add {{fileName}}."
         }
       },
+      "play": {
+        "no_importer": "Set an importer for this game before launching."
+      },
       "dialog": {
         "extract_archive_path": {
           "title": "Choose extraction path",
@@ -255,6 +259,11 @@
           "title": "Add Game",
           "name_input_placeholder": "Game Name (e.g. Genshin)",
           "path_input_placeholder": "Mod folder path",
+          "nte_game_name": "NTE",
+          "nte_install_path": "NTE install folder",
+          "nte_not_found": "NTE game not found.",
+          "nte_custom_mod_folder": "Custom mod folder",
+          "nte_custom_mod_folder_description": "Optional. The game Mods folder will be linked to this folder.",
           "xxmi_path_required": "Set the XXMI path first to load importers.",
           "open_xxmi_settings": "Open Importer settings",
           "#": {
@@ -270,6 +279,12 @@
           "order_label": "Display order",
           "order_value": "{{current}} of {{total}}",
           "order_description": "Use the arrow buttons to change this game's position in the dropdown."
+        },
+        "nte-launch": {
+          "title": "Set launcher path",
+          "path_label": "Launcher path",
+          "path_required": "Please select a launcher path.",
+          "launch": "Save and launch launcher"
         },
         "preset-management": {
           "legacy-badge": "Legacy",
@@ -391,7 +406,10 @@
             "duplicate-game-name": "A game with that name already exists",
             "duplicate-mod-folder-path": "That mod folder path is already in use",
             "invalid-params": "Game name and mod folder path are required",
-            "failed": "Failed to add game"
+            "failed": "Failed to add game",
+            "nte_mods_link_conflict": "Both the game Mods folder and the custom mod folder contain files. Clear one before linking.",
+            "nte_mods_link_path_occupied": "The game Mods folder path is occupied and cannot be linked.",
+            "nte_custom_mod_folder_inside_link_path": "The custom mod folder cannot be inside the game Mods folder path, or vice versa."
           },
           "delete-game-mutation": {
             "success": "Game deleted"
@@ -402,6 +420,15 @@
           "reorder-games-mutation": {
             "success": "Game order saved",
             "failed": "Failed to save game order"
+          },
+          "set-game-executable-path": {
+            "invalid-path": "The selected launcher path is invalid.",
+            "failed": "Failed to save the launcher path."
+          },
+          "start-nte-game": {
+            "not-set": "No launcher path is set for this game.",
+            "not-found": "The saved launcher path no longer exists.",
+            "failed": "Failed to launch the launcher."
           },
           "toggle-mutation": {
             "0": "The {{name}} folder already exists",
@@ -1076,7 +1103,8 @@
       "file_name": "File Name",
       "file_name_placeholder": "Enter file name",
       "download_location": "Download Location",
-      "need_select_character_folder": "Select a character folder on the left"
+      "need_select_character_folder": "Select a character folder on the left",
+      "select_path_failed": "Failed to select path."
     }
   },
   "updater": {

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -169,6 +169,7 @@
         "title": "{{name}}に追加",
         "description": "圧縮ファイルは自動的に解凍されます"
       },
+      "download_completed": "\"{{name}}\" のダウンロードが完了しました。",
       "all_enabled": "すべて有効化",
       "all_disabled": "すべて無効化",
       "content-header": {
@@ -221,6 +222,9 @@
           "error": "{{fileName}} の追加に失敗しました"
         }
       },
+      "play": {
+        "no_importer": "起動する前に、このゲームの Importer を設定してください。"
+      },
       "dialog": {
         "extract_archive_path": {
           "title": "解凍パスを選択",
@@ -235,6 +239,11 @@
           "title": "ゲーム追加",
           "name_input_placeholder": "ゲーム名 (例: 原神)",
           "path_input_placeholder": "MODフォルダーのパス",
+          "nte_game_name": "異環",
+          "nte_install_path": "NTE インストールフォルダー",
+          "nte_not_found": "NTE ゲームが見つかりません。",
+          "nte_custom_mod_folder": "カスタム MOD フォルダー",
+          "nte_custom_mod_folder_description": "任意です。ゲームの Mods フォルダーがこのフォルダーにリンクされます。",
           "xxmi_path_required": "Importer を読み込むには、先に XXMI パスを設定してください。",
           "open_xxmi_settings": "Importer 設定を開く",
           "#": {
@@ -247,6 +256,12 @@
           "path_label": "MODフォルダーのパス",
           "importer_label": "Importer",
           "no_importer": "なし"
+        },
+        "nte-launch": {
+          "title": "ランチャーパスを指定",
+          "path_label": "ランチャーのパス",
+          "path_required": "ランチャーのパスを選択してください。",
+          "launch": "保存してランチャーを起動"
         },
         "preset-management": {
           "description": "このプリセットには {{length}} 個のMODが保存されています。",
@@ -369,13 +384,25 @@
             "duplicate-game-name": "そのゲーム名は既に存在します",
             "duplicate-mod-folder-path": "そのMODフォルダーパスは既に使用されています",
             "invalid-params": "ゲーム名とMODフォルダーパスを入力してください",
-            "failed": "ゲームの追加に失敗しました"
+            "failed": "ゲームの追加に失敗しました",
+            "nte_mods_link_conflict": "ゲームの Mods フォルダーとカスタム MOD フォルダーの両方にファイルがあります。リンクする前にどちらかを空にしてください。",
+            "nte_mods_link_path_occupied": "ゲームの Mods フォルダーパスが使用中のためリンクできません。",
+            "nte_custom_mod_folder_inside_link_path": "カスタム MOD フォルダーはゲームの Mods フォルダーパス内、またはその逆の関係にはできません。"
           },
           "delete-game-mutation": {
             "success": "ゲームを削除しました"
           },
           "update-game-mutation": {
             "success": "ゲーム設定を保存しました"
+          },
+          "set-game-executable-path": {
+            "invalid-path": "選択したランチャーのパスが無効です。",
+            "failed": "ランチャーのパスを保存できませんでした。"
+          },
+          "start-nte-game": {
+            "not-set": "設定されたランチャーのパスがありません。",
+            "not-found": "保存されたランチャーのパスが存在しません。",
+            "failed": "ランチャーの起動に失敗しました。"
           },
           "toggle-mutation": {
             "0": "{{name}} フォルダはすでに存在します",
@@ -1039,7 +1066,8 @@
       "file_name": "ファイル名",
       "file_name_placeholder": "ファイル名を入力してください",
       "download_location": "ダウンロード先",
-      "need_select_character_folder": "左側でキャラクターフォルダーを選択してください"
+      "need_select_character_folder": "左側でキャラクターフォルダーを選択してください",
+      "select_path_failed": "パスの選択に失敗しました。"
     }
   },
   "updater": {

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -168,6 +168,7 @@
         "title": "{{name}}에 추가",
         "description": "압축 파일은 자동으로 압축 해제됩니다"
       },
+      "download_completed": "\"{{name}}\" 다운로드가 완료되었습니다.",
       "all_enabled": "모두 활성화",
       "all_disabled": "모두 비활성화",
       "content-header": {
@@ -220,6 +221,9 @@
           "error": "{{fileName}} 추가 실패"
         }
       },
+      "play": {
+        "no_importer": "게임을 실행하려면 먼저 Importer를 설정해 주세요."
+      },
       "dialog": {
         "extract_archive_path": {
           "title": "압축 해제 경로 선택",
@@ -234,6 +238,11 @@
           "title": "게임 추가",
           "name_input_placeholder": "게임 이름 (예: 원공노)",
           "path_input_placeholder": "모드 폴더 경로",
+          "nte_game_name": "이환",
+          "nte_install_path": "NTE 설치 폴더",
+          "nte_not_found": "NTE 게임을 찾을 수 없습니다.",
+          "nte_custom_mod_folder": "사용자 지정 모드 폴더",
+          "nte_custom_mod_folder_description": "선택 사항입니다. 게임 Mods 폴더가 이 폴더에 연결됩니다.",
           "xxmi_path_required": "Importer를 가져오려면 먼저 XXMI 경로를 설정해야 합니다.",
           "open_xxmi_settings": "Importer 설정 열기",
           "#": {
@@ -249,6 +258,12 @@
           "order_label": "표시 순서",
           "order_value": "{{total}}개 중 {{current}}번째",
           "order_description": "위아래 버튼으로 드롭다운에 표시되는 게임 순서를 변경합니다."
+        },
+        "nte-launch": {
+          "title": "런처 경로 지정",
+          "path_label": "런처 경로",
+          "path_required": "런처 경로를 선택해 주세요.",
+          "launch": "저장 후 런처 실행"
         },
         "preset-management": {
           "description": "이 프리셋에는 {{length}}개의 모드가 저장되어 있습니다.",
@@ -371,7 +386,10 @@
             "duplicate-game-name": "이미 존재하는 게임 이름입니다.",
             "duplicate-mod-folder-path": "이미 사용 중인 모드 폴더 경로입니다.",
             "invalid-params": "게임 이름과 모드 폴더 경로를 입력해주세요.",
-            "failed": "게임 추가에 실패했습니다."
+            "failed": "게임 추가에 실패했습니다.",
+            "nte_mods_link_conflict": "게임 Mods 폴더와 사용자 지정 모드 폴더 모두에 파일이 있습니다. 연결하기 전에 한쪽을 비워주세요.",
+            "nte_mods_link_path_occupied": "게임 Mods 폴더 경로가 사용 중이어서 연결할 수 없습니다.",
+            "nte_custom_mod_folder_inside_link_path": "사용자 지정 모드 폴더는 게임 Mods 폴더 경로 안에 있거나, 그 반대일 수 없습니다."
           },
           "delete-game-mutation": {
             "success": "게임이 삭제되었습니다."
@@ -382,6 +400,15 @@
           "reorder-games-mutation": {
             "success": "게임 순서가 저장되었습니다.",
             "failed": "게임 순서를 저장하지 못했습니다."
+          },
+          "set-game-executable-path": {
+            "invalid-path": "선택한 런처 경로가 유효하지 않습니다.",
+            "failed": "런처 경로를 저장하지 못했습니다."
+          },
+          "start-nte-game": {
+            "not-set": "설정된 런처 경로가 없습니다.",
+            "not-found": "저장된 런처 경로가 더 이상 존재하지 않습니다.",
+            "failed": "런처 실행에 실패했습니다."
           },
           "toggle-mutation": {
             "0": "이미 {{name}} 폴더가 존재합니다",
@@ -1058,7 +1085,8 @@
       "file_name": "파일 이름",
       "file_name_placeholder": "파일 이름을 입력하세요",
       "download_location": "다운로드 위치",
-      "need_select_character_folder": "좌측에서 캐릭터 폴더를 선택하세요"
+      "need_select_character_folder": "좌측에서 캐릭터 폴더를 선택하세요",
+      "select_path_failed": "경로 선택에 실패했습니다."
     }
   },
   "updater": {

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -168,6 +168,7 @@
         "title": "添加到 {{name}}",
         "description": "压缩文件将自动解压"
       },
+      "download_completed": "已下载 \"{{name}}\"。",
       "all_enabled": "全部启用",
       "all_disabled": "全部禁用",
       "content-header": {
@@ -220,6 +221,9 @@
           "error": "{{fileName}} 添加失败"
         }
       },
+      "play": {
+        "no_importer": "启动前请先为此游戏设置 Importer。"
+      },
       "dialog": {
         "extract_archive_path": {
           "title": "选择解压路径",
@@ -234,6 +238,11 @@
           "title": "添加游戏",
           "name_input_placeholder": "游戏名称 (例如：原神)",
           "path_input_placeholder": "模组文件夹路径",
+          "nte_game_name": "异环",
+          "nte_install_path": "NTE 安装文件夹",
+          "nte_not_found": "未找到 NTE 游戏。",
+          "nte_custom_mod_folder": "自定义模组文件夹",
+          "nte_custom_mod_folder_description": "可选。游戏的 Mods 文件夹将链接到此文件夹。",
           "xxmi_path_required": "要加载 Importer，请先设置 XXMI 路径。",
           "open_xxmi_settings": "打开 Importer 设置",
           "#": {
@@ -246,6 +255,12 @@
           "path_label": "模组文件夹路径",
           "importer_label": "Importer",
           "no_importer": "无"
+        },
+        "nte-launch": {
+          "title": "指定启动器路径",
+          "path_label": "启动器路径",
+          "path_required": "请选择启动器路径。",
+          "launch": "保存并启动启动器"
         },
         "preset-management": {
           "description": "此预设包含 {{length}} 个模组。",
@@ -368,13 +383,25 @@
             "duplicate-game-name": "该游戏名称已存在",
             "duplicate-mod-folder-path": "该模组文件夹路径已被使用",
             "invalid-params": "请输入游戏名称和模组文件夹路径",
-            "failed": "添加游戏失败"
+            "failed": "添加游戏失败",
+            "nte_mods_link_conflict": "游戏 Mods 文件夹和自定义模组文件夹都包含文件。链接前请先清空其中一个。",
+            "nte_mods_link_path_occupied": "游戏 Mods 文件夹路径已被占用，无法链接。",
+            "nte_custom_mod_folder_inside_link_path": "自定义模组文件夹不能位于游戏 Mods 文件夹路径内，反之亦然。"
           },
           "delete-game-mutation": {
             "success": "游戏已删除"
           },
           "update-game-mutation": {
             "success": "游戏设置已保存"
+          },
+          "set-game-executable-path": {
+            "invalid-path": "所选启动器路径无效。",
+            "failed": "保存启动器路径失败。"
+          },
+          "start-nte-game": {
+            "not-set": "尚未设置启动器路径。",
+            "not-found": "保存的启动器路径已不存在。",
+            "failed": "启动启动器失败。"
           },
           "toggle-mutation": {
             "0": "{{name}} 文件夹已存在",
@@ -1038,7 +1065,8 @@
       "file_name": "文件名",
       "file_name_placeholder": "输入文件名",
       "download_location": "下载位置",
-      "need_select_character_folder": "请在左侧选择角色文件夹"
+      "need_select_character_folder": "请在左侧选择角色文件夹",
+      "select_path_failed": "选择路径失败。"
     }
   },
   "updater": {

--- a/src/renderer/src/routes/__root.tsx
+++ b/src/renderer/src/routes/__root.tsx
@@ -94,10 +94,16 @@ function RootComponent() {
     selectionId: string;
     suggestedName?: string;
     downloadTargetName?: string;
+    downloadImporterKey?: string;
   } | null>(null);
 
   const handlePathSelectorModeSelect = useCallback(
-    (data: { selectionId: string; suggestedName?: string; downloadTargetName?: string }) => {
+    (data: {
+      selectionId: string;
+      suggestedName?: string;
+      downloadTargetName?: string;
+      downloadImporterKey?: string;
+    }) => {
       setPathSelectorData(data);
     },
     [],
@@ -124,6 +130,7 @@ function RootComponent() {
           selectionId={pathSelectorData.selectionId}
           suggestedName={pathSelectorData.suggestedName}
           downloadTargetName={pathSelectorData.downloadTargetName}
+          downloadImporterKey={pathSelectorData.downloadImporterKey}
         />
       )}
 

--- a/src/renderer/src/routes/gamebanana/index.tsx
+++ b/src/renderer/src/routes/gamebanana/index.tsx
@@ -17,8 +17,11 @@ import {
   useGameBananaModCategoryOverview,
   useGameBananaModOverview,
 } from "@renderer/hooks/use-gamebanana-data";
+import { useGames } from "@renderer/hooks/use-mod-data";
 import { cn } from "@renderer/lib/utils";
-import { useGameBananaStore } from "@renderer/store/gamebanana";
+import { gameBananaStore, useGameBananaStore } from "@renderer/store/gamebanana";
+import { modStore } from "@renderer/store/mod";
+import { getGameBananaKeyForImporter } from "@shared/mod";
 import { createFileRoute } from "@tanstack/react-router";
 import { Loader2Icon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -82,6 +85,7 @@ function RouteComponent() {
     isLoading: isGamesLoading,
     error: gamesError,
   } = useGameBananaGames(isAuthReady);
+  const { data: modGames = [] } = useGames();
   const selectedGameKey = useGameBananaStore((state) => state.selectedGame);
   const selectedCategoryId = useGameBananaStore((state) => state.selectedCategoryId);
   const categoryBreadcrumbs = useGameBananaStore((state) => state.categoryBreadcrumbs);
@@ -165,6 +169,20 @@ function RouteComponent() {
       setSelectedGame(games[0].key);
     }
   }, [games, selectedGameKey, setInitialGame, setSelectedGame]);
+
+  useEffect(() => {
+    if (!games.length || !modGames.length) return;
+    if (!gameBananaStore.getState().consumeModGameSync()) return;
+
+    const modSelectedGame = modStore.getState().selectedGame;
+    if (!modSelectedGame) return;
+
+    const modGameConfig = modGames.find((game) => game.game === modSelectedGame);
+    const gameBananaKey = getGameBananaKeyForImporter(modGameConfig?.importer);
+    if (!gameBananaKey || !games.some((game) => game.key === gameBananaKey)) return;
+
+    setSelectedGame(gameBananaKey as GameBananaGameKey);
+  }, [games, modGames, setSelectedGame]);
 
   const rootCategories = gameOverviewQuery.data?.profile._aModRootCategories ?? [];
   const categoryChildren = categoryOverviewQuery.data?.categories ?? [];

--- a/src/renderer/src/routes/gamebanana/index.tsx
+++ b/src/renderer/src/routes/gamebanana/index.tsx
@@ -85,7 +85,7 @@ function RouteComponent() {
     isLoading: isGamesLoading,
     error: gamesError,
   } = useGameBananaGames(isAuthReady);
-  const { data: modGames = [] } = useGames();
+  const { data: modGames = [], isLoading: isModGamesLoading } = useGames();
   const selectedGameKey = useGameBananaStore((state) => state.selectedGame);
   const selectedCategoryId = useGameBananaStore((state) => state.selectedCategoryId);
   const categoryBreadcrumbs = useGameBananaStore((state) => state.categoryBreadcrumbs);
@@ -171,8 +171,9 @@ function RouteComponent() {
   }, [games, selectedGameKey, setInitialGame, setSelectedGame]);
 
   useEffect(() => {
-    if (!games.length || !modGames.length) return;
+    if (!games.length || isModGamesLoading) return;
     if (!gameBananaStore.getState().consumeModGameSync()) return;
+    if (!modGames.length) return;
 
     const modSelectedGame = modStore.getState().selectedGame;
     if (!modSelectedGame) return;
@@ -182,7 +183,7 @@ function RouteComponent() {
     if (!gameBananaKey || !games.some((game) => game.key === gameBananaKey)) return;
 
     setSelectedGame(gameBananaKey as GameBananaGameKey);
-  }, [games, modGames, setSelectedGame]);
+  }, [games, modGames, isModGamesLoading, setSelectedGame]);
 
   const rootCategories = gameOverviewQuery.data?.profile._aModRootCategories ?? [];
   const categoryChildren = categoryOverviewQuery.data?.categories ?? [];

--- a/src/renderer/src/routes/mod/index.tsx
+++ b/src/renderer/src/routes/mod/index.tsx
@@ -179,6 +179,8 @@ function ModRouteContent() {
         ? (findGameByImporter(games, currentDownloadMode.downloadImporterKey)?.game ?? null)
         : null;
 
+      if (currentDownloadMode.downloadImporterKey && !gameByImporter) return;
+
       const primary = currentDownloadMode.downloadTargetName;
       const fallback = currentDownloadMode.suggestedName;
 

--- a/src/renderer/src/routes/mod/index.tsx
+++ b/src/renderer/src/routes/mod/index.tsx
@@ -28,7 +28,7 @@ import {
 import { useModFixRunner } from "@renderer/hooks/use-mod-fix-runner";
 import { useTitlebar } from "@renderer/hooks/use-titlebar";
 import { modStore, useModStore } from "@renderer/store/mod";
-import type { ResolvedArchiveExtractPathMode } from "@shared/mod";
+import { findGameByImporter, type ResolvedArchiveExtractPathMode } from "@shared/mod";
 import type { FolderGroup } from "@shared/types";
 import { createFileRoute } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
@@ -157,31 +157,64 @@ function ModRouteContent() {
   }, [games, selectedGame, setSelectedGame]);
 
   useEffect(() => {
-    if (!downloadMode?.suggestedName && !downloadMode?.downloadTargetName) return;
+    if (
+      !downloadMode?.suggestedName &&
+      !downloadMode?.downloadTargetName &&
+      !downloadMode?.downloadImporterKey
+    ) {
+      return;
+    }
     if (resolvedDownloadIdsRef.current.has(downloadMode.downloadId)) return;
+    if (downloadMode.downloadImporterKey && games.length === 0) return;
 
-    resolvedDownloadIdsRef.current.add(downloadMode.downloadId);
+    const downloadId = downloadMode.downloadId;
 
     const resolveTarget = async () => {
-      const primary = downloadMode.downloadTargetName;
-      const fallback = downloadMode.suggestedName;
+      if (modStore.getState().downloadMode?.downloadId !== downloadId) return;
 
-      let result = primary ? await window.api.invoke("mod:resolveDownloadTarget", primary) : null;
+      const currentDownloadMode = modStore.getState().downloadMode;
+      if (!currentDownloadMode) return;
+
+      const gameByImporter = currentDownloadMode.downloadImporterKey
+        ? (findGameByImporter(games, currentDownloadMode.downloadImporterKey)?.game ?? null)
+        : null;
+
+      const primary = currentDownloadMode.downloadTargetName;
+      const fallback = currentDownloadMode.suggestedName;
+
+      let result = primary
+        ? await window.api.invoke("mod:resolveDownloadTarget", primary, gameByImporter ?? undefined)
+        : null;
 
       if (!result && fallback) {
-        result = await window.api.invoke("mod:resolveDownloadTarget", fallback);
+        result = await window.api.invoke(
+          "mod:resolveDownloadTarget",
+          fallback,
+          gameByImporter ?? undefined,
+        );
       }
 
-      if (!result) return;
-      if (modStore.getState().downloadMode?.downloadId !== downloadMode.downloadId) return;
+      if (modStore.getState().downloadMode?.downloadId !== downloadId) return;
 
-      setSelectedGame(result.game);
-      void window.api.invoke("mod:setLastGame", result.game);
-      setPendingDownloadTarget({
-        downloadId: downloadMode.downloadId,
-        game: result.game,
-        group: result.group,
-      });
+      if (result) {
+        const targetGame = gameByImporter ?? result.game;
+        setSelectedGame(targetGame);
+        void window.api.invoke("mod:setLastGame", targetGame);
+        setPendingDownloadTarget({
+          downloadId,
+          game: targetGame,
+          group: result.group,
+        });
+        resolvedDownloadIdsRef.current.add(downloadId);
+        return;
+      }
+
+      if (gameByImporter) {
+        setSelectedGame(gameByImporter);
+        void window.api.invoke("mod:setLastGame", gameByImporter);
+      }
+
+      resolvedDownloadIdsRef.current.add(downloadId);
     };
 
     void resolveTarget().catch((error) => {
@@ -191,6 +224,8 @@ function ModRouteContent() {
     downloadMode?.downloadId,
     downloadMode?.suggestedName,
     downloadMode?.downloadTargetName,
+    downloadMode?.downloadImporterKey,
+    games,
     setSelectedGame,
   ]);
 

--- a/src/renderer/src/store/gamebanana.ts
+++ b/src/renderer/src/store/gamebanana.ts
@@ -16,6 +16,7 @@ interface GameBananaSelectedSubmission {
 
 interface GameBananaState {
     selectedGame: GameBananaGameKey | "";
+    pendingModGameSync: boolean;
     selectedCategoryId?: number;
     categoryBreadcrumbs: GameBananaBreadcrumb[];
     selectedMod?: GameBananaSelectedSubmission;
@@ -24,6 +25,8 @@ interface GameBananaState {
     modSearch: string;
     setSelectedGame: (game: GameBananaGameKey) => void;
     setInitialGame: (game: GameBananaGameKey) => void;
+    requestModGameSync: () => void;
+    consumeModGameSync: () => boolean;
     selectCategory: (categoryId: number, categoryName: string) => void;
     selectMod: (submission: GameBananaSelectedSubmission) => void;
     clearSelectedMod: () => void;
@@ -36,6 +39,7 @@ interface GameBananaState {
 
 export const gameBananaStore = createStore<GameBananaState>((set, get) => ({
     selectedGame: "",
+    pendingModGameSync: false,
     selectedCategoryId: undefined,
     categoryBreadcrumbs: [],
     selectedMod: undefined,
@@ -56,6 +60,14 @@ export const gameBananaStore = createStore<GameBananaState>((set, get) => ({
         if (!get().selectedGame) {
             set({ selectedGame });
         }
+    },
+    requestModGameSync: () => set({ pendingModGameSync: true }),
+    consumeModGameSync: () => {
+        const pendingModGameSync = get().pendingModGameSync;
+        if (pendingModGameSync) {
+            set({ pendingModGameSync: false });
+        }
+        return pendingModGameSync;
     },
     selectCategory: (categoryId, categoryName) =>
         set((state) => {

--- a/src/renderer/src/store/mod.ts
+++ b/src/renderer/src/store/mod.ts
@@ -22,18 +22,22 @@ interface ModState {
     setEditingGame: (game: GameConfig | null) => void;
     isEditGameDialogOpen: boolean;
     setIsEditGameDialogOpen: (open: boolean) => void;
+    isNteLaunchDialogOpen: boolean;
+    setIsNteLaunchDialogOpen: (open: boolean) => void;
     isCustomDownloadDialogOpen: boolean;
     setIsCustomDownloadDialogOpen: (open: boolean) => void;
     downloadMode: {
         downloadId: string;
         suggestedName?: string;
         downloadTargetName?: string;
+        downloadImporterKey?: string;
     } | null;
     setDownloadMode: (
         mode: {
             downloadId: string;
             suggestedName?: string;
             downloadTargetName?: string;
+            downloadImporterKey?: string;
         } | null,
     ) => void;
     archiveExtractPrompt: { requestId: string; fileName: string } | null;
@@ -79,6 +83,8 @@ export const modStore = createStore<ModState>((set) => ({
     setEditingGame: (editingGame) => set({ editingGame }),
     isEditGameDialogOpen: false,
     setIsEditGameDialogOpen: (isEditGameDialogOpen) => set({ isEditGameDialogOpen }),
+    isNteLaunchDialogOpen: false,
+    setIsNteLaunchDialogOpen: (isNteLaunchDialogOpen) => set({ isNteLaunchDialogOpen }),
     isCustomDownloadDialogOpen: false,
     setIsCustomDownloadDialogOpen: (isCustomDownloadDialogOpen) =>
         set({ isCustomDownloadDialogOpen }),

--- a/src/renderer/src/types/mod.ts
+++ b/src/renderer/src/types/mod.ts
@@ -30,14 +30,6 @@ export interface ModInfo {
     }[];
 }
 
-export interface GameConfig {
-    game: string;
-    modFolderPath: string;
-    importer: string | null;
-    linkedModFolderPath: string | null;
-    order: number;
-}
-
 export interface FolderGroup {
     name: string;
     path: string;

--- a/src/renderer/src/types/mod.ts
+++ b/src/renderer/src/types/mod.ts
@@ -30,6 +30,14 @@ export interface ModInfo {
     }[];
 }
 
+export interface GameConfig {
+    game: string;
+    modFolderPath: string;
+    importer: string | null;
+    linkedModFolderPath: string | null;
+    order: number;
+}
+
 export interface FolderGroup {
     name: string;
     path: string;

--- a/src/shared/mod.ts
+++ b/src/shared/mod.ts
@@ -23,4 +23,31 @@ export type SidebarLayoutMode = (typeof SIDEBAR_LAYOUT_MODES)[number];
 export const NTE_IMPORTER_KEY = "NTE";
 export const NTE_GAMEBANANA_ID = 23012;
 
+export const GAMEBANANA_ID_TO_IMPORTER = {
+    8552: "GIMI",
+    18366: "SRMI",
+    10349: "HIMI",
+    19567: "ZZMI",
+    20357: "WWMI",
+    21842: "EFMI",
+    [NTE_GAMEBANANA_ID]: NTE_IMPORTER_KEY,
+} as const;
+
 export const isNteImporter = (importer: string | null | undefined) => importer === NTE_IMPORTER_KEY;
+
+export function getImporterForGameBananaId(gameId: number): string | null {
+    return GAMEBANANA_ID_TO_IMPORTER[gameId as keyof typeof GAMEBANANA_ID_TO_IMPORTER] ?? null;
+}
+
+export function findGameByImporter<T extends { game: string; importer: string | null }>(
+    games: T[],
+    importerKey: string,
+): T | null {
+    return (
+        games.find((game) =>
+            importerKey === NTE_IMPORTER_KEY
+                ? isNteImporter(game.importer)
+                : game.importer === importerKey,
+        ) ?? null
+    );
+}

--- a/src/shared/mod.ts
+++ b/src/shared/mod.ts
@@ -33,10 +33,29 @@ export const GAMEBANANA_ID_TO_IMPORTER = {
     [NTE_GAMEBANANA_ID]: NTE_IMPORTER_KEY,
 } as const;
 
+export const IMPORTER_TO_GAMEBANANA_GAME_KEY = {
+    GIMI: "gi",
+    SRMI: "sr",
+    HIMI: "hi",
+    ZZMI: "zz",
+    WWMI: "ww",
+    EFMI: "ef",
+    [NTE_IMPORTER_KEY]: "nte",
+} as const;
+
 export const isNteImporter = (importer: string | null | undefined) => importer === NTE_IMPORTER_KEY;
 
 export function getImporterForGameBananaId(gameId: number): string | null {
     return GAMEBANANA_ID_TO_IMPORTER[gameId as keyof typeof GAMEBANANA_ID_TO_IMPORTER] ?? null;
+}
+
+export function getGameBananaKeyForImporter(importer: string | null | undefined) {
+    if (!importer) return null;
+    if (isNteImporter(importer)) return IMPORTER_TO_GAMEBANANA_GAME_KEY[NTE_IMPORTER_KEY];
+    return (
+        IMPORTER_TO_GAMEBANANA_GAME_KEY[importer as keyof typeof IMPORTER_TO_GAMEBANANA_GAME_KEY] ??
+        null
+    );
 }
 
 export function findGameByImporter<T extends { game: string; importer: string | null }>(

--- a/src/shared/mod.ts
+++ b/src/shared/mod.ts
@@ -19,3 +19,8 @@ export type ModGridLayoutMode = (typeof MOD_GRID_LAYOUT_MODES)[number];
 export const SIDEBAR_LAYOUT_MODES = ["row", "grid"] as const;
 
 export type SidebarLayoutMode = (typeof SIDEBAR_LAYOUT_MODES)[number];
+
+export const NTE_IMPORTER_KEY = "NTE";
+export const NTE_GAMEBANANA_ID = 23012;
+
+export const isNteImporter = (importer: string | null | undefined) => importer === NTE_IMPORTER_KEY;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -214,6 +214,8 @@ export interface GameConfig {
     modFolderPath: string;
     importer: string | null;
     linkedModFolderPath: string | null;
+    gameInstallPath: string | null;
+    gameExecutablePath: string | null;
     order: number;
 }
 
@@ -231,6 +233,7 @@ export type IpcEvents = {
         selectionId: string;
         suggestedName?: string;
         downloadTargetName?: string;
+        downloadImporterKey?: string;
     }) => void;
     "language:update": (language: string) => void;
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -213,6 +213,7 @@ export interface GameConfig {
     game: string;
     modFolderPath: string;
     importer: string | null;
+    linkedModFolderPath: string | null;
     order: number;
 }
 

--- a/src/shared/xxmi-match.ts
+++ b/src/shared/xxmi-match.ts
@@ -5,6 +5,7 @@ export const GAME_MATCH_CASES: Record<string, string[]> = {
     WWMI: ["명조", "묑조", "wuwa", "wuthering", "wwmi", "ww"],
     EFMI: ["엔드필드", "엔필", "endfield", "efmi"],
     HIMI: ["붕괴", "붕괴3", "붕괴3rd", "himi", "honkai", "hi3rd"],
+    NTE: ["이환", "异环", "nte", "neverness", "everness", "htgame"],
 };
 
 export const getMatchingImporter = (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large feature touching SQLite schema, filesystem junctions/moves, and detached process launch; incorrect linking or rollback bugs could affect users’ mod folders, though changes are scoped behind the NTE importer.
> 
> **Overview**
> **Release 2.45.0** adds first-class support for **NTE** (*Neverness To Everness*) alongside existing XXMI-backed games.
> 
> **Game configuration** persists `linkedModFolderPath`, `gameInstallPath`, and `gameExecutablePath` on `game_paths`, with duplicate detection across mod and linked paths. NTE setup resolves install folders from `HTGame.exe`, optionally **junction-links** the game’s `Content/Paks/Mods` folder to a custom mod directory, and rolls back disk changes on failed add/update/remove.
> 
> **Mod library behavior** for NTE routes characters/groups/mods through pak-based folders: enable/disable toggles `.pak` files (and `DISABLED` folder names) instead of XXMI-style prefixes, including exclusive toggle and enable/disable-all.
> 
> **Launch & IPC**: new handlers resolve NTE paths, pick/set the launcher executable, and **spawn** the game detached. The mod UI adds NTE-specific add/edit flows, an **NTE launch dialog** when no executable is set, and a unified **Play** button (NTE vs XXMI). NTE games hide ini/fix-tool/model-viewer mod actions.
> 
> **Downloads & GameBanana**: downloads can carry `downloadImporterKey` to scope fuzzy target resolution and pre-select the matching game; GameBanana adds the NTE game id and maps importer keys for file metadata and **syncing GameBanana game** when navigating from the mod page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1885910f6d0834b5f1a03861dcfd38563372208. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for NTE game launcher integration with configurable game executable paths
  * Enhanced game management with linked custom mod folder support
  * New launch dialog for NTE games with executable path selection and validation
  * Improved game path resolution and detection for custom folder configurations
  * Updated localization for mod management workflows across multiple languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->