### PR TITLE
chore: release v2.52.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahida-desktop",
-  "version": "2.51.0",
+  "version": "2.52.0",
   "description": "Native app for nahida.live",
   "homepage": "https://nahida.live",
   "author": "nahida.live",

--- a/plugins/ipc-generator.ts
+++ b/plugins/ipc-generator.ts
@@ -164,10 +164,9 @@ function generateIpc(options: IpcGeneratorOptions) {
                 );
 
                 if (propertyMatch) {
-                    const propertyPath = propertyMatch[1];
                     channels.set(
                         channel,
-                        `() => typeof import("@main/index").desktop.${propertyPath}`,
+                        `() => typeof import("@main/index").desktop.${propertyMatch[1]}`,
                     );
                     continue;
                 }
@@ -182,9 +181,9 @@ function generateIpc(options: IpcGeneratorOptions) {
                         channel,
                         `(...args: Parameters<typeof ${importRef}>) => ReturnType<typeof ${importRef}>`,
                     );
-                } else {
-                    channels.set(channel, `(...args: any[]) => any`);
+                    continue;
                 }
+                channels.set(channel, `(...args: any[]) => any`);
             }
         }
 

--- a/plugins/ipc-generator.ts
+++ b/plugins/ipc-generator.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+
 import type { Plugin } from "vite";
 
 interface IpcGeneratorOptions {
@@ -141,6 +142,8 @@ function generateIpc(options: IpcGeneratorOptions) {
                 }
 
                 // function call in arrow/return: => d.foo.bar(...) or return d.foo.bar(...)
+                // Use inline import type so the symbol resolves across the renderer tsconfig boundary,
+                // which does not include src/main/**/*.
                 const returnMatch = impl.match(
                     /(?:return|=>)\s*(?:await\s+)?(?:desktop|d)\.([a-zA-Z0-9_$.]+)\(/,
                 );
@@ -149,22 +152,38 @@ function generateIpc(options: IpcGeneratorOptions) {
                     const methodPath = returnMatch[1];
                     channels.set(
                         channel,
-                        `(...args: Parameters<typeof desktop.${methodPath}>) => ReturnType<typeof desktop.${methodPath}>`,
+                        `(...args: Parameters<typeof import("@main/index").desktop.${methodPath}>) => ReturnType<typeof import("@main/index").desktop.${methodPath}>`,
+                    );
+                    continue;
+                }
+
+                // property access in arrow/return: => d.foo.bar (no trailing call)
+                // e.g. gamebanana:getGames returns d.service.gamebanana.games
+                const propertyMatch = impl.match(
+                    /(?:return|=>)\s*(?:await\s+)?(?:desktop|d)\.([a-zA-Z0-9_$.]+)/,
+                );
+
+                if (propertyMatch) {
+                    const propertyPath = propertyMatch[1];
+                    channels.set(
+                        channel,
+                        `() => typeof import("@main/index").desktop.${propertyPath}`,
+                    );
+                    continue;
+                }
+
+                //simple imported function call: => myFunc(...)
+                const bareReturnMatch = impl.match(
+                    /(?:return|=>)\s*(?:await\s+)?([a-zA-Z0-9_$]+)\(/,
+                );
+                if (bareReturnMatch && importMap.has(bareReturnMatch[1])) {
+                    const importRef = importMap.get(bareReturnMatch[1]);
+                    channels.set(
+                        channel,
+                        `(...args: Parameters<typeof ${importRef}>) => ReturnType<typeof ${importRef}>`,
                     );
                 } else {
-                    //simple imported function call: => myFunc(...)
-                    const bareReturnMatch = impl.match(
-                        /(?:return|=>)\s*(?:await\s+)?([a-zA-Z0-9_$]+)\(/,
-                    );
-                    if (bareReturnMatch && importMap.has(bareReturnMatch[1])) {
-                        const importRef = importMap.get(bareReturnMatch[1]);
-                        channels.set(
-                            channel,
-                            `(...args: Parameters<typeof ${importRef}>) => ReturnType<typeof ${importRef}>`,
-                        );
-                    } else {
-                        channels.set(channel, `(...args: any[]) => any`);
-                    }
+                    channels.set(channel, `(...args: any[]) => any`);
                 }
             }
         }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import { electronApp, optimizer } from "@electron-toolkit/utils";
 import AutoLaunch from "auto-launch";
-import { app, protocol } from "electron";
+import { app, crashReporter, protocol } from "electron";
 import { installExtension, REACT_DEVELOPER_TOOLS } from "electron-devtools-installer";
 
 import type { NativeLib } from "./lib/native";
@@ -48,6 +48,14 @@ if (IS_ELECTRON) {
     app?.commandLine.appendSwitch("disable-pinch-zoom");
     app?.commandLine.appendSwitch("disable-pinch");
 }
+
+crashReporter.start({
+    productName: "NahidaDesktop",
+    companyName: "nahida",
+    submitURL: "",
+    uploadToServer: false,
+    ignoreSystemCrashHandler: true,
+});
 
 const dbPath = !app.isPackaged ? DB_FILE_NAME : path.join(app.getPath("userData"), "data.db");
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -51,7 +51,7 @@ if (IS_ELECTRON) {
 
 crashReporter.start({
     productName: "NahidaDesktop",
-    companyName: "nahida",
+    globalExtra: { _companyName: "nahida" },
     submitURL: "",
     uploadToServer: false,
     ignoreSystemCrashHandler: true,

--- a/src/main/services/gamebanana/index.ts
+++ b/src/main/services/gamebanana/index.ts
@@ -525,33 +525,23 @@ export class GameBananaService {
                         if (cookie) {
                             try {
                                 await this.saveCookie(cookie);
-                                callback({
-                                    cancel: false,
-                                    responseHeaders: details.responseHeaders,
-                                });
                                 resolveOnce(cookie);
-                                // close()를 webRequest 콜백 내부에서 동기 호출하면
-                                // Chromium 네트워크 스택 처리 중 webContents/세션이 teardown 되어
-                                // 네이티브 크래시(0xFFFF0003)가 발생함. 콜백 반환 후 close.
-                                setImmediate(() => {
-                                    if (!loginWindow.isDestroyed()) {
-                                        loginWindow.close();
-                                    }
-                                });
-                                return;
                             } catch {
-                                callback({
-                                    cancel: false,
-                                    responseHeaders: details.responseHeaders,
-                                });
                                 rejectOnce(new Error("GAMEBANANA_AUTH_FAILED"));
-                                setImmediate(() => {
-                                    if (!loginWindow.isDestroyed()) {
-                                        loginWindow.close();
-                                    }
-                                });
-                                return;
                             }
+                            callback({
+                                cancel: false,
+                                responseHeaders: details.responseHeaders,
+                            });
+                            // close()를 webRequest 콜백 내부에서 동기 호출하면
+                            // Chromium 네트워크 스택 처리 중 webContents/세션이 teardown 되어
+                            // 네이티브 크래시(0xFFFF0003)가 발생함. 콜백 반환 후 close.
+                            setImmediate(() => {
+                                if (!loginWindow.isDestroyed()) {
+                                    loginWindow.close();
+                                }
+                            });
+                            return;
                         }
 
                         callback({ cancel: false, responseHeaders: details.responseHeaders });

--- a/src/main/services/gamebanana/index.ts
+++ b/src/main/services/gamebanana/index.ts
@@ -57,7 +57,7 @@ type ManualRmcSaveResult =
 
 export class GameBananaService {
     public readonly games = gameBananaGames;
-    private readonly apiBaseUrl = "https://gamebanana.com/apiv12";
+    private readonly apiBaseUrl = "https://gamebanana.com/apiv13";
     private readonly loginUrl = "https://gamebanana.com/members/account/login";
     private readonly logoutUrl = "https://gamebanana.com/members/account/logout";
     private readonly authUrls = [
@@ -751,15 +751,15 @@ export class GameBananaService {
     }
 
     private getModPreviewUrl(profile: Awaited<ReturnType<GameBananaService["getModProfile"]>>) {
-        const preview = profile._aPreviewMedia?._aImages?.[0];
+        const preview = profile._aPreviewContent?.screenshots?.[0];
         if (!preview) {
             return null;
         }
 
         const absoluteUrl = [
             preview._sFile,
-            preview._sFile800,
             preview._sFile530,
+            preview._sFile220,
             preview._sUrl,
         ].find((value) => Boolean(value && /^https?:\/\//i.test(value)));
         if (absoluteUrl) {
@@ -768,8 +768,8 @@ export class GameBananaService {
 
         const relativeUrl = [
             preview._sFile,
-            preview._sFile800,
             preview._sFile530,
+            preview._sFile220,
             preview._sUrl,
         ].find(Boolean);
         if (!relativeUrl || !preview._sBaseUrl) {

--- a/src/main/services/gamebanana/index.ts
+++ b/src/main/services/gamebanana/index.ts
@@ -501,7 +501,10 @@ export class GameBananaService {
                 this.loginWindow = loginWindow;
                 const webRequest = loginWindow.webContents.session.webRequest;
 
+                let cleanedUp = false;
                 const cleanup = () => {
+                    if (cleanedUp) return;
+                    cleanedUp = true;
                     webRequest.onHeadersReceived(null as never);
                     if (this.loginWindow === loginWindow) {
                         this.loginWindow = null;
@@ -527,9 +530,14 @@ export class GameBananaService {
                                     responseHeaders: details.responseHeaders,
                                 });
                                 resolveOnce(cookie);
-                                if (!loginWindow.isDestroyed()) {
-                                    loginWindow.close();
-                                }
+                                // close()를 webRequest 콜백 내부에서 동기 호출하면
+                                // Chromium 네트워크 스택 처리 중 webContents/세션이 teardown 되어
+                                // 네이티브 크래시(0xFFFF0003)가 발생함. 콜백 반환 후 close.
+                                setImmediate(() => {
+                                    if (!loginWindow.isDestroyed()) {
+                                        loginWindow.close();
+                                    }
+                                });
                                 return;
                             } catch {
                                 callback({
@@ -537,9 +545,11 @@ export class GameBananaService {
                                     responseHeaders: details.responseHeaders,
                                 });
                                 rejectOnce(new Error("GAMEBANANA_AUTH_FAILED"));
-                                if (!loginWindow.isDestroyed()) {
-                                    loginWindow.close();
-                                }
+                                setImmediate(() => {
+                                    if (!loginWindow.isDestroyed()) {
+                                        loginWindow.close();
+                                    }
+                                });
                                 return;
                             }
                         }

--- a/src/main/services/gamebanana/model.ts
+++ b/src/main/services/gamebanana/model.ts
@@ -23,16 +23,30 @@ const PreviewImageSchema = z
         _sBaseUrl: UrlString.optional(),
         _sCaption: z.string().optional(),
         _sFile: z.string().optional(),
+        _sFile100: z.string().optional(),
+        _sFile220: z.string().optional(),
         _sFile530: z.string().optional(),
-        _sFile800: z.string().optional(),
     })
     .catchall(z.unknown());
 
+const normalizePreviewMedia = (value: unknown) => {
+    if (Array.isArray(value)) {
+        return { screenshots: value };
+    }
+    if (value && typeof value === "object") {
+        const record = value as Record<string, unknown>;
+        if (record.screenshot && !record.screenshots) {
+            return { screenshots: [record.screenshot] };
+        }
+    }
+    return value;
+};
+
 const PreviewMediaSchema = z.preprocess(
-    (value) => (Array.isArray(value) ? { _aImages: value } : value),
+    normalizePreviewMedia,
     z
         .object({
-            _aImages: z.array(PreviewImageSchema).optional(),
+            screenshots: z.array(PreviewImageSchema).optional(),
         })
         .catchall(z.unknown()),
 );
@@ -84,7 +98,7 @@ const SubmissionRecordSchema = z
         _tsDateAdded: z.number().optional(),
         _tsDateModified: z.number().optional(),
         _tsDateUpdated: z.number().optional(),
-        _aPreviewMedia: PreviewMediaSchema.optional(),
+        _aPreviewContent: PreviewMediaSchema.optional(),
         _aSubmitter: MemberSchema,
         _aRootCategory: NestedCategorySchema.optional(),
         _aSubCategory: NestedCategorySchema.optional(),
@@ -166,7 +180,7 @@ export const ModProfileSchema = z
         _idRow: NumericId,
         _sName: z.string(),
         _sProfileUrl: HttpUrlString,
-        _aPreviewMedia: PreviewMediaSchema.optional(),
+        _aPreviewContent: PreviewMediaSchema.optional(),
         _nPostCount: z.number().optional(),
         _nDownloadCount: z.number().optional(),
         _aFiles: z.array(ModFileSchema).optional(),

--- a/src/renderer/src/routes/gamebanana/-panels/game-home-panel.tsx
+++ b/src/renderer/src/routes/gamebanana/-panels/game-home-panel.tsx
@@ -1,11 +1,17 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@renderer/components/ui/card";
 import { ScrollArea } from "@renderer/components/ui/scroll-area";
 import type { TFunction } from "i18next";
+
+import type { GameBananaSubmissionSelection, GameSubfeedQuery } from "../-types";
+
 import { SubmissionCard } from "../-cards/submission-card";
 import { ErrorState, OverviewSkeleton, PaginationButtons } from "../-shared/common";
 import { getGameBananaErrorPresentation } from "../-shared/errors";
-import type { GameBananaSubmissionSelection, GameSubfeedQuery } from "../-types";
 import { getSubmissionDateKey } from "../-utils";
+
+function getFeedRecords(query: GameSubfeedQuery) {
+  return query.data?._aRecords.filter((record) => record._sModelName === "Mod");
+}
 
 export function GameHomePanel({
   t,
@@ -36,7 +42,7 @@ export function GameHomePanel({
         className="h-full min-h-0 min-w-0"
         viewportClassName="overflow-x-hidden [&>div]:!block [&>div]:!min-w-0 [&>div]:!w-full [&>div]:max-w-full"
       >
-        <div className="min-w-0 max-w-full space-y-4 p-4">
+        <div className="max-w-full min-w-0 space-y-4 p-4">
           <Card className="flex h-full min-h-0 flex-col p-0">
             <CardHeader>
               <div className="flex items-center justify-between gap-3 pt-3">
@@ -65,8 +71,8 @@ export function GameHomePanel({
                       details={errorPresentation.details}
                     />
                   )}
-                  <div className="grid gap-4 grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
-                    {subfeedQuery.data?._aRecords.map((submission) => (
+                  <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 2xl:grid-cols-4">
+                    {getFeedRecords(subfeedQuery).map((submission) => (
                       <SubmissionCard
                         key={`feed-${submission._idRow}-${getSubmissionDateKey(submission)}`}
                         submission={submission}

--- a/src/renderer/src/routes/gamebanana/-panels/game-home-panel.tsx
+++ b/src/renderer/src/routes/gamebanana/-panels/game-home-panel.tsx
@@ -9,10 +9,6 @@ import { ErrorState, OverviewSkeleton, PaginationButtons } from "../-shared/comm
 import { getGameBananaErrorPresentation } from "../-shared/errors";
 import { getSubmissionDateKey } from "../-utils";
 
-function getFeedRecords(query: GameSubfeedQuery) {
-  return query.data?._aRecords.filter((record) => record._sModelName === "Mod") ?? [];
-}
-
 export function GameHomePanel({
   t,
   language,
@@ -94,4 +90,8 @@ export function GameHomePanel({
       </ScrollArea>
     </>
   );
+}
+
+function getFeedRecords(query: GameSubfeedQuery) {
+  return query.data?._aRecords.filter((record) => record._sModelName === "Mod") ?? [];
 }

--- a/src/renderer/src/routes/gamebanana/-panels/game-home-panel.tsx
+++ b/src/renderer/src/routes/gamebanana/-panels/game-home-panel.tsx
@@ -10,7 +10,7 @@ import { getGameBananaErrorPresentation } from "../-shared/errors";
 import { getSubmissionDateKey } from "../-utils";
 
 function getFeedRecords(query: GameSubfeedQuery) {
-  return query.data?._aRecords.filter((record) => record._sModelName === "Mod");
+  return query.data?._aRecords.filter((record) => record._sModelName === "Mod") ?? [];
 }
 
 export function GameHomePanel({

--- a/src/renderer/src/routes/gamebanana/-types.ts
+++ b/src/renderer/src/routes/gamebanana/-types.ts
@@ -25,8 +25,8 @@ export interface GameBananaBreadcrumbItem {
 }
 
 export type SubmissionListItem = GameSubfeedData["_aRecords"][number];
-export type PreviewMedia = NonNullable<SubmissionListItem["_aPreviewMedia"]>;
-export type PreviewImage = NonNullable<PreviewMedia["_aImages"]>[number];
+export type PreviewMedia = NonNullable<SubmissionListItem["_aPreviewContent"]>;
+export type PreviewImage = NonNullable<PreviewMedia["screenshots"]>[number];
 export type RootCategoryItem = GameOverviewData["profile"]["_aModRootCategories"][number];
 export type CategoryChildItem = CategoryOverviewData["categories"][number];
 export type ModFileItem = NonNullable<ModOverviewData["profile"]["_aFiles"]>[number];

--- a/src/renderer/src/routes/gamebanana/-utils.ts
+++ b/src/renderer/src/routes/gamebanana/-utils.ts
@@ -27,18 +27,18 @@ export function getSubmissionDateKey(
     return getSubmissionTimestamp(submission) ?? submission._idRow;
 }
 
-export function getSubmissionPreviewUrl(submission: { _aPreviewMedia?: PreviewMedia }) {
-    const preview = submission._aPreviewMedia?._aImages?.[0];
+export function getSubmissionPreviewUrl(submission: { _aPreviewContent?: PreviewMedia }) {
+    const preview = submission._aPreviewContent?.screenshots?.[0];
     return preview ? resolvePreviewImageUrl(preview, "preview") : undefined;
 }
 
-export function getSubmissionFullPreviewUrl(submission: { _aPreviewMedia?: PreviewMedia }) {
-    const preview = submission._aPreviewMedia?._aImages?.[0];
+export function getSubmissionFullPreviewUrl(submission: { _aPreviewContent?: PreviewMedia }) {
+    const preview = submission._aPreviewContent?.screenshots?.[0];
     return preview ? resolvePreviewImageUrl(preview) : undefined;
 }
 
-export function getSubmissionPreviewImages(submission: { _aPreviewMedia?: PreviewMedia }) {
-    const previews = submission._aPreviewMedia?._aImages ?? [];
+export function getSubmissionPreviewImages(submission: { _aPreviewContent?: PreviewMedia }) {
+    const previews = submission._aPreviewContent?.screenshots ?? [];
 
     return previews
         .map((preview, index) => {
@@ -62,8 +62,14 @@ export function getSubmissionPreviewImages(submission: { _aPreviewMedia?: Previe
 function resolvePreviewImageUrl(preview: PreviewImage, variant: "full" | "preview" = "full") {
     const candidates =
         variant === "preview"
-            ? [preview._sFile800, preview._sFile530, preview._sFile, preview._sUrl]
-            : [preview._sFile, preview._sFile800, preview._sFile530, preview._sUrl];
+            ? [
+                  preview._sFile530,
+                  preview._sFile220,
+                  preview._sFile100,
+                  preview._sFile,
+                  preview._sUrl,
+              ]
+            : [preview._sFile, preview._sFile530, preview._sFile220, preview._sUrl];
     const absoluteCandidate = candidates.find((value) => isAbsoluteUrl(value));
     if (absoluteCandidate) return absoluteCandidate;
 


### PR DESCRIPTION
## Changes

- **feat(gamebanana):** migrate to API v13
- **fix(gamebanana):** prevent native crash during login window teardown
- **fix(ipc):** resolve renderer IPC handler types across tsconfig boundary
- **chore:** bump version to 2.52.0

## Version Bump

Minor (2.51.0 → 2.52.0) — GameBanana API v13 migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GameBanana integration for the latest API version.
  * Improved mod preview image loading with better support for screenshots and available image sizes.
  * Fixed login-window cleanup and closing behavior to reduce crashes.
  * Improved feed display by showing only supported mod records.
* **Reliability**
  * Added local crash reporting to help diagnose application failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->