### PR TITLE
feat(drive): support mod manager download targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahida-desktop",
-  "version": "2.49.3",
+  "version": "2.49.4",
   "description": "Native app for nahida.live",
   "homepage": "https://nahida.live",
   "author": "nahida.live",

--- a/src/main/ipc/handlers/drive.ts
+++ b/src/main/ipc/handlers/drive.ts
@@ -19,7 +19,7 @@ export function registerDriveHandlers(d: NahidaDesktop) {
     });
 
     rh("drive:fn:startDownload", async ({ items, targetPath }) => {
-        return await d.service.drive.fn.startDownload({ items, targetPath });
+        return await d.service.drive.fn.startDownload({ items, targetPath, source: "drive" });
     });
 
     rh("drive:fn:startUpload", async ({ destId, paths, conflictStrategy }) => {

--- a/src/main/lib/path-selector.ts
+++ b/src/main/lib/path-selector.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import type { DownloadSource } from "@shared/mod";
 import { dialog } from "electron";
 import { nanoid } from "nanoid";
@@ -15,9 +17,11 @@ export interface PathSelectorResult {
 export interface PendingPathSelection {
     id: string;
     suggestedName?: string;
+    suggestedNames?: string[];
     downloadTargetName?: string;
     downloadImporterKey?: string;
     downloadSource: DownloadSource;
+    selectFile: boolean;
     resolve: (result: PathSelectorResult) => void;
     reject: (error: Error) => void;
 }
@@ -35,6 +39,8 @@ export class PathSelector {
         downloadTargetName?: string,
         downloadImporterKey?: string,
         downloadSource: DownloadSource = "nahidaLive",
+        suggestedNames?: string[],
+        selectFile = false,
     ): Promise<PathSelectorResult> {
         return new Promise((resolve, reject) => {
             const selectionId = nanoid();
@@ -42,9 +48,11 @@ export class PathSelector {
             this.pendingSelections.set(selectionId, {
                 id: selectionId,
                 suggestedName,
+                suggestedNames,
                 downloadTargetName,
                 downloadImporterKey,
                 downloadSource,
+                selectFile,
                 resolve,
                 reject,
             });
@@ -62,6 +70,7 @@ export class PathSelector {
                                     downloadTargetName,
                                     downloadImporterKey,
                                     downloadSource,
+                                    suggestedNames,
                                 );
                             }, 500);
                         });
@@ -73,6 +82,7 @@ export class PathSelector {
                             downloadTargetName,
                             downloadImporterKey,
                             downloadSource,
+                            suggestedNames,
                         );
                     }
                 });
@@ -84,6 +94,7 @@ export class PathSelector {
                     downloadTargetName,
                     downloadImporterKey,
                     downloadSource,
+                    suggestedNames,
                 );
             }
         });
@@ -95,6 +106,7 @@ export class PathSelector {
         downloadTargetName?: string,
         downloadImporterKey?: string,
         downloadSource: DownloadSource = "nahidaLive",
+        suggestedNames?: string[],
     ) {
         const mainWindow = this.desktop.window.main.window;
         if (!mainWindow) {
@@ -109,6 +121,7 @@ export class PathSelector {
         this.desktop.ipc.postMessageToWindow(mainWindow, "pathSelector:modeSelect", {
             selectionId,
             suggestedName,
+            suggestedNames,
             downloadTargetName,
             downloadImporterKey,
             downloadSource,
@@ -121,15 +134,25 @@ export class PathSelector {
             throw new Error("Pending selection not found");
         }
 
-        const path = await this.selectFolderDialog();
+        try {
+            if (pending.selectFile) {
+                const result = await this.selectFileDialog(pending.suggestedName);
+                pending.resolve({
+                    mode: "folder",
+                    path: result ? path.dirname(result) : null,
+                    fileName: result ? path.basename(result) : undefined,
+                });
+                return;
+            }
 
-        if (path) {
-            pending.resolve({ mode: "folder", path });
-        } else {
-            pending.resolve({ mode: "folder", path: null });
+            const selectedPath = await this.selectFolderDialog();
+            pending.resolve({ mode: "folder", path: selectedPath });
+        } catch (error) {
+            pending.reject(error instanceof Error ? error : new Error(String(error)));
+            throw error;
+        } finally {
+            this.pendingSelections.delete(selectionId);
         }
-
-        this.pendingSelections.delete(selectionId);
     }
 
     public async selectModManagerPath(
@@ -177,5 +200,21 @@ export class PathSelector {
         }
 
         return savePath;
+    }
+
+    private async selectFileDialog(suggestedName?: string): Promise<string | null> {
+        const window = this.desktop.window.main.window;
+        if (!window) throw new Error("Main window not found");
+
+        const dialogResult = await dialog.showSaveDialog(window, {
+            defaultPath: suggestedName,
+        });
+        if (dialogResult.canceled || !dialogResult.filePath) return null;
+
+        const isWritable = await this.desktop.lib.fs.isPathWritable(
+            path.dirname(dialogResult.filePath),
+        );
+        if (!isWritable) throw new Error("Path is not writable");
+        return dialogResult.filePath;
     }
 }

--- a/src/main/services/drive.ts
+++ b/src/main/services/drive.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { promisify } from "node:util";
 import { gunzip, gzip, zstdCompress, zstdDecompress } from "node:zlib";
 
@@ -16,6 +15,7 @@ import Upload, {
     type UploadParams,
 } from "@main/lib/upload";
 import type { LinkData } from "@main/server";
+import type { DownloadSource } from "@shared/mod";
 import { toErrorMessage } from "@shared/utils";
 import { dialog } from "electron";
 import { retry } from "es-toolkit";
@@ -26,7 +26,6 @@ import { nanoid } from "nanoid";
 import type { NahidaDesktop } from "..";
 import type { LocalTransfer, TransferParams } from "./transfer";
 
-import { saveFileDialog, selectDirectoryDialog } from "./dialog";
 import { processChunked } from "./util";
 
 const Fn = eden.akasha.content({ id: "" }).get;
@@ -248,11 +247,13 @@ export class DriveService {
             targetPath,
             link,
             data,
+            source = "nahidaLive",
         }: {
             items: Array<{ id: string; isDir: boolean; name: string }>;
             targetPath?: string;
             link?: LinkData;
             data?: DownloadMetadata;
+            source?: Extract<DownloadSource, "drive" | "nahidaLive">;
         }): Promise<"started" | "canceled"> => {
             if (items.length === 0) return "canceled";
 
@@ -262,47 +263,27 @@ export class DriveService {
 
             const isSingle = items.length === 1;
             const single = items[0];
-            const allDirs = items.every((item) => item.isDir);
-
             let savePath = targetPath;
             let suggestedName = isSingle ? single.name : undefined;
 
             if (!savePath) {
-                if (isSingle && !single.isDir) {
-                    const result = await saveFileDialog({ suggestedName });
-                    if (result.canceled) {
-                        this.desktop.logger.info(
-                            "Download cancelled by user selection",
-                            "Drive:Download",
-                        );
-                        return "canceled";
-                    }
-                    savePath = path.dirname(result.filePath);
-                    suggestedName = path.basename(result.filePath);
-                } else if (allDirs) {
-                    const result =
-                        await this.desktop.lib.pathSelector.getSelectedPathWithModeModal(
-                            suggestedName,
-                        );
-                    if (!result.path) {
-                        this.desktop.logger.info(
-                            "Download cancelled by user selection",
-                            "Drive:Download",
-                        );
-                        return "canceled";
-                    }
-                    savePath = result.path;
-                } else {
-                    const result = await selectDirectoryDialog();
-                    if (result.canceled || !result.filePath) {
-                        this.desktop.logger.info(
-                            "Download cancelled by user selection",
-                            "Drive:Download",
-                        );
-                        return "canceled";
-                    }
-                    savePath = result.filePath;
+                const result = await this.desktop.lib.pathSelector.getSelectedPathWithModeModal(
+                    suggestedName,
+                    undefined,
+                    undefined,
+                    source,
+                    items.map((item) => item.name),
+                    isSingle && !single.isDir,
+                );
+                if (!result.path) {
+                    this.desktop.logger.info(
+                        "Download cancelled by user selection",
+                        "Drive:Download",
+                    );
+                    return "canceled";
                 }
+                savePath = result.path;
+                suggestedName = isSingle ? (result.fileName ?? suggestedName) : undefined;
             }
 
             savePath = this.desktop.lib.fs.sanitizePath(savePath);

--- a/src/main/services/mod-manager/library.ts
+++ b/src/main/services/mod-manager/library.ts
@@ -228,8 +228,11 @@ export class ModLibraryService {
         );
         if (!match) return null;
 
-        const candidate = candidates.find((candidate) => candidate.group.name === match.value);
-        if (!candidate) return null;
+        const matchingCandidates = candidates.filter(
+            (candidate) => candidate.group.name === match.value,
+        );
+        if (matchingCandidates.length !== 1) return null;
+        const candidate = matchingCandidates[0];
 
         return {
             game: candidate.game,

--- a/src/renderer/src/components/path-selector-dialog.tsx
+++ b/src/renderer/src/components/path-selector-dialog.tsx
@@ -19,6 +19,7 @@ interface PathSelectorDialogProps {
   onOpenChange: (open: boolean) => void;
   selectionId: string;
   suggestedName?: string;
+  suggestedNames?: string[];
   downloadTargetName?: string;
   downloadImporterKey?: string;
   downloadSource: DownloadSource;
@@ -29,6 +30,7 @@ export function PathSelectorDialog({
   onOpenChange,
   selectionId,
   suggestedName,
+  suggestedNames,
   downloadTargetName,
   downloadImporterKey,
   downloadSource,
@@ -73,6 +75,7 @@ export function PathSelectorDialog({
     setDownloadMode({
       downloadId: selectionId,
       suggestedName,
+      suggestedNames,
       downloadTargetName,
       downloadImporterKey,
       downloadSource,
@@ -92,7 +95,11 @@ export function PathSelectorDialog({
         <DialogHeader>
           <DialogTitle>{t("components.path-selector-dialog.title")}</DialogTitle>
           <DialogDescription>
-            {t("components.path-selector-dialog.description", { name: suggestedName })}
+            {suggestedNames && suggestedNames.length > 1
+              ? t("components.path-selector-dialog.multiple_description", {
+                  count: suggestedNames.length,
+                })
+              : t("components.path-selector-dialog.description", { name: suggestedName })}
           </DialogDescription>
         </DialogHeader>
 

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -1063,7 +1063,8 @@
           "downloadSources": {
             "gamebanana": "GameBanana",
             "nahidaLive": "Nahida Live",
-            "hui": "Hui"
+            "hui": "Hui",
+            "drive": "Drive"
           }
         },
         "layout": {
@@ -1186,6 +1187,7 @@
     "path-selector-dialog": {
       "title": "Select Path",
       "description": "Choose how to download {{name}}",
+      "multiple_description": "Choose how to download {{count}} items",
       "mod_manager": {
         "title": "Mod Manager",
         "description": {

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -1026,7 +1026,8 @@
           "downloadSources": {
             "gamebanana": "GameBanana",
             "nahidaLive": "Nahida Live",
-            "hui": "Hui"
+            "hui": "Hui",
+            "drive": "ドライブ"
           }
         },
         "layout": {
@@ -1149,6 +1150,7 @@
     "path-selector-dialog": {
       "title": "パス選択",
       "description": "{{name}} をダウンロードする方法を選択してください",
+      "multiple_description": "{{count}}個の項目をダウンロードする方法を選択してください",
       "mod_manager": {
         "title": "MODマネージャー",
         "description": {

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -1045,7 +1045,8 @@
           "downloadSources": {
             "gamebanana": "GameBanana",
             "nahidaLive": "나히다 라이브",
-            "hui": "Hui"
+            "hui": "Hui",
+            "drive": "드라이브"
           }
         },
         "layout": {
@@ -1168,6 +1169,7 @@
     "path-selector-dialog": {
       "title": "경로 선택",
       "description": "{{name}} 를 어떤 방식으로 다운로드 할지 선택하세요",
+      "multiple_description": "{{count}}개 항목을 어떤 방식으로 다운로드할지 선택하세요",
       "mod_manager": {
         "title": "모드 매니저",
         "description": {

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -1025,7 +1025,8 @@
           "downloadSources": {
             "gamebanana": "GameBanana",
             "nahidaLive": "Nahida Live",
-            "hui": "Hui"
+            "hui": "Hui",
+            "drive": "云端硬盘"
           }
         },
         "layout": {
@@ -1148,6 +1149,7 @@
     "path-selector-dialog": {
       "title": "选择路径",
       "description": "选择下载 {{name}} 的方式",
+      "multiple_description": "选择下载 {{count}} 个项目的方式",
       "mod_manager": {
         "title": "模组管理器",
         "description": {

--- a/src/renderer/src/routes/__root.tsx
+++ b/src/renderer/src/routes/__root.tsx
@@ -104,6 +104,7 @@ function RootComponent() {
   const [pathSelectorData, setPathSelectorData] = useState<{
     selectionId: string;
     suggestedName?: string;
+    suggestedNames?: string[];
     downloadTargetName?: string;
     downloadImporterKey?: string;
     downloadSource: DownloadSource;
@@ -113,6 +114,7 @@ function RootComponent() {
     (data: {
       selectionId: string;
       suggestedName?: string;
+      suggestedNames?: string[];
       downloadTargetName?: string;
       downloadImporterKey?: string;
       downloadSource: DownloadSource;
@@ -142,6 +144,7 @@ function RootComponent() {
           onOpenChange={(open) => !open && setPathSelectorData(null)}
           selectionId={pathSelectorData.selectionId}
           suggestedName={pathSelectorData.suggestedName}
+          suggestedNames={pathSelectorData.suggestedNames}
           downloadTargetName={pathSelectorData.downloadTargetName}
           downloadImporterKey={pathSelectorData.downloadImporterKey}
           downloadSource={pathSelectorData.downloadSource}
@@ -149,14 +152,14 @@ function RootComponent() {
       )}
 
       <main className={cn("flex w-screen overflow-hidden", screenHeight)}>
-        <div className="flex flex-row w-full">
+        <div className="flex w-full flex-row">
           {!isNoSidebar && <Sidebar />}
 
           <div
             className={cn(
-              "flex-1 min-w-0 h-full relative overflow-hidden",
+              "relative h-full min-w-0 flex-1 overflow-hidden",
               DEFAULT_BG,
-              titlebarStyle === "modern" ? "border-t border-l rounded-tl-lg" : "border-l",
+              titlebarStyle === "modern" ? "rounded-tl-lg border-t border-l" : "border-l",
             )}
           >
             <Outlet />
@@ -209,10 +212,10 @@ function ErrorComponent({ error }: ErrorComponentProps) {
 
           {error?.message ? (
             <details className="rounded-lg border bg-muted/40 px-3 py-2 text-xs">
-              <summary className="cursor-pointer select-none font-medium text-muted-foreground">
+              <summary className="cursor-pointer font-medium text-muted-foreground select-none">
                 {t("page.root.error.details")}
               </summary>
-              <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap wrap-break-word font-mono text-destructive">
+              <pre className="mt-2 max-h-48 overflow-auto font-mono wrap-break-word whitespace-pre-wrap text-destructive">
                 {error.message}
               </pre>
             </details>

--- a/src/renderer/src/routes/mod/index.tsx
+++ b/src/renderer/src/routes/mod/index.tsx
@@ -171,6 +171,7 @@ function ModRouteContent() {
     if (
       !shouldAutoResolve ||
       (!downloadMode?.suggestedName &&
+        !downloadMode?.suggestedNames?.length &&
         !downloadMode?.downloadTargetName &&
         !downloadMode?.downloadImporterKey)
     ) {
@@ -195,9 +196,7 @@ function ModRouteContent() {
       if (currentDownloadMode.downloadImporterKey && !gameByImporter) return;
 
       const primary = currentDownloadMode.downloadTargetName;
-      const fallback = currentDownloadMode.suggestedName;
-
-      let result = primary
+      const primaryResult = primary
         ? await window.api.invoke("mod:resolveDownloadTarget", primary, gameByImporter ?? undefined)
         : null;
 
@@ -210,13 +209,29 @@ function ModRouteContent() {
         return;
       }
 
-      if (!result && fallback) {
-        result = await window.api.invoke(
-          "mod:resolveDownloadTarget",
-          fallback,
-          gameByImporter ?? undefined,
-        );
-      }
+      const fallbackNames = currentDownloadMode.suggestedNames?.length
+        ? currentDownloadMode.suggestedNames
+        : currentDownloadMode.suggestedName
+          ? [currentDownloadMode.suggestedName]
+          : [];
+      const fallbackResults = primaryResult
+        ? []
+        : await Promise.all(
+            fallbackNames.map((name) =>
+              window.api.invoke("mod:resolveDownloadTarget", name, gameByImporter ?? undefined),
+            ),
+          );
+      const firstFallbackResult = fallbackResults[0] ?? null;
+      const result =
+        primaryResult ??
+        (firstFallbackResult &&
+        fallbackResults.every(
+          (candidate) =>
+            candidate?.game === firstFallbackResult.game &&
+            candidate.group.path === firstFallbackResult.group.path,
+        )
+          ? firstFallbackResult
+          : null);
 
       const stateAfterResolve = modStore.getState();
       if (
@@ -258,6 +273,7 @@ function ModRouteContent() {
   }, [
     downloadMode?.downloadId,
     downloadMode?.suggestedName,
+    downloadMode?.suggestedNames,
     downloadMode?.downloadTargetName,
     downloadMode?.downloadImporterKey,
     downloadMode?.downloadSource,

--- a/src/renderer/src/store/mod.ts
+++ b/src/renderer/src/store/mod.ts
@@ -30,6 +30,7 @@ interface ModState {
     downloadMode: {
         downloadId: string;
         suggestedName?: string;
+        suggestedNames?: string[];
         downloadTargetName?: string;
         downloadImporterKey?: string;
         downloadSource: DownloadSource;
@@ -38,6 +39,7 @@ interface ModState {
         mode: {
             downloadId: string;
             suggestedName?: string;
+            suggestedNames?: string[];
             downloadTargetName?: string;
             downloadImporterKey?: string;
             downloadSource: DownloadSource;

--- a/src/shared/mod.ts
+++ b/src/shared/mod.ts
@@ -20,7 +20,7 @@ export const SIDEBAR_LAYOUT_MODES = ["row", "grid"] as const;
 
 export type SidebarLayoutMode = (typeof SIDEBAR_LAYOUT_MODES)[number];
 
-export const DOWNLOAD_SOURCES = ["gamebanana", "nahidaLive", "hui"] as const;
+export const DOWNLOAD_SOURCES = ["gamebanana", "nahidaLive", "hui", "drive"] as const;
 
 export type DownloadSource = (typeof DOWNLOAD_SOURCES)[number];
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -270,6 +270,7 @@ export type IpcEvents = {
     "pathSelector:modeSelect": (data: {
         selectionId: string;
         suggestedName?: string;
+        suggestedNames?: string[];
         downloadTargetName?: string;
         downloadImporterKey?: string;
         downloadSource: import("./mod").DownloadSource;


### PR DESCRIPTION
## Summary
- add Drive as an auto-resolved download source
- route Drive and Shared Drive downloads through the mod manager for all selection types
- auto-select only when every selected item resolves to one unambiguous target
- bump the app version to 2.49.4

## Validation
- pnpm lint -- changed TypeScript files
- pnpm build
- node --test src/shared/fuzzy-match.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Drive as a download source option.
  * Improved download location selection for files and folders.
  * Added support for selecting destinations for multiple downloads.
  * Added localized descriptions for multi-item path selection.

* **Bug Fixes**
  * Prevented ambiguous folder matches from selecting an incorrect download target.
  * Improved cancellation and error handling during destination selection.

* **Chores**
  * Updated the app version to 2.49.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->