### PR TITLE
perf(mod): avoid repeated shader ownership scans

### DIFF
--- a/src/main/services/mod-manager/shader-fixes.test.ts
+++ b/src/main/services/mod-manager/shader-fixes.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import os from "node:os";
+import path from "node:path";
+
+import fse from "fs-extra";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
+
+import type { NahidaDesktop } from "../..";
+import type { ModLibraryService } from "./library";
+
+import { ModShaderFixesService, SHADER_FIXES_MOD_MARKER_FILE } from "./shader-fixes";
+
+const fastGlobCalls = vi.hoisted(() => [] as (string | string[])[]);
+
+vi.mock("fast-glob", async (importOriginal) => {
+    const original = await importOriginal<typeof import("fast-glob")>();
+    const fastGlob = Reflect.get(original, "default") as typeof import("fast-glob");
+    return {
+        ...original,
+        default: new Proxy(fastGlob, {
+            apply(target, thisArg, args) {
+                fastGlobCalls.push(args[0] as string | string[]);
+                return Reflect.apply(target, thisArg, args);
+            },
+        }),
+    };
+});
+
+describe("ModShaderFixesService", () => {
+    let rootPath: string;
+    let importerPath: string;
+    let modsPath: string;
+    let service: ModShaderFixesService;
+
+    beforeEach(async () => {
+        rootPath = await fse.mkdtemp(path.join(os.tmpdir(), "nahida-shader-fixes-"));
+        importerPath = path.join(rootPath, "Importer");
+        modsPath = path.join(importerPath, "Mods");
+        await fse.ensureDir(modsPath);
+
+        service = new ModShaderFixesService(
+            {
+                service: {
+                    xxmi: {
+                        getEnabledImporters: () => [
+                            { key: "Importer", importerFolder: importerPath },
+                        ],
+                    },
+                },
+                lib: {
+                    utils: {
+                        getFileHash: async (filePath: string) =>
+                            createHash("sha256")
+                                .update(await fse.readFile(filePath))
+                                .digest("hex"),
+                    },
+                },
+                logger: { error: vi.fn() },
+            } as unknown as NahidaDesktop,
+            {
+                games: async () => [{ modFolderPath: modsPath }],
+            } as unknown as ModLibraryService,
+        );
+
+        fastGlobCalls.length = 0;
+    });
+
+    afterEach(async () => {
+        await fse.remove(rootPath);
+    });
+
+    it("uses the manifest directly and scans owners once when disabling", async () => {
+        const modPath = path.join(modsPath, "Group", "Mod");
+        await Promise.all(
+            ["a.ini", "nested/b.ini", "nested/c.ini"].map(async (file) => {
+                await fse.outputFile(path.join(modPath, "ShaderFixes", file), file);
+            }),
+        );
+        await service.handleShaders(modPath, true);
+        await fse.remove(path.join(modPath, "ShaderFixes"));
+        fastGlobCalls.length = 0;
+
+        await service.handleShaders(modPath, false);
+
+        assert.deepEqual(fastGlobCalls, [`**/${SHADER_FIXES_MOD_MARKER_FILE}`]);
+        assert.equal(await fse.pathExists(path.join(importerPath, "ShaderFixes", "a.ini")), false);
+        assert.equal(await fse.pathExists(path.join(modPath, SHADER_FIXES_MOD_MARKER_FILE)), false);
+    });
+
+    it("preserves a shader fix while another mod owns it", async () => {
+        const firstModPath = path.join(modsPath, "Group", "First");
+        const secondModPath = path.join(modsPath, "Group", "Second");
+        await Promise.all(
+            [firstModPath, secondModPath].map(async (modPath) => {
+                await fse.outputFile(path.join(modPath, "ShaderFixes", "shared.ini"), "shared");
+                await service.handleShaders(modPath, true);
+            }),
+        );
+
+        await service.handleShaders(firstModPath, false);
+        assert.equal(
+            await fse.pathExists(path.join(importerPath, "ShaderFixes", "shared.ini")),
+            true,
+        );
+
+        await service.handleShaders(secondModPath, false);
+        assert.equal(
+            await fse.pathExists(path.join(importerPath, "ShaderFixes", "shared.ini")),
+            false,
+        );
+    });
+
+    it("preserves a shader fix that changed after it was copied", async () => {
+        const modPath = path.join(modsPath, "Group", "Mod");
+        const targetPath = path.join(importerPath, "ShaderFixes", "changed.ini");
+        await fse.outputFile(path.join(modPath, "ShaderFixes", "changed.ini"), "original");
+        await service.handleShaders(modPath, true);
+        await fse.writeFile(targetPath, "changed");
+
+        await service.handleShaders(modPath, false);
+
+        assert.equal(await fse.readFile(targetPath, "utf8"), "changed");
+        assert.equal(await fse.pathExists(path.join(modPath, SHADER_FIXES_MOD_MARKER_FILE)), false);
+    });
+
+    it("does not scan the mod when no manifest exists", async () => {
+        const modPath = path.join(modsPath, "Group", "Mod");
+        await fse.outputFile(path.join(modPath, "ShaderFixes", "unused.ini"), "unused");
+        fastGlobCalls.length = 0;
+
+        await service.handleShaders(modPath, false);
+
+        assert.deepEqual(fastGlobCalls, []);
+    });
+});

--- a/src/main/services/mod-manager/shader-fixes.ts
+++ b/src/main/services/mod-manager/shader-fixes.ts
@@ -1,11 +1,14 @@
 import { createHash } from "node:crypto";
 import path from "node:path";
+
 import { getMatchingImporter } from "@shared/xxmi-match";
 import fg from "fast-glob";
 import fse from "fs-extra";
 import { nanoid } from "nanoid";
+
 import type { NahidaDesktop } from "../..";
 import type { ModLibraryService } from "./library";
+
 import { isSameOrChildPath, normalizeModPath } from "./path-utils";
 
 interface ShaderFixesModManifestFile {
@@ -225,55 +228,76 @@ export class ModShaderFixesService {
     }
 
     private async getShaderFixesManifestSearchRoots(modPath: string): Promise<string[]> {
-        const roots = new Set<string>();
-        roots.add(path.dirname(modPath));
+        const roots = new Map<string, string>();
+        const addRoot = (root: string) => {
+            const resolvedRoot = path.resolve(root);
+            roots.set(normalizeModPath(resolvedRoot), resolvedRoot);
+        };
+        addRoot(path.dirname(modPath));
 
         try {
             for (const game of await this.library.games()) {
-                roots.add(game.modFolderPath);
+                addRoot(game.modFolderPath);
             }
         } catch (error) {
             this.desktop.logger.error(error, "Mod:getShaderFixesManifestSearchRoots:games");
         }
 
         for (const importer of this.desktop.service.xxmi.getEnabledImporters()) {
-            roots.add(importer.importerFolder);
+            addRoot(importer.importerFolder);
         }
 
-        const existingRoots: string[] = [];
-        for (const root of roots) {
-            if (await fse.pathExists(root)) {
-                existingRoots.push(root);
-            }
-        }
-        return existingRoots;
+        const existingRoots = (
+            await Promise.all(
+                Array.from(roots.values()).map(async (root) =>
+                    (await fse.pathExists(root)) ? root : null,
+                ),
+            )
+        )
+            .filter((root): root is string => root !== null)
+            .sort((a, b) => a.length - b.length);
+
+        return existingRoots.filter(
+            (root, index) =>
+                !existingRoots
+                    .slice(0, index)
+                    .some((parentRoot) => isSameOrChildPath(parentRoot, root)),
+        );
     }
 
-    private async hasOtherShaderFixesOwner(
+    private async getOtherOwnedShaderFixesTargetKeys(
         modPath: string,
         modKey: string,
-        targetKey: string,
-    ): Promise<boolean> {
-        for (const root of await this.getShaderFixesManifestSearchRoots(modPath)) {
-            const manifestFiles = await fg(`**/${SHADER_FIXES_MOD_MARKER_FILE}`, {
-                cwd: root,
-                onlyFiles: true,
-                dot: true,
-                ignore: [`**/${SHADER_FIXES_DIR_NAME}/**`],
-            });
-
-            for (const manifestFile of manifestFiles) {
-                const manifest = await this.readShaderFixesModManifestFile(
-                    path.join(root, manifestFile),
-                );
-                if (!manifest || manifest.modKey === modKey) continue;
-                if (manifest.files.some((file) => file.targetKey === targetKey)) {
-                    return true;
+    ): Promise<Set<string>> {
+        const manifestPaths = new Map<string, string>();
+        await Promise.all(
+            (await this.getShaderFixesManifestSearchRoots(modPath)).map(async (root) => {
+                for (const manifestFile of await fg(`**/${SHADER_FIXES_MOD_MARKER_FILE}`, {
+                    cwd: root,
+                    onlyFiles: true,
+                    dot: true,
+                    ignore: [`**/${SHADER_FIXES_DIR_NAME}/**`],
+                })) {
+                    const manifestPath = path.join(root, manifestFile);
+                    manifestPaths.set(normalizeModPath(manifestPath), manifestPath);
                 }
-            }
-        }
+            }),
+        );
 
-        return false;
+        return new Set(
+            (
+                await Promise.all(
+                    Array.from(manifestPaths.values()).map(
+                        async (manifestPath) =>
+                            await this.readShaderFixesModManifestFile(manifestPath),
+                    ),
+                )
+            ).flatMap((manifest) =>
+                manifest && manifest.modKey !== modKey
+                    ? manifest.files.map((file) => file.targetKey)
+                    : [],
+            ),
+        );
     }
 
     private async getShaderFixesModKey(modPath: string, create: true): Promise<string>;
@@ -353,6 +377,8 @@ export class ModShaderFixesService {
         modPath: string,
         enable: boolean,
     ): Promise<ShaderFixesProcessedFile[]> {
+        if (!enable) return await this.disableShaders(modPath);
+
         const shaderFiles = await this.getShaderFixesFileCandidates(modPath);
         if (shaderFiles.length === 0) return [];
 
@@ -362,73 +388,80 @@ export class ModShaderFixesService {
         const processedFiles: ShaderFixesProcessedFile[] = [];
 
         try {
-            if (enable) {
-                const modKey = await this.getShaderFixesModKey(modPath, true);
-                const manifest: ShaderFixesModManifest = {
-                    version: SHADER_FIXES_MOD_MARKER_VERSION,
-                    modKey,
-                    files: [],
-                };
+            const modKey = await this.getShaderFixesModKey(modPath, true);
+            const manifest: ShaderFixesModManifest = {
+                version: SHADER_FIXES_MOD_MARKER_VERSION,
+                modKey,
+                files: [],
+            };
 
-                await fse.ensureDir(globalShaderPath);
-                for (const { file, sourcePath: source } of shaderFiles) {
-                    const target = path.join(globalShaderPath, file);
-                    const hash = await this.hashFile(source);
-                    const targetKey = this.getShaderFixesTargetKey(target);
-                    const targetExists = await fse.pathExists(target);
+            await fse.ensureDir(globalShaderPath);
+            for (const { file, sourcePath: source } of shaderFiles) {
+                const target = path.join(globalShaderPath, file);
+                const hash = await this.hashFile(source);
+                const targetKey = this.getShaderFixesTargetKey(target);
+                const targetExists = await fse.pathExists(target);
 
-                    if (targetExists) {
-                        const currentHash = await this.hashFile(target);
-                        if (currentHash === hash) {
-                            const manifestFile = { file, targetPath: target, targetKey, hash };
-                            manifest.files.push(manifestFile);
-                            processedFiles.push({ ...manifestFile, modKey, createdTarget: false });
-                            await this.writeShaderFixesModManifest(modPath, manifest);
-                        }
-                        continue;
+                if (targetExists) {
+                    const currentHash = await this.hashFile(target);
+                    if (currentHash === hash) {
+                        const manifestFile = { file, targetPath: target, targetKey, hash };
+                        manifest.files.push(manifestFile);
+                        processedFiles.push({ ...manifestFile, modKey, createdTarget: false });
+                        await this.writeShaderFixesModManifest(modPath, manifest);
                     }
-
-                    await fse.copy(source, target);
-                    const manifestFile = { file, targetPath: target, targetKey, hash };
-                    manifest.files.push(manifestFile);
-                    processedFiles.push({ ...manifestFile, modKey, createdTarget: true });
-                    await this.writeShaderFixesModManifest(modPath, manifest);
+                    continue;
                 }
 
-                if (manifest.files.length > 0) {
-                    await this.writeShaderFixesModManifest(modPath, manifest);
-                } else {
-                    await this.deleteModManifest(modPath);
-                }
+                await fse.copy(source, target);
+                const manifestFile = { file, targetPath: target, targetKey, hash };
+                manifest.files.push(manifestFile);
+                processedFiles.push({ ...manifestFile, modKey, createdTarget: true });
+                await this.writeShaderFixesModManifest(modPath, manifest);
+            }
+
+            if (manifest.files.length > 0) {
+                await this.writeShaderFixesModManifest(modPath, manifest);
             } else {
-                const modKey = await this.getShaderFixesModKey(modPath);
-                if (!modKey) return [];
-
-                const manifest = await this.readShaderFixesModManifest(modPath);
-                if (!manifest) {
-                    await this.deleteModManifest(modPath);
-                    return [];
-                }
-
-                for (const file of manifest.files) {
-                    const hasOtherOwner = await this.hasOtherShaderFixesOwner(
-                        modPath,
-                        modKey,
-                        file.targetKey,
-                    );
-                    if (hasOtherOwner) continue;
-
-                    if (await fse.pathExists(file.targetPath)) {
-                        const currentHash = await this.hashFile(file.targetPath);
-                        if (currentHash === file.hash) {
-                            processedFiles.push({ ...file, modKey, createdTarget: true });
-                            await fse.remove(file.targetPath);
-                        }
-                    }
-                }
-
                 await this.deleteModManifest(modPath);
             }
+        } catch (err) {
+            const shaderError = err instanceof Error ? err : new Error(String(err));
+            throw Object.assign(shaderError, { processedFiles });
+        }
+
+        return processedFiles;
+    }
+
+    private async disableShaders(modPath: string): Promise<ShaderFixesProcessedFile[]> {
+        const manifest = await this.readShaderFixesModManifest(modPath);
+        if (!manifest) return [];
+
+        const processedFiles: ShaderFixesProcessedFile[] = [];
+
+        try {
+            const otherOwnedTargetKeys = await this.getOtherOwnedShaderFixesTargetKeys(
+                modPath,
+                manifest.modKey,
+            );
+
+            for (const file of manifest.files) {
+                if (otherOwnedTargetKeys.has(file.targetKey)) continue;
+
+                if (await fse.pathExists(file.targetPath)) {
+                    const currentHash = await this.hashFile(file.targetPath);
+                    if (currentHash === file.hash) {
+                        processedFiles.push({
+                            ...file,
+                            modKey: manifest.modKey,
+                            createdTarget: true,
+                        });
+                        await fse.remove(file.targetPath);
+                    }
+                }
+            }
+
+            await this.deleteModManifest(modPath);
         } catch (err) {
             const shaderError = err instanceof Error ? err : new Error(String(err));
             throw Object.assign(shaderError, { processedFiles });


### PR DESCRIPTION
## Summary

- use the ShaderFixes manifest directly when disabling a mod
- collect ownership manifests once across deduplicated search roots
- preserve shared and user-modified ShaderFixes files
- add regression coverage for cleanup behavior and scan count

## Root cause

Disabling a mod recursively searched every configured mod and importer root once per ShaderFixes file to determine whether another mod owned the target. This made cleanup scale as the number of copied files multiplied by the size of the mod library.

## Impact

Mods containing ShaderFixes disable without repeatedly scanning the full mod library. The existing ownership and hash safeguards remain intact.

## Validation

- `pnpm test` — 81 tests passed
- `pnpm lint -- src/main/services/mod-manager/shader-fixes.ts src/main/services/mod-manager/shader-fixes.test.ts`
- `pnpm fmt -- src/main/services/mod-manager/shader-fixes.ts src/main/services/mod-manager/shader-fixes.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shader-fix cleanup when disabling mods.
  * Preserved shader fixes still used by other mods.
  * Prevented modified importer files from being overwritten.
  * Avoided unnecessary scans when no shader-fix manifest is available.
  * Improved handling of duplicate and nested shader-fix locations.

* **Tests**
  * Added coverage for shader-fix ownership, cleanup, file changes, and missing manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->