### PR TITLE
Release 2.49.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahida-desktop",
-  "version": "2.49.2",
+  "version": "2.49.3",
   "description": "Native app for nahida.live",
   "homepage": "https://nahida.live",
   "author": "nahida.live",

--- a/src/main/lib/custom-downloader/index.ts
+++ b/src/main/lib/custom-downloader/index.ts
@@ -370,6 +370,7 @@ export class CustomDownloader {
             suggestedFileName,
             downloadFilePayload.categoryName,
             downloadFilePayload.importerKey ?? undefined,
+            "gamebanana",
         );
         if (!result.path) return "canceled";
         const destinationPath = result.path;
@@ -534,7 +535,12 @@ export class CustomDownloader {
     }): Promise<"started" | "canceled"> {
         const { title: _title, fileUrl } = props;
         const title = this.sanitize(_title);
-        const result = await this.desktop.lib.pathSelector.getSelectedPathWithModeModal(title);
+        const result = await this.desktop.lib.pathSelector.getSelectedPathWithModeModal(
+            title,
+            undefined,
+            undefined,
+            "hui",
+        );
 
         if (!result.path) {
             return "canceled";

--- a/src/main/lib/path-selector.ts
+++ b/src/main/lib/path-selector.ts
@@ -1,3 +1,4 @@
+import type { DownloadSource } from "@shared/mod";
 import { dialog } from "electron";
 import { nanoid } from "nanoid";
 
@@ -16,6 +17,7 @@ export interface PendingPathSelection {
     suggestedName?: string;
     downloadTargetName?: string;
     downloadImporterKey?: string;
+    downloadSource: DownloadSource;
     resolve: (result: PathSelectorResult) => void;
     reject: (error: Error) => void;
 }
@@ -32,6 +34,7 @@ export class PathSelector {
         suggestedName?: string,
         downloadTargetName?: string,
         downloadImporterKey?: string,
+        downloadSource: DownloadSource = "nahidaLive",
     ): Promise<PathSelectorResult> {
         return new Promise((resolve, reject) => {
             const selectionId = nanoid();
@@ -41,6 +44,7 @@ export class PathSelector {
                 suggestedName,
                 downloadTargetName,
                 downloadImporterKey,
+                downloadSource,
                 resolve,
                 reject,
             });
@@ -57,6 +61,7 @@ export class PathSelector {
                                     suggestedName,
                                     downloadTargetName,
                                     downloadImporterKey,
+                                    downloadSource,
                                 );
                             }, 500);
                         });
@@ -67,6 +72,7 @@ export class PathSelector {
                             suggestedName,
                             downloadTargetName,
                             downloadImporterKey,
+                            downloadSource,
                         );
                     }
                 });
@@ -77,6 +83,7 @@ export class PathSelector {
                     suggestedName,
                     downloadTargetName,
                     downloadImporterKey,
+                    downloadSource,
                 );
             }
         });
@@ -87,6 +94,7 @@ export class PathSelector {
         suggestedName?: string,
         downloadTargetName?: string,
         downloadImporterKey?: string,
+        downloadSource: DownloadSource = "nahidaLive",
     ) {
         const mainWindow = this.desktop.window.main.window;
         if (!mainWindow) {
@@ -103,6 +111,7 @@ export class PathSelector {
             suggestedName,
             downloadTargetName,
             downloadImporterKey,
+            downloadSource,
         });
     }
 

--- a/src/main/setting.ts
+++ b/src/main/setting.ts
@@ -2,9 +2,11 @@ import type { NahidaDesktop } from "@main/index";
 import { normalizeDriveNameSortPolicy, type DriveNameSortPolicy } from "@shared/drive";
 import {
     ARCHIVE_EXTRACT_PATH_MODES,
+    DOWNLOAD_SOURCES,
     MOD_GRID_LAYOUT_MODES,
     SIDEBAR_LAYOUT_MODES,
     type ArchiveExtractPathMode,
+    type DownloadSource,
     type ModGridLayoutMode,
     type SidebarLayoutMode,
 } from "@shared/mod";
@@ -17,6 +19,7 @@ import {
 import type { AutoUpdateMode } from "@shared/updater";
 import AutoLaunch from "auto-launch";
 import { app, BrowserWindow } from "electron";
+
 import { LogLevel } from "./internal/logger";
 
 interface Bounds {
@@ -150,6 +153,22 @@ function parseBooleanSetting(value: string | null | undefined, fallback: boolean
     }
 
     return value === "true";
+}
+
+function normalizeDownloadSources(value: unknown): DownloadSource[] {
+    if (!Array.isArray(value)) return ["gamebanana"];
+    return value.filter((source): source is DownloadSource =>
+        DOWNLOAD_SOURCES.includes(source as DownloadSource),
+    );
+}
+
+function parseDownloadSources(value: string | null | undefined): DownloadSource[] {
+    if (!value) return ["gamebanana"] satisfies DownloadSource[];
+    try {
+        return normalizeDownloadSources(JSON.parse(value));
+    } catch {
+        return ["gamebanana"];
+    }
 }
 
 export class Setting {
@@ -309,6 +328,19 @@ export class Setting {
                 getDefault: () => false,
                 fromStored: (value) => parseBooleanSetting(value, false),
                 toStored: (value) => String(value),
+            },
+            "mod.autoResolveDownloadTarget": {
+                definition: APP_SETTINGS["mod.autoResolveDownloadTarget"],
+                getDefault: () => false,
+                fromStored: (value) => parseBooleanSetting(value, false),
+                toStored: (value) => String(value),
+            },
+            "mod.autoResolveDownloadTargetSources": {
+                definition: APP_SETTINGS["mod.autoResolveDownloadTargetSources"],
+                getDefault: () => ["gamebanana"],
+                fromStored: (value) => parseDownloadSources(value),
+                normalize: (value) => normalizeDownloadSources(value),
+                toStored: (value) => JSON.stringify(value),
             },
             "mod.copyShaderFixesOnEnable": {
                 definition: APP_SETTINGS["mod.copyShaderFixesOnEnable"],

--- a/src/renderer/src/components/mod/game-preset-selector.tsx
+++ b/src/renderer/src/components/mod/game-preset-selector.tsx
@@ -67,6 +67,7 @@ export const GamePresetSelector = memo(function GamePresetSelector({
   const navi = useNavigate();
   const selectedGame = useModStore((s) => s.selectedGame);
   const setSelectedGame = useModStore((s) => s.setSelectedGame);
+  const markUserSelectedDuringDownload = useModStore((s) => s.markUserSelectedDuringDownload);
   const selectedPreset = useModStore((s) => s.selectedPreset);
   const setSelectedPreset = useModStore((s) => s.setSelectedPreset);
   const setIsSelectedPresetDialogOpen = useModStore((s) => s.setIsSelectedPresetDialogOpen);
@@ -91,6 +92,7 @@ export const GamePresetSelector = memo(function GamePresetSelector({
   }, [isSelectedPresetDialogOpen, setSelectedPreset]);
 
   const handleGameSelect = async (game: string) => {
+    markUserSelectedDuringDownload();
     setSelectedGame(game);
     await window.api.invoke("mod:setLastGame", game);
   };

--- a/src/renderer/src/components/path-selector-dialog.tsx
+++ b/src/renderer/src/components/path-selector-dialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from "@renderer/components/ui/dialog";
 import { useModStore } from "@renderer/store/mod";
+import type { DownloadSource } from "@shared/mod";
 import { useNavigate } from "@tanstack/react-router";
 import { FolderOpen, Grid3x3 } from "lucide-react";
 import { useRef } from "react";
@@ -20,6 +21,7 @@ interface PathSelectorDialogProps {
   suggestedName?: string;
   downloadTargetName?: string;
   downloadImporterKey?: string;
+  downloadSource: DownloadSource;
 }
 
 export function PathSelectorDialog({
@@ -29,6 +31,7 @@ export function PathSelectorDialog({
   suggestedName,
   downloadTargetName,
   downloadImporterKey,
+  downloadSource,
 }: PathSelectorDialogProps) {
   const { t } = useTranslation();
   const navi = useNavigate();
@@ -72,6 +75,7 @@ export function PathSelectorDialog({
       suggestedName,
       downloadTargetName,
       downloadImporterKey,
+      downloadSource,
     });
     void navi({ to: "/mod" });
     closeWithoutCancel();

--- a/src/renderer/src/hooks/use-global-events.ts
+++ b/src/renderer/src/hooks/use-global-events.ts
@@ -1,3 +1,4 @@
+import type { DownloadSource } from "@shared/mod";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -11,6 +12,7 @@ export function useGlobalEvents(
         suggestedName?: string;
         downloadTargetName?: string;
         downloadImporterKey?: string;
+        downloadSource: DownloadSource;
     }) => void,
 ) {
     const navi = useNavigate();

--- a/src/renderer/src/hooks/use-settings.ts
+++ b/src/renderer/src/hooks/use-settings.ts
@@ -1,13 +1,15 @@
 import { getSetting, setSetting, settingsManyQueryKey } from "@renderer/lib/settings";
 import type { AppSettings, SettingKey } from "@shared/settings";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 type SettingsConfig = Record<string, SettingKey>;
 
 type SettingsShape<TConfig extends SettingsConfig> = {
     [P in keyof TConfig]: AppSettings[TConfig[P]];
 };
+
+type SettingUpdate<T> = T | ((current: T) => T);
 
 function useInvalidateOnSettingUpdate(keys: readonly SettingKey[], queryKey: readonly unknown[]) {
     const queryClient = useQueryClient();
@@ -69,22 +71,41 @@ export function useSettings<TConfig extends SettingsConfig>(settingsConfig: TCon
     });
 
     const [settings, setSettings] = useState<SettingsShape<TConfig>>({} as SettingsShape<TConfig>);
+    const settingsRef = useRef(settings);
+    const settingUpdateQueueRef = useRef(Promise.resolve());
     const [isInitialized, setIsInitialized] = useState(false);
 
     useEffect(() => {
         if (data) {
+            settingsRef.current = data;
             setSettings(data);
             setIsInitialized(true);
         }
     }, [data]);
 
-    const update = async <K extends keyof TConfig>(key: K, value: SettingsShape<TConfig>[K]) => {
-        const nextSettings = { ...settings, [key]: value };
+    const update = async <K extends keyof TConfig>(
+        key: K,
+        updateValue: SettingUpdate<SettingsShape<TConfig>[K]>,
+    ) => {
+        const value =
+            typeof updateValue === "function"
+                ? (
+                      updateValue as (
+                          current: SettingsShape<TConfig>[K],
+                      ) => SettingsShape<TConfig>[K]
+                  )(settingsRef.current[key])
+                : updateValue;
+        const nextSettings = { ...settingsRef.current, [key]: value };
         const singleSettingQueryKey = ["settings", settingsConfig[key]] as const;
+        settingsRef.current = nextSettings;
         setSettings(nextSettings);
         queryClient.setQueryData(queryKey, nextSettings);
         queryClient.setQueryData<SettingsShape<TConfig>[K]>(singleSettingQueryKey, value);
-        await setSetting(settingsConfig[key], value);
+        const pendingUpdate = settingUpdateQueueRef.current
+            .catch(() => {})
+            .then(() => setSetting(settingsConfig[key], value));
+        settingUpdateQueueRef.current = pendingUpdate;
+        await pendingUpdate;
     };
 
     return {

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -1057,7 +1057,14 @@
           "copyShaderFixesOnEnable": "Copy ShaderFixes on enable",
           "copyShaderFixesOnEnableDescription": "Copy ShaderFixes files from the mod into the active Importer's ShaderFixes folder when enabling a mod.",
           "searchModPreview": "Search Preview in Subfolders",
-          "searchModPreviewDescription": "If no preview image exists in the character folder, search for preview images inside mod folders."
+          "searchModPreviewDescription": "If no preview image exists in the character folder, search for preview images inside mod folders.",
+          "autoResolveDownloadTarget": "Automatically select download target folder",
+          "autoResolveDownloadTargetDescription": "Automatically select a mod folder with a name similar to the download.",
+          "downloadSources": {
+            "gamebanana": "GameBanana",
+            "nahidaLive": "Nahida Live",
+            "hui": "Hui"
+          }
         },
         "layout": {
           "title": "Layout",

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -1020,7 +1020,14 @@
           "copyShaderFixesOnEnable": "有効化時にShaderFixesをコピー",
           "copyShaderFixesOnEnableDescription": "MODを有効化するとき、MOD内のShaderFixesファイルを有効なImporterのShaderFixesフォルダーへコピーします。",
           "searchModPreview": "サブフォルダからモッドプレビューを検索",
-          "searchModPreviewDescription": "キャラクター フォルダにプレビュー画像がない場合、モッド フォルダ内からプレビュー画像を検索します。"
+          "searchModPreviewDescription": "キャラクター フォルダにプレビュー画像がない場合、モッド フォルダ内からプレビュー画像を検索します。",
+          "autoResolveDownloadTarget": "ダウンロード先フォルダーを自動選択",
+          "autoResolveDownloadTargetDescription": "ダウンロード名に似たMODフォルダーを自動的に選択します。",
+          "downloadSources": {
+            "gamebanana": "GameBanana",
+            "nahidaLive": "Nahida Live",
+            "hui": "Hui"
+          }
         },
         "layout": {
           "title": "レイアウト",

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -1039,7 +1039,14 @@
           "copyShaderFixesOnEnable": "활성화 시 ShaderFixes 복사",
           "copyShaderFixesOnEnableDescription": "모드를 활성화할 때 모드 안의 ShaderFixes 파일을 활성 Importer의 ShaderFixes 폴더로 복사합니다.",
           "searchModPreview": "하위 폴더에서 미리보기 검색",
-          "searchModPreviewDescription": "캐릭터 폴더에 프리뷰 이미지가 없는 경우, 모드 폴더 내부에서 프리뷰 이미지를 검색합니다."
+          "searchModPreviewDescription": "캐릭터 폴더에 프리뷰 이미지가 없는 경우, 모드 폴더 내부에서 프리뷰 이미지를 검색합니다.",
+          "autoResolveDownloadTarget": "다운로드 대상 폴더 자동 선택",
+          "autoResolveDownloadTargetDescription": "다운로드 이름과 비슷한 모드 폴더를 자동으로 선택합니다.",
+          "downloadSources": {
+            "gamebanana": "GameBanana",
+            "nahidaLive": "나히다 라이브",
+            "hui": "Hui"
+          }
         },
         "layout": {
           "title": "레이아웃",

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -1019,7 +1019,14 @@
           "copyShaderFixesOnEnable": "启用时复制 ShaderFixes",
           "copyShaderFixesOnEnableDescription": "启用模组时，将模组中的 ShaderFixes 文件复制到已激活导入器的 ShaderFixes 文件夹。",
           "searchModPreview": "在子文件夹中搜索模组预览",
-          "searchModPreviewDescription": "如果角色文件夹中没有预览图像，则在模组文件夹内部搜索预览图像。"
+          "searchModPreviewDescription": "如果角色文件夹中没有预览图像，则在模组文件夹内部搜索预览图像。",
+          "autoResolveDownloadTarget": "自动选择下载目标文件夹",
+          "autoResolveDownloadTargetDescription": "自动选择名称与下载内容相似的模组文件夹。",
+          "downloadSources": {
+            "gamebanana": "GameBanana",
+            "nahidaLive": "Nahida Live",
+            "hui": "Hui"
+          }
         },
         "layout": {
           "title": "布局",

--- a/src/renderer/src/routes/__root.tsx
+++ b/src/renderer/src/routes/__root.tsx
@@ -12,6 +12,7 @@ import { useTitlebar } from "@renderer/hooks/use-titlebar";
 import { getSetting } from "@renderer/lib/settings";
 import { cn } from "@renderer/lib/utils";
 import { useGlobalStore } from "@renderer/store/global";
+import type { DownloadSource } from "@shared/mod";
 import type { QueryClient } from "@tanstack/react-query";
 import {
   createRootRouteWithContext,
@@ -105,6 +106,7 @@ function RootComponent() {
     suggestedName?: string;
     downloadTargetName?: string;
     downloadImporterKey?: string;
+    downloadSource: DownloadSource;
   } | null>(null);
 
   const handlePathSelectorModeSelect = useCallback(
@@ -113,6 +115,7 @@ function RootComponent() {
       suggestedName?: string;
       downloadTargetName?: string;
       downloadImporterKey?: string;
+      downloadSource: DownloadSource;
     }) => {
       setPathSelectorData(data);
     },
@@ -141,6 +144,7 @@ function RootComponent() {
           suggestedName={pathSelectorData.suggestedName}
           downloadTargetName={pathSelectorData.downloadTargetName}
           downloadImporterKey={pathSelectorData.downloadImporterKey}
+          downloadSource={pathSelectorData.downloadSource}
         />
       )}
 

--- a/src/renderer/src/routes/mod/index.tsx
+++ b/src/renderer/src/routes/mod/index.tsx
@@ -26,6 +26,7 @@ import {
   useModWatcherEvents,
 } from "@renderer/hooks/use-mod-events";
 import { useModFixRunner } from "@renderer/hooks/use-mod-fix-runner";
+import { useSettings } from "@renderer/hooks/use-settings";
 import { useTitlebar } from "@renderer/hooks/use-titlebar";
 import { modStore, useModStore } from "@renderer/store/mod";
 import { findGameByImporter, type ResolvedArchiveExtractPathMode } from "@shared/mod";
@@ -37,6 +38,11 @@ import { useTranslation } from "react-i18next";
 export const Route = createFileRoute("/mod/")({
   component: RouteComponent,
 });
+
+const downloadTargetSettingsConfig = {
+  enabled: "mod.autoResolveDownloadTarget",
+  sources: "mod.autoResolveDownloadTargetSources",
+} as const;
 
 function RouteComponent() {
   return <ModRouteContent />;
@@ -71,6 +77,7 @@ function ModRouteContent() {
 
   const { data: games = [] } = useGames();
   const { data: characters = [] } = useCharacters(selectedGame);
+  const { settings: downloadTargetSettings } = useSettings(downloadTargetSettingsConfig);
   const [pendingDownloadTarget, setPendingDownloadTarget] = useState<{
     downloadId: string;
     game: string;
@@ -158,10 +165,14 @@ function ModRouteContent() {
   }, [games, selectedGame, setSelectedGame]);
 
   useEffect(() => {
+    const shouldAutoResolve =
+      downloadTargetSettings.enabled === true &&
+      downloadTargetSettings.sources?.includes(downloadMode?.downloadSource ?? "gamebanana");
     if (
-      !downloadMode?.suggestedName &&
-      !downloadMode?.downloadTargetName &&
-      !downloadMode?.downloadImporterKey
+      !shouldAutoResolve ||
+      (!downloadMode?.suggestedName &&
+        !downloadMode?.downloadTargetName &&
+        !downloadMode?.downloadImporterKey)
     ) {
       return;
     }
@@ -169,9 +180,10 @@ function ModRouteContent() {
     if (downloadMode.downloadImporterKey && games.length === 0) return;
 
     const downloadId = downloadMode.downloadId;
+    let active = true;
 
     const resolveTarget = async () => {
-      if (modStore.getState().downloadMode?.downloadId !== downloadId) return;
+      if (!active || modStore.getState().downloadMode?.downloadId !== downloadId) return;
 
       const currentDownloadMode = modStore.getState().downloadMode;
       if (!currentDownloadMode) return;
@@ -191,6 +203,7 @@ function ModRouteContent() {
 
       const stateAfterPrimary = modStore.getState();
       if (
+        !active ||
         stateAfterPrimary.downloadMode?.downloadId !== downloadId ||
         stateAfterPrimary.userSelectedDuringDownload
       ) {
@@ -207,6 +220,7 @@ function ModRouteContent() {
 
       const stateAfterResolve = modStore.getState();
       if (
+        !active ||
         stateAfterResolve.downloadMode?.downloadId !== downloadId ||
         stateAfterResolve.userSelectedDuringDownload
       ) {
@@ -237,11 +251,18 @@ function ModRouteContent() {
     void resolveTarget().catch((error) => {
       console.error("Failed to resolve download target", error);
     });
+
+    return () => {
+      active = false;
+    };
   }, [
     downloadMode?.downloadId,
     downloadMode?.suggestedName,
     downloadMode?.downloadTargetName,
     downloadMode?.downloadImporterKey,
+    downloadMode?.downloadSource,
+    downloadTargetSettings.enabled,
+    downloadTargetSettings.sources,
     games,
     setSelectedGame,
   ]);

--- a/src/renderer/src/routes/setting/mod.tsx
+++ b/src/renderer/src/routes/setting/mod.tsx
@@ -1,6 +1,7 @@
 import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { clampModGridColumnCount, clampModGridWidth } from "@renderer/components/mod/grid-layout";
 import { Card, CardContent, CardHeader, CardTitle } from "@renderer/components/ui/card";
+import { Checkbox } from "@renderer/components/ui/checkbox";
 import { FieldDescription, FieldGroup, FieldTitle } from "@renderer/components/ui/field";
 import { Input } from "@renderer/components/ui/input";
 import {
@@ -17,6 +18,7 @@ import { useSettings } from "@renderer/hooks/use-settings";
 import { Logger } from "@renderer/lib/logger";
 import {
   MOD_GRID_LAYOUT_MODES,
+  DOWNLOAD_SOURCES,
   SIDEBAR_LAYOUT_MODES,
   type ModGridLayoutMode,
   type SidebarLayoutMode,
@@ -37,6 +39,8 @@ const settingsConfig = {
   virtualizationEnabled: "mod.virtualizationEnabled",
   virtualizationThreshold: "mod.virtualizationThreshold",
   searchModPreview: "mod.searchModPreview",
+  autoResolveDownloadTarget: "mod.autoResolveDownloadTarget",
+  autoResolveDownloadTargetSources: "mod.autoResolveDownloadTargetSources",
   copyShaderFixesOnEnable: "mod.copyShaderFixesOnEnable",
   sidebarLayout: "mod.sidebarLayout",
   gridLayoutMode: "mod.gridLayoutMode",
@@ -288,6 +292,49 @@ function ModSettingsRouteContent() {
                 checked={settings.searchModPreview}
                 onCheckedChange={(val) => update("searchModPreview", val)}
               />
+            </div>
+
+            <Separator />
+
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5 pr-4">
+                  <span className="text-sm font-medium">
+                    {t("page.setting.mod.mod_management.autoResolveDownloadTarget")}
+                  </span>
+                  <p className="text-xs text-muted-foreground">
+                    {t("page.setting.mod.mod_management.autoResolveDownloadTargetDescription")}
+                  </p>
+                </div>
+                <Switch
+                  checked={settings.autoResolveDownloadTarget}
+                  onCheckedChange={(val) => update("autoResolveDownloadTarget", val)}
+                />
+              </div>
+
+              <div className="grid gap-2 rounded-lg border bg-muted/20 p-3 sm:grid-cols-3">
+                {DOWNLOAD_SOURCES.map((source) => (
+                  <label
+                    key={source}
+                    className="flex cursor-pointer items-center gap-2 text-sm has-disabled:cursor-not-allowed has-disabled:opacity-50"
+                  >
+                    <Checkbox
+                      checked={settings.autoResolveDownloadTargetSources.includes(source)}
+                      disabled={!settings.autoResolveDownloadTarget}
+                      onCheckedChange={(checked) =>
+                        update("autoResolveDownloadTargetSources", (currentSources) =>
+                          checked
+                            ? currentSources.includes(source)
+                              ? currentSources
+                              : [...currentSources, source]
+                            : currentSources.filter((selectedSource) => selectedSource !== source),
+                        )
+                      }
+                    />
+                    {t(`page.setting.mod.mod_management.downloadSources.${source}`)}
+                  </label>
+                ))}
+              </div>
             </div>
           </CardContent>
         </Card>

--- a/src/renderer/src/store/mod.ts
+++ b/src/renderer/src/store/mod.ts
@@ -1,3 +1,4 @@
+import type { DownloadSource } from "@shared/mod";
 import type { FolderGroup, GameConfig, Preset } from "@shared/types";
 import { createStore, useStore } from "zustand";
 
@@ -31,6 +32,7 @@ interface ModState {
         suggestedName?: string;
         downloadTargetName?: string;
         downloadImporterKey?: string;
+        downloadSource: DownloadSource;
     } | null;
     setDownloadMode: (
         mode: {
@@ -38,6 +40,7 @@ interface ModState {
             suggestedName?: string;
             downloadTargetName?: string;
             downloadImporterKey?: string;
+            downloadSource: DownloadSource;
         } | null,
     ) => void;
     userSelectedDuringDownload: boolean;

--- a/src/shared/fuzzy-match.test.ts
+++ b/src/shared/fuzzy-match.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+
 import { findBestFuzzyMatch, rankFuzzyMatches } from "./fuzzy-match.ts";
 
 const candidates = ["alice", "anby", "aria"];
@@ -27,6 +28,24 @@ void describe("fuzzy match", () => {
 
     void it("matches alice download names", () => {
         assert.equal(findBestFuzzyMatch(candidates, "AliceSwimsuit")?.value, "alice");
+    });
+
+    void it("requires exact tokens for short candidates", () => {
+        assert.equal(findBestFuzzyMatch(["A"], "AliceSwimsuit", { threshold: 0.85 }), null);
+        assert.equal(findBestFuzzyMatch(["an"], "AnbyDefault", { threshold: 0.85 }), null);
+        assert.equal(findBestFuzzyMatch(["ari"], "AriaRaceQueen", { threshold: 0.85 }), null);
+        assert.equal(findBestFuzzyMatch(["A"], "A_Default", { threshold: 0.85 })?.value, "A");
+    });
+
+    void it("rejects unrelated single-character substitutions", () => {
+        assert.equal(findBestFuzzyMatch(["Lull"], "full", { threshold: 0.85 }), null);
+    });
+
+    void it("allows single edits after a stable prefix", () => {
+        assert.equal(
+            findBestFuzzyMatch(["alice"], "AlxceDefault", { threshold: 0.85 })?.value,
+            "alice",
+        );
     });
 
     void it("returns null when the best score is below threshold", () => {

--- a/src/shared/fuzzy-match.ts
+++ b/src/shared/fuzzy-match.ts
@@ -76,6 +76,7 @@ function scoreCandidate(candidate: string, input: string, inputTokens: string[])
     if (!candidate || !input) return 0;
     if (candidate === input) return EXACT_FULL_MATCH_SCORE;
     if (inputTokens.some((token) => token === candidate)) return EXACT_TOKEN_MATCH_SCORE;
+    if (candidate.length < 4) return 0;
     if (input.startsWith(candidate)) return INPUT_STARTS_WITH_CANDIDATE_SCORE;
     if (input.includes(candidate)) return INPUT_INCLUDES_CANDIDATE_SCORE;
 
@@ -100,14 +101,14 @@ function scoreToken(candidate: string, token: string) {
         commonPrefixLength >= Math.max(2, Math.ceil(shorterLength * 0.6))
             ? 0.85 + 0.1 * (commonPrefixLength / longerLength)
             : 0;
-    const shortTokenTypoScore =
-        shorterLength >= 4 && tokenDistance === 1 && Math.abs(candidate.length - token.length) <= 1
-            ? 0.88
-            : 0;
+    const transpositionScore = hasSingleAdjacentTransposition(candidate, token) ? 0.88 : 0;
+    const singleEditScore =
+        shorterLength >= 4 && commonPrefixLength >= 2 && tokenDistance === 1 ? 0.88 : 0;
 
     return Math.max(
         strongPrefixScore,
-        shortTokenTypoScore,
+        transpositionScore,
+        singleEditScore,
         (1 - tokenDistance / longerLength) * TOKEN_LEVENSHTEIN_MAX_SCORE,
     );
 }

--- a/src/shared/mod.ts
+++ b/src/shared/mod.ts
@@ -20,6 +20,10 @@ export const SIDEBAR_LAYOUT_MODES = ["row", "grid"] as const;
 
 export type SidebarLayoutMode = (typeof SIDEBAR_LAYOUT_MODES)[number];
 
+export const DOWNLOAD_SOURCES = ["gamebanana", "nahidaLive", "hui"] as const;
+
+export type DownloadSource = (typeof DOWNLOAD_SOURCES)[number];
+
 export const NTE_IMPORTER_KEY = "NTE";
 export const NTE_GAMEBANANA_ID = 23012;
 

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1,5 +1,10 @@
 import type { DriveNameSortPolicy } from "./drive";
-import type { ArchiveExtractPathMode, ModGridLayoutMode, SidebarLayoutMode } from "./mod";
+import type {
+    ArchiveExtractPathMode,
+    DownloadSource,
+    ModGridLayoutMode,
+    SidebarLayoutMode,
+} from "./mod";
 import type { AutoUpdateMode } from "./updater";
 
 export interface AppSettings {
@@ -20,6 +25,8 @@ export interface AppSettings {
     "mod.virtualizationEnabled": boolean;
     "mod.virtualizationThreshold": number;
     "mod.searchModPreview": boolean;
+    "mod.autoResolveDownloadTarget": boolean;
+    "mod.autoResolveDownloadTargetSources": DownloadSource[];
     "mod.copyShaderFixesOnEnable": boolean;
     "mod.sidebarLayout": SidebarLayoutMode;
     "mod.characterSidebarWidth": number;
@@ -135,6 +142,16 @@ export const APP_SETTINGS = {
         publicKey: "mod.searchModPreview",
         scope: "mod",
         storageKey: "mod_search_mod_preview",
+    },
+    "mod.autoResolveDownloadTarget": {
+        publicKey: "mod.autoResolveDownloadTarget",
+        scope: "mod",
+        storageKey: "mod_auto_resolve_download_target",
+    },
+    "mod.autoResolveDownloadTargetSources": {
+        publicKey: "mod.autoResolveDownloadTargetSources",
+        scope: "mod",
+        storageKey: "mod_auto_resolve_download_target_sources",
     },
     "mod.copyShaderFixesOnEnable": {
         publicKey: "mod.copyShaderFixesOnEnable",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -272,6 +272,7 @@ export type IpcEvents = {
         suggestedName?: string;
         downloadTargetName?: string;
         downloadImporterKey?: string;
+        downloadSource: import("./mod").DownloadSource;
     }) => void;
     "language:update": (language: string) => void;
 


### PR DESCRIPTION
## Summary
- make automatic download target folder selection opt-in
- allow users to enable target resolution per download source
- tighten fuzzy matching for short folder names while preserving safe typo matching
- prevent automatic resolution from overriding manual game or folder selections
- serialize rapid settings updates to avoid losing source selections

## Validation
- pnpm lint on changed files
- node --test --experimental-strip-types src/shared/fuzzy-match.test.ts
- pnpm build