### PR TITLE
perf(mod): centralize ShaderFixes ownership

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahida-desktop",
-  "version": "2.52.1",
+  "version": "2.52.2",
   "description": "Native app for nahida.live",
   "homepage": "https://nahida.live",
   "author": "nahida.live",

--- a/src/main/services/mod-manager/shader-fixes.test.ts
+++ b/src/main/services/mod-manager/shader-fixes.test.ts
@@ -106,6 +106,7 @@ describe("ModShaderFixesService", () => {
             }),
         );
         await service.handleShaders(modPath, true);
+        assert.equal(atomicWriteState.calls, 2);
         await fse.remove(path.join(modPath, "ShaderFixes"));
         fastGlobCalls.length = 0;
 
@@ -210,6 +211,46 @@ describe("ModShaderFixesService", () => {
         await service.handleShaders(secondModPath, false);
         assert.deepEqual(fastGlobCalls, []);
         assert.equal(await fse.pathExists(targetPath), false);
+    });
+
+    it("cleans the original importer after an enabled mod is moved", async () => {
+        const originalModPath = path.join(modsPath, "Group", "Mod");
+        const originalTargetPath = path.join(importerPath, "ShaderFixes", "moved.ini");
+        await fse.outputFile(path.join(originalModPath, "ShaderFixes", "moved.ini"), "moved");
+        await service.handleShaders(originalModPath, true);
+
+        const otherImporterPath = path.join(rootPath, "OtherImporter");
+        const otherModsPath = path.join(otherImporterPath, "Mods");
+        const movedModPath = path.join(otherModsPath, "Group", "Mod");
+        await fse.ensureDir(path.dirname(movedModPath));
+        importers.push({ key: "OtherImporter", importerFolder: otherImporterPath });
+        games.push({ game: "Other", modFolderPath: otherModsPath, importer: "OtherImporter" });
+        await fse.move(originalModPath, movedModPath);
+        await fse.remove(path.join(importerPath, "ShaderFixes", SHADER_FIXES_MOD_MARKER_FILE));
+        fastGlobCalls.length = 0;
+
+        await service.handleShaders(movedModPath, false);
+
+        assert.deepEqual(fastGlobCalls, [
+            { pattern: `**/${SHADER_FIXES_MOD_MARKER_FILE}`, cwd: modsPath },
+        ]);
+        assert.equal(await fse.pathExists(originalTargetPath), false);
+        assert.equal(
+            await fse.pathExists(path.join(movedModPath, SHADER_FIXES_MOD_MARKER_FILE)),
+            false,
+        );
+        assert.deepEqual(
+            await fse.readJson(
+                path.join(importerPath, "ShaderFixes", SHADER_FIXES_MOD_MARKER_FILE),
+            ),
+            { version: 1, targets: {} },
+        );
+        assert.equal(
+            await fse.pathExists(
+                path.join(otherImporterPath, "ShaderFixes", SHADER_FIXES_MOD_MARKER_FILE),
+            ),
+            false,
+        );
     });
 
     it("rebuilds a corrupted owner index before deleting files", async () => {

--- a/src/main/services/mod-manager/shader-fixes.test.ts
+++ b/src/main/services/mod-manager/shader-fixes.test.ts
@@ -8,10 +8,14 @@ import { afterEach, beforeEach, describe, it, vi } from "vitest";
 
 import type { NahidaDesktop } from "../..";
 import type { ModLibraryService } from "./library";
+import type { ShaderFixesProcessedFile } from "./shader-fixes";
 
 import { ModShaderFixesService, SHADER_FIXES_MOD_MARKER_FILE } from "./shader-fixes";
 
-const fastGlobCalls = vi.hoisted(() => [] as (string | string[])[]);
+const fastGlobCalls = vi.hoisted(
+    () => [] as { pattern: string | string[]; cwd: string | undefined }[],
+);
+const atomicWriteState = vi.hoisted(() => ({ calls: 0, failOnCall: null as number | null }));
 
 vi.mock("fast-glob", async (importOriginal) => {
     const original = await importOriginal<typeof import("fast-glob")>();
@@ -20,7 +24,27 @@ vi.mock("fast-glob", async (importOriginal) => {
         ...original,
         default: new Proxy(fastGlob, {
             apply(target, thisArg, args) {
-                fastGlobCalls.push(args[0] as string | string[]);
+                fastGlobCalls.push({
+                    pattern: args[0] as string | string[],
+                    cwd: (args[1] as { cwd?: string } | undefined)?.cwd,
+                });
+                return Reflect.apply(target, thisArg, args);
+            },
+        }),
+    };
+});
+
+vi.mock("write-file-atomic", async (importOriginal) => {
+    const original = await importOriginal<typeof import("write-file-atomic")>();
+    const writeFileAtomic = Reflect.get(original, "default") as typeof import("write-file-atomic");
+    return {
+        ...original,
+        default: new Proxy(writeFileAtomic, {
+            apply(target, thisArg, args) {
+                atomicWriteState.calls += 1;
+                if (atomicWriteState.calls === atomicWriteState.failOnCall) {
+                    throw new Error("OWNER_INDEX_WRITE_FAILED");
+                }
                 return Reflect.apply(target, thisArg, args);
             },
         }),
@@ -32,20 +56,22 @@ describe("ModShaderFixesService", () => {
     let importerPath: string;
     let modsPath: string;
     let service: ModShaderFixesService;
+    let importers: { key: string; importerFolder: string }[];
+    let games: { game: string; modFolderPath: string; importer: string }[];
 
     beforeEach(async () => {
         rootPath = await fse.mkdtemp(path.join(os.tmpdir(), "nahida-shader-fixes-"));
         importerPath = path.join(rootPath, "Importer");
         modsPath = path.join(importerPath, "Mods");
         await fse.ensureDir(modsPath);
+        importers = [{ key: "Importer", importerFolder: importerPath }];
+        games = [{ game: "Test", modFolderPath: modsPath, importer: "Importer" }];
 
         service = new ModShaderFixesService(
             {
                 service: {
                     xxmi: {
-                        getEnabledImporters: () => [
-                            { key: "Importer", importerFolder: importerPath },
-                        ],
+                        getEnabledImporters: () => importers,
                     },
                 },
                 lib: {
@@ -59,18 +85,20 @@ describe("ModShaderFixesService", () => {
                 logger: { error: vi.fn() },
             } as unknown as NahidaDesktop,
             {
-                games: async () => [{ modFolderPath: modsPath }],
+                games: async () => games,
             } as unknown as ModLibraryService,
         );
 
         fastGlobCalls.length = 0;
+        atomicWriteState.calls = 0;
+        atomicWriteState.failOnCall = null;
     });
 
     afterEach(async () => {
         await fse.remove(rootPath);
     });
 
-    it("uses the manifest directly and scans owners once when disabling", async () => {
+    it("uses the central owner index without scanning when disabling", async () => {
         const modPath = path.join(modsPath, "Group", "Mod");
         await Promise.all(
             ["a.ini", "nested/b.ini", "nested/c.ini"].map(async (file) => {
@@ -83,9 +111,15 @@ describe("ModShaderFixesService", () => {
 
         await service.handleShaders(modPath, false);
 
-        assert.deepEqual(fastGlobCalls, [`**/${SHADER_FIXES_MOD_MARKER_FILE}`]);
+        assert.deepEqual(fastGlobCalls, []);
         assert.equal(await fse.pathExists(path.join(importerPath, "ShaderFixes", "a.ini")), false);
         assert.equal(await fse.pathExists(path.join(modPath, SHADER_FIXES_MOD_MARKER_FILE)), false);
+        assert.deepEqual(
+            await fse.readJson(
+                path.join(importerPath, "ShaderFixes", SHADER_FIXES_MOD_MARKER_FILE),
+            ),
+            { version: 1, targets: {} },
+        );
     });
 
     it("preserves a shader fix while another mod owns it", async () => {
@@ -122,6 +156,164 @@ describe("ModShaderFixesService", () => {
 
         assert.equal(await fse.readFile(targetPath, "utf8"), "changed");
         assert.equal(await fse.pathExists(path.join(modPath, SHADER_FIXES_MOD_MARKER_FILE)), false);
+    });
+
+    it("migrates existing manifests by scanning only the current importer mods", async () => {
+        const firstModPath = path.join(modsPath, "Group", "First");
+        const secondModPath = path.join(modsPath, "Group", "Second");
+        const targetPath = path.join(importerPath, "ShaderFixes", "shared.ini");
+        const hash = createHash("sha256").update("shared").digest("hex");
+        await fse.outputFile(targetPath, "shared");
+        await Promise.all(
+            [
+                { modPath: firstModPath, modKey: "first" },
+                { modPath: secondModPath, modKey: "second" },
+            ].map(async ({ modPath, modKey }) => {
+                await fse.outputJson(path.join(modPath, SHADER_FIXES_MOD_MARKER_FILE), {
+                    version: 1,
+                    modKey,
+                    files: [
+                        {
+                            file: "shared.ini",
+                            targetPath,
+                            targetKey: "legacy-target-key",
+                            hash,
+                        },
+                    ],
+                });
+            }),
+        );
+        const otherImporterPath = path.join(rootPath, "OtherImporter");
+        const otherModsPath = path.join(otherImporterPath, "Mods");
+        await fse.ensureDir(otherModsPath);
+        importers.push({ key: "OtherImporter", importerFolder: otherImporterPath });
+        games.push({ game: "Other", modFolderPath: otherModsPath, importer: "OtherImporter" });
+        fastGlobCalls.length = 0;
+
+        await service.handleShaders(firstModPath, false);
+
+        assert.deepEqual(fastGlobCalls, [
+            { pattern: `**/${SHADER_FIXES_MOD_MARKER_FILE}`, cwd: modsPath },
+        ]);
+        assert.equal(await fse.pathExists(targetPath), true);
+        assert.deepEqual(
+            await fse.readJson(
+                path.join(importerPath, "ShaderFixes", SHADER_FIXES_MOD_MARKER_FILE),
+            ),
+            {
+                version: 1,
+                targets: { "shared.ini": { hash, owners: ["second"] } },
+            },
+        );
+
+        fastGlobCalls.length = 0;
+        await service.handleShaders(secondModPath, false);
+        assert.deepEqual(fastGlobCalls, []);
+        assert.equal(await fse.pathExists(targetPath), false);
+    });
+
+    it("rebuilds a corrupted owner index before deleting files", async () => {
+        const modPath = path.join(modsPath, "Group", "Mod");
+        const targetPath = path.join(importerPath, "ShaderFixes", "legacy.ini");
+        const hash = createHash("sha256").update("legacy").digest("hex");
+        await fse.outputFile(targetPath, "legacy");
+        await fse.outputJson(path.join(modPath, SHADER_FIXES_MOD_MARKER_FILE), {
+            version: 1,
+            modKey: "legacy",
+            files: [
+                {
+                    file: "legacy.ini",
+                    targetPath,
+                    targetKey: "legacy-target-key",
+                    hash,
+                },
+            ],
+        });
+        await fse.writeFile(
+            path.join(importerPath, "ShaderFixes", SHADER_FIXES_MOD_MARKER_FILE),
+            "invalid",
+        );
+        fastGlobCalls.length = 0;
+
+        await service.handleShaders(modPath, false);
+
+        assert.deepEqual(fastGlobCalls, [
+            { pattern: `**/${SHADER_FIXES_MOD_MARKER_FILE}`, cwd: modsPath },
+        ]);
+        assert.equal(await fse.pathExists(targetPath), false);
+    });
+
+    it("removes owner state when an enable operation is rolled back", async () => {
+        const modPath = path.join(modsPath, "Group", "Mod");
+        const targetPath = path.join(importerPath, "ShaderFixes", "rollback.ini");
+        await fse.outputFile(path.join(modPath, "ShaderFixes", "rollback.ini"), "rollback");
+
+        const processedFiles = await service.handleShaders(modPath, true);
+        await service.rollbackEnabledShaders(modPath, processedFiles);
+
+        assert.equal(await fse.pathExists(targetPath), false);
+        assert.deepEqual(
+            await fse.readJson(
+                path.join(importerPath, "ShaderFixes", SHADER_FIXES_MOD_MARKER_FILE),
+            ),
+            { version: 1, targets: {} },
+        );
+        assert.equal(await fse.pathExists(path.join(modPath, SHADER_FIXES_MOD_MARKER_FILE)), false);
+    });
+
+    it("can roll back when saving owner state fails during enable", async () => {
+        const modPath = path.join(modsPath, "Group", "Mod");
+        const targetPath = path.join(importerPath, "ShaderFixes", "rollback.ini");
+        await fse.outputFile(path.join(modPath, "ShaderFixes", "rollback.ini"), "rollback");
+        atomicWriteState.failOnCall = 2;
+
+        const error = await service
+            .handleShaders(modPath, true)
+            .catch((failure: unknown) => failure);
+        assert.equal(error instanceof Error, true);
+        const processedFiles = (error as { processedFiles: ShaderFixesProcessedFile[] })
+            .processedFiles;
+        assert.equal(processedFiles.length, 1);
+
+        atomicWriteState.failOnCall = null;
+        await service.rollbackEnabledShaders(modPath, processedFiles);
+
+        assert.equal(await fse.pathExists(targetPath), false);
+        assert.deepEqual(
+            await fse.readJson(
+                path.join(importerPath, "ShaderFixes", SHADER_FIXES_MOD_MARKER_FILE),
+            ),
+            { version: 1, targets: {} },
+        );
+    });
+
+    it("does not copy the reserved owner index from a mod ShaderFixes folder", async () => {
+        const modPath = path.join(modsPath, "Group", "Mod");
+        await fse.outputFile(path.join(modPath, "ShaderFixes", "actual.ini"), "actual");
+        await fse.outputFile(
+            path.join(modPath, "ShaderFixes", SHADER_FIXES_MOD_MARKER_FILE),
+            "reserved",
+        );
+
+        await service.handleShaders(modPath, true);
+
+        assert.deepEqual(
+            await fse.readJson(
+                path.join(importerPath, "ShaderFixes", SHADER_FIXES_MOD_MARKER_FILE),
+            ),
+            {
+                version: 1,
+                targets: {
+                    "actual.ini": {
+                        hash: createHash("sha256").update("actual").digest("hex"),
+                        owners: [
+                            (await fse.readJson(path.join(modPath, SHADER_FIXES_MOD_MARKER_FILE)))
+                                .modKey,
+                        ],
+                    },
+                },
+            },
+        );
     });
 
     it("does not scan the mod when no manifest exists", async () => {

--- a/src/main/services/mod-manager/shader-fixes.ts
+++ b/src/main/services/mod-manager/shader-fixes.ts
@@ -5,6 +5,7 @@ import { getMatchingImporter } from "@shared/xxmi-match";
 import fg from "fast-glob";
 import fse from "fs-extra";
 import { nanoid } from "nanoid";
+import writeFileAtomic from "write-file-atomic";
 
 import type { NahidaDesktop } from "../..";
 import type { ModLibraryService } from "./library";
@@ -29,6 +30,16 @@ interface ShaderFixesFileCandidate {
     sourcePath: string;
 }
 
+interface ShaderFixesOwnerIndexTarget {
+    hash: string;
+    owners: string[];
+}
+
+interface ShaderFixesOwnerIndex {
+    version: number;
+    targets: Record<string, ShaderFixesOwnerIndexTarget>;
+}
+
 export interface ShaderFixesProcessedFile extends ShaderFixesModManifestFile {
     modKey: string;
     createdTarget: boolean;
@@ -37,6 +48,7 @@ export interface ShaderFixesProcessedFile extends ShaderFixesModManifestFile {
 const SHADER_FIXES_DIR_NAME = "ShaderFixes";
 export const SHADER_FIXES_MOD_MARKER_FILE = ".nahida-shader-fixes.json";
 const SHADER_FIXES_MOD_MARKER_VERSION = 1;
+const SHADER_FIXES_OWNER_INDEX_VERSION = 1;
 
 export class ModShaderFixesService {
     private shaderOperationQueue: Promise<void> = Promise.resolve();
@@ -61,15 +73,47 @@ export class ModShaderFixesService {
     ): Promise<void> {
         await this.withShaderOperationLock(async () => {
             let rollbackError: unknown = null;
+            const globalShaderPath = await this.getGlobalShaderFixesPath(modPath);
+            const ownerIndex = globalShaderPath
+                ? await this.getShaderFixesOwnerIndex(modPath, globalShaderPath)
+                : null;
 
             for (const file of [...processedShaders].reverse()) {
                 try {
+                    const targetKey = globalShaderPath
+                        ? this.getShaderFixesOwnerTargetKey(globalShaderPath, file.targetPath)
+                        : null;
+                    const target = targetKey ? ownerIndex?.targets[targetKey] : null;
+                    const remainingOwners = target?.owners.filter((owner) => owner !== file.modKey);
+                    if (
+                        targetKey &&
+                        target &&
+                        remainingOwners &&
+                        remainingOwners.length > 0 &&
+                        ownerIndex
+                    ) {
+                        ownerIndex.targets[targetKey] = {
+                            ...target,
+                            owners: remainingOwners,
+                        };
+                        continue;
+                    }
+                    if (targetKey && target && ownerIndex) delete ownerIndex.targets[targetKey];
+
                     if (file.createdTarget && (await fse.pathExists(file.targetPath))) {
                         const currentHash = await this.hashFile(file.targetPath);
                         if (currentHash === file.hash) {
                             await fse.remove(file.targetPath);
                         }
                     }
+                } catch (error) {
+                    rollbackError = error;
+                }
+            }
+
+            if (globalShaderPath && ownerIndex) {
+                try {
+                    await this.writeShaderFixesOwnerIndex(globalShaderPath, ownerIndex);
                 } catch (error) {
                     rollbackError = error;
                 }
@@ -227,25 +271,126 @@ export class ModShaderFixesService {
         await fse.writeJson(this.getShaderFixesModManifestPath(modPath), manifest, { spaces: 2 });
     }
 
-    private async getShaderFixesManifestSearchRoots(modPath: string): Promise<string[]> {
+    private getShaderFixesOwnerIndexPath(globalShaderPath: string): string {
+        return path.join(globalShaderPath, SHADER_FIXES_MOD_MARKER_FILE);
+    }
+
+    private validateShaderFixesOwnerIndex(index: unknown): ShaderFixesOwnerIndex | null {
+        if (!index || typeof index !== "object") return null;
+
+        const candidate = index as Partial<ShaderFixesOwnerIndex>;
+        if (
+            candidate.version !== SHADER_FIXES_OWNER_INDEX_VERSION ||
+            !candidate.targets ||
+            typeof candidate.targets !== "object" ||
+            Array.isArray(candidate.targets)
+        ) {
+            return null;
+        }
+
+        const targets = Object.fromEntries(
+            Object.entries(candidate.targets).flatMap(([targetKey, target]) => {
+                if (
+                    !target ||
+                    typeof target !== "object" ||
+                    typeof target.hash !== "string" ||
+                    !Array.isArray(target.owners)
+                ) {
+                    return [];
+                }
+
+                const normalizedTargetKey = this.normalizeShaderFixesOwnerTargetKey(targetKey);
+                const owners = Array.from(
+                    new Set(
+                        target.owners.filter(
+                            (owner): owner is string =>
+                                typeof owner === "string" && owner.length > 0,
+                        ),
+                    ),
+                );
+                if (!normalizedTargetKey || owners.length === 0) return [];
+
+                return [[normalizedTargetKey, { hash: target.hash, owners }]];
+            }),
+        );
+        if (Object.keys(targets).length !== Object.keys(candidate.targets).length) return null;
+
+        return {
+            version: SHADER_FIXES_OWNER_INDEX_VERSION,
+            targets,
+        };
+    }
+
+    private async readShaderFixesOwnerIndex(
+        globalShaderPath: string,
+    ): Promise<ShaderFixesOwnerIndex | null> {
+        const indexPath = this.getShaderFixesOwnerIndexPath(globalShaderPath);
+        try {
+            const index = this.validateShaderFixesOwnerIndex(await fse.readJson(indexPath));
+            if (index) return index;
+            this.desktop.logger.error(
+                new Error("INVALID_SHADER_FIXES_OWNER_INDEX"),
+                `Mod:readShaderFixesOwnerIndex:${indexPath}`,
+            );
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+                this.desktop.logger.error(error, `Mod:readShaderFixesOwnerIndex:${indexPath}`);
+            }
+        }
+
+        return null;
+    }
+
+    private async writeShaderFixesOwnerIndex(
+        globalShaderPath: string,
+        index: ShaderFixesOwnerIndex,
+    ): Promise<void> {
+        await fse.ensureDir(globalShaderPath);
+        await writeFileAtomic(
+            this.getShaderFixesOwnerIndexPath(globalShaderPath),
+            `${JSON.stringify(index, null, 2)}\n`,
+        );
+    }
+
+    private async getShaderFixesManifestSearchRoots(
+        modPath: string,
+        globalShaderPath: string,
+    ): Promise<string[]> {
         const roots = new Map<string, string>();
         const addRoot = (root: string) => {
             const resolvedRoot = path.resolve(root);
             roots.set(normalizeModPath(resolvedRoot), resolvedRoot);
         };
-        addRoot(path.dirname(modPath));
 
         try {
+            const importers = this.desktop.service.xxmi.getEnabledImporters();
             for (const game of await this.library.games()) {
-                addRoot(game.modFolderPath);
+                const importerKey =
+                    game.importer ??
+                    getMatchingImporter(
+                        game.game,
+                        importers.map((importer) => importer.key),
+                    );
+                const importer = importers.find(
+                    (candidate) => candidate.key.toUpperCase() === importerKey?.toUpperCase(),
+                );
+                if (
+                    importer &&
+                    normalizeModPath(path.join(importer.importerFolder, SHADER_FIXES_DIR_NAME)) ===
+                        normalizeModPath(globalShaderPath)
+                ) {
+                    addRoot(game.modFolderPath);
+                }
             }
         } catch (error) {
             this.desktop.logger.error(error, "Mod:getShaderFixesManifestSearchRoots:games");
         }
 
-        for (const importer of this.desktop.service.xxmi.getEnabledImporters()) {
-            addRoot(importer.importerFolder);
+        const conventionalModsPath = path.join(path.dirname(globalShaderPath), "Mods");
+        if (isSameOrChildPath(conventionalModsPath, modPath)) {
+            addRoot(conventionalModsPath);
         }
+        if (roots.size === 0) addRoot(path.dirname(modPath));
 
         const existingRoots = (
             await Promise.all(
@@ -265,38 +410,67 @@ export class ModShaderFixesService {
         );
     }
 
-    private async getOtherOwnedShaderFixesTargetKeys(
+    private async rebuildShaderFixesOwnerIndex(
         modPath: string,
-        modKey: string,
-    ): Promise<Set<string>> {
+        globalShaderPath: string,
+    ): Promise<ShaderFixesOwnerIndex> {
         const manifestPaths = new Map<string, string>();
         await Promise.all(
-            (await this.getShaderFixesManifestSearchRoots(modPath)).map(async (root) => {
-                for (const manifestFile of await fg(`**/${SHADER_FIXES_MOD_MARKER_FILE}`, {
-                    cwd: root,
-                    onlyFiles: true,
-                    dot: true,
-                    ignore: [`**/${SHADER_FIXES_DIR_NAME}/**`],
-                })) {
-                    const manifestPath = path.join(root, manifestFile);
-                    manifestPaths.set(normalizeModPath(manifestPath), manifestPath);
-                }
-            }),
+            (await this.getShaderFixesManifestSearchRoots(modPath, globalShaderPath)).map(
+                async (root) => {
+                    for (const manifestFile of await fg(`**/${SHADER_FIXES_MOD_MARKER_FILE}`, {
+                        cwd: root,
+                        onlyFiles: true,
+                        dot: true,
+                        ignore: [`**/${SHADER_FIXES_DIR_NAME}/**`],
+                    })) {
+                        const manifestPath = path.join(root, manifestFile);
+                        manifestPaths.set(normalizeModPath(manifestPath), manifestPath);
+                    }
+                },
+            ),
         );
 
-        return new Set(
-            (
-                await Promise.all(
-                    Array.from(manifestPaths.values()).map(
-                        async (manifestPath) =>
-                            await this.readShaderFixesModManifestFile(manifestPath),
-                    ),
-                )
-            ).flatMap((manifest) =>
-                manifest && manifest.modKey !== modKey
-                    ? manifest.files.map((file) => file.targetKey)
-                    : [],
+        const index: ShaderFixesOwnerIndex = {
+            version: SHADER_FIXES_OWNER_INDEX_VERSION,
+            targets: {},
+        };
+        for (const manifest of await Promise.all(
+            Array.from(manifestPaths.values()).map(
+                async (manifestPath) => await this.readShaderFixesModManifestFile(manifestPath),
             ),
+        )) {
+            if (!manifest) continue;
+
+            for (const file of manifest.files) {
+                const targetKey = this.getShaderFixesOwnerTargetKey(
+                    globalShaderPath,
+                    file.targetPath,
+                );
+                if (!targetKey) continue;
+
+                const target = index.targets[targetKey];
+                if (!target) {
+                    index.targets[targetKey] = { hash: file.hash, owners: [manifest.modKey] };
+                    continue;
+                }
+                if (target.hash === file.hash && !target.owners.includes(manifest.modKey)) {
+                    target.owners.push(manifest.modKey);
+                }
+            }
+        }
+
+        await this.writeShaderFixesOwnerIndex(globalShaderPath, index);
+        return index;
+    }
+
+    private async getShaderFixesOwnerIndex(
+        modPath: string,
+        globalShaderPath: string,
+    ): Promise<ShaderFixesOwnerIndex> {
+        return (
+            (await this.readShaderFixesOwnerIndex(globalShaderPath)) ??
+            (await this.rebuildShaderFixesOwnerIndex(modPath, globalShaderPath))
         );
     }
 
@@ -326,6 +500,27 @@ export class ModShaderFixesService {
             .split(/[\\/]+/)
             .filter(Boolean)
             .join("/");
+    }
+
+    private normalizeShaderFixesOwnerTargetKey(targetPath: string): string | null {
+        const normalizedPath = this.normalizeShaderFixesRelativePath(targetPath);
+        if (
+            !normalizedPath ||
+            path.isAbsolute(targetPath) ||
+            normalizedPath.split("/").includes("..") ||
+            normalizedPath.toLowerCase() === SHADER_FIXES_MOD_MARKER_FILE.toLowerCase()
+        ) {
+            return null;
+        }
+        return normalizedPath.toLowerCase();
+    }
+
+    private getShaderFixesOwnerTargetKey(
+        globalShaderPath: string,
+        targetPath: string,
+    ): string | null {
+        if (!isSameOrChildPath(globalShaderPath, targetPath)) return null;
+        return this.normalizeShaderFixesOwnerTargetKey(path.relative(globalShaderPath, targetPath));
     }
 
     private async getShaderFixesFileCandidates(
@@ -360,6 +555,7 @@ export class ModShaderFixesService {
                 cwd: shaderPath,
                 onlyFiles: true,
                 dot: true,
+                ignore: [`**/${SHADER_FIXES_MOD_MARKER_FILE}`],
             });
 
             for (const file of files.sort((a, b) => a.localeCompare(b))) {
@@ -389,6 +585,7 @@ export class ModShaderFixesService {
 
         try {
             const modKey = await this.getShaderFixesModKey(modPath, true);
+            const ownerIndex = await this.getShaderFixesOwnerIndex(modPath, globalShaderPath);
             const manifest: ShaderFixesModManifest = {
                 version: SHADER_FIXES_MOD_MARKER_VERSION,
                 modKey,
@@ -404,19 +601,26 @@ export class ModShaderFixesService {
 
                 if (targetExists) {
                     const currentHash = await this.hashFile(target);
-                    if (currentHash === hash) {
-                        const manifestFile = { file, targetPath: target, targetKey, hash };
-                        manifest.files.push(manifestFile);
-                        processedFiles.push({ ...manifestFile, modKey, createdTarget: false });
-                        await this.writeShaderFixesModManifest(modPath, manifest);
-                    }
-                    continue;
+                    if (currentHash !== hash) continue;
+                } else {
+                    await fse.copy(source, target);
                 }
 
-                await fse.copy(source, target);
                 const manifestFile = { file, targetPath: target, targetKey, hash };
                 manifest.files.push(manifestFile);
-                processedFiles.push({ ...manifestFile, modKey, createdTarget: true });
+                processedFiles.push({ ...manifestFile, modKey, createdTarget: !targetExists });
+
+                const ownerTargetKey = this.normalizeShaderFixesOwnerTargetKey(file);
+                if (!ownerTargetKey) continue;
+                const indexedTarget = ownerIndex.targets[ownerTargetKey];
+                ownerIndex.targets[ownerTargetKey] = {
+                    hash,
+                    owners:
+                        indexedTarget?.hash === hash
+                            ? Array.from(new Set([...indexedTarget.owners, modKey]))
+                            : [modKey],
+                };
+                await this.writeShaderFixesOwnerIndex(globalShaderPath, ownerIndex);
                 await this.writeShaderFixesModManifest(modPath, manifest);
             }
 
@@ -437,16 +641,45 @@ export class ModShaderFixesService {
         const manifest = await this.readShaderFixesModManifest(modPath);
         if (!manifest) return [];
 
+        const globalShaderPath = await this.getGlobalShaderFixesPath(modPath);
+        if (!globalShaderPath) return [];
+
         const processedFiles: ShaderFixesProcessedFile[] = [];
 
         try {
-            const otherOwnedTargetKeys = await this.getOtherOwnedShaderFixesTargetKeys(
+            const currentOwnerIndex = await this.getShaderFixesOwnerIndex(
                 modPath,
-                manifest.modKey,
+                globalShaderPath,
             );
+            const missingOwner = manifest.files.some((file) => {
+                const targetKey = this.getShaderFixesOwnerTargetKey(
+                    globalShaderPath,
+                    file.targetPath,
+                );
+                return (
+                    targetKey &&
+                    !currentOwnerIndex.targets[targetKey]?.owners.includes(manifest.modKey)
+                );
+            });
+            const ownerIndex = missingOwner
+                ? await this.rebuildShaderFixesOwnerIndex(modPath, globalShaderPath)
+                : currentOwnerIndex;
 
             for (const file of manifest.files) {
-                if (otherOwnedTargetKeys.has(file.targetKey)) continue;
+                const targetKey = this.getShaderFixesOwnerTargetKey(
+                    globalShaderPath,
+                    file.targetPath,
+                );
+                if (!targetKey) continue;
+
+                const target = ownerIndex.targets[targetKey];
+                if (!target?.owners.includes(manifest.modKey)) continue;
+
+                const remainingOwners = target.owners.filter((owner) => owner !== manifest.modKey);
+                if (remainingOwners.length > 0) {
+                    ownerIndex.targets[targetKey] = { ...target, owners: remainingOwners };
+                    continue;
+                }
 
                 if (await fse.pathExists(file.targetPath)) {
                     const currentHash = await this.hashFile(file.targetPath);
@@ -459,8 +692,10 @@ export class ModShaderFixesService {
                         await fse.remove(file.targetPath);
                     }
                 }
+                delete ownerIndex.targets[targetKey];
             }
 
+            await this.writeShaderFixesOwnerIndex(globalShaderPath, ownerIndex);
             await this.deleteModManifest(modPath);
         } catch (err) {
             const shaderError = err instanceof Error ? err : new Error(String(err));

--- a/src/main/services/mod-manager/shader-fixes.ts
+++ b/src/main/services/mod-manager/shader-fixes.ts
@@ -415,6 +415,10 @@ export class ModShaderFixesService {
         globalShaderPath: string,
     ): Promise<ShaderFixesOwnerIndex> {
         const manifestPaths = new Map<string, string>();
+        const currentManifestPath = this.getShaderFixesModManifestPath(modPath);
+        if (await fse.pathExists(currentManifestPath)) {
+            manifestPaths.set(normalizeModPath(currentManifestPath), currentManifestPath);
+        }
         await Promise.all(
             (await this.getShaderFixesManifestSearchRoots(modPath, globalShaderPath)).map(
                 async (root) => {
@@ -523,6 +527,23 @@ export class ModShaderFixesService {
         return this.normalizeShaderFixesOwnerTargetKey(path.relative(globalShaderPath, targetPath));
     }
 
+    private getShaderFixesPathFromManifestFile(file: ShaderFixesModManifestFile): string | null {
+        const relativePath = this.normalizeShaderFixesOwnerTargetKey(file.file);
+        if (!relativePath) return null;
+
+        const globalShaderPath = relativePath
+            .split("/")
+            .reduce((currentPath) => path.dirname(currentPath), path.resolve(file.targetPath));
+        if (
+            path.basename(globalShaderPath).toLowerCase() !== SHADER_FIXES_DIR_NAME.toLowerCase() ||
+            normalizeModPath(path.join(globalShaderPath, relativePath)) !==
+                normalizeModPath(path.resolve(file.targetPath))
+        ) {
+            return null;
+        }
+        return globalShaderPath;
+    }
+
     private async getShaderFixesFileCandidates(
         modPath: string,
     ): Promise<ShaderFixesFileCandidate[]> {
@@ -620,11 +641,11 @@ export class ModShaderFixesService {
                             ? Array.from(new Set([...indexedTarget.owners, modKey]))
                             : [modKey],
                 };
-                await this.writeShaderFixesOwnerIndex(globalShaderPath, ownerIndex);
                 await this.writeShaderFixesModManifest(modPath, manifest);
             }
 
             if (manifest.files.length > 0) {
+                await this.writeShaderFixesOwnerIndex(globalShaderPath, ownerIndex);
                 await this.writeShaderFixesModManifest(modPath, manifest);
             } else {
                 await this.deleteModManifest(modPath);
@@ -641,61 +662,65 @@ export class ModShaderFixesService {
         const manifest = await this.readShaderFixesModManifest(modPath);
         if (!manifest) return [];
 
-        const globalShaderPath = await this.getGlobalShaderFixesPath(modPath);
-        if (!globalShaderPath) return [];
-
         const processedFiles: ShaderFixesProcessedFile[] = [];
 
         try {
-            const currentOwnerIndex = await this.getShaderFixesOwnerIndex(
-                modPath,
-                globalShaderPath,
-            );
-            const missingOwner = manifest.files.some((file) => {
-                const targetKey = this.getShaderFixesOwnerTargetKey(
-                    globalShaderPath,
-                    file.targetPath,
+            for (const group of this.groupShaderFixesManifestFilesByImporter(
+                manifest.files,
+            ).values()) {
+                const currentOwnerIndex = await this.getShaderFixesOwnerIndex(
+                    modPath,
+                    group.globalShaderPath,
                 );
-                return (
-                    targetKey &&
-                    !currentOwnerIndex.targets[targetKey]?.owners.includes(manifest.modKey)
-                );
-            });
-            const ownerIndex = missingOwner
-                ? await this.rebuildShaderFixesOwnerIndex(modPath, globalShaderPath)
-                : currentOwnerIndex;
+                const missingOwner = group.files.some((file) => {
+                    const targetKey = this.getShaderFixesOwnerTargetKey(
+                        group.globalShaderPath,
+                        file.targetPath,
+                    );
+                    return (
+                        targetKey &&
+                        !currentOwnerIndex.targets[targetKey]?.owners.includes(manifest.modKey)
+                    );
+                });
+                const ownerIndex = missingOwner
+                    ? await this.rebuildShaderFixesOwnerIndex(modPath, group.globalShaderPath)
+                    : currentOwnerIndex;
 
-            for (const file of manifest.files) {
-                const targetKey = this.getShaderFixesOwnerTargetKey(
-                    globalShaderPath,
-                    file.targetPath,
-                );
-                if (!targetKey) continue;
+                for (const file of group.files) {
+                    const targetKey = this.getShaderFixesOwnerTargetKey(
+                        group.globalShaderPath,
+                        file.targetPath,
+                    );
+                    if (!targetKey) continue;
 
-                const target = ownerIndex.targets[targetKey];
-                if (!target?.owners.includes(manifest.modKey)) continue;
+                    const target = ownerIndex.targets[targetKey];
+                    if (!target?.owners.includes(manifest.modKey)) continue;
 
-                const remainingOwners = target.owners.filter((owner) => owner !== manifest.modKey);
-                if (remainingOwners.length > 0) {
-                    ownerIndex.targets[targetKey] = { ...target, owners: remainingOwners };
-                    continue;
-                }
-
-                if (await fse.pathExists(file.targetPath)) {
-                    const currentHash = await this.hashFile(file.targetPath);
-                    if (currentHash === file.hash) {
-                        processedFiles.push({
-                            ...file,
-                            modKey: manifest.modKey,
-                            createdTarget: true,
-                        });
-                        await fse.remove(file.targetPath);
+                    const remainingOwners = target.owners.filter(
+                        (owner) => owner !== manifest.modKey,
+                    );
+                    if (remainingOwners.length > 0) {
+                        ownerIndex.targets[targetKey] = { ...target, owners: remainingOwners };
+                        continue;
                     }
+
+                    if (await fse.pathExists(file.targetPath)) {
+                        const currentHash = await this.hashFile(file.targetPath);
+                        if (currentHash === file.hash) {
+                            processedFiles.push({
+                                ...file,
+                                modKey: manifest.modKey,
+                                createdTarget: true,
+                            });
+                            await fse.remove(file.targetPath);
+                        }
+                    }
+                    delete ownerIndex.targets[targetKey];
                 }
-                delete ownerIndex.targets[targetKey];
+
+                await this.writeShaderFixesOwnerIndex(group.globalShaderPath, ownerIndex);
             }
 
-            await this.writeShaderFixesOwnerIndex(globalShaderPath, ownerIndex);
             await this.deleteModManifest(modPath);
         } catch (err) {
             const shaderError = err instanceof Error ? err : new Error(String(err));
@@ -703,5 +728,22 @@ export class ModShaderFixesService {
         }
 
         return processedFiles;
+    }
+
+    private groupShaderFixesManifestFilesByImporter(files: ShaderFixesModManifestFile[]) {
+        return files.reduce((groups, file) => {
+            const globalShaderPath = this.getShaderFixesPathFromManifestFile(file);
+            if (!globalShaderPath) return groups;
+
+            const groupKey = normalizeModPath(globalShaderPath);
+            const group = groups.get(groupKey);
+            if (group) {
+                group.files.push(file);
+                return groups;
+            }
+
+            groups.set(groupKey, { globalShaderPath, files: [file] });
+            return groups;
+        }, new Map<string, { globalShaderPath: string; files: ShaderFixesModManifestFile[] }>());
     }
 }


### PR DESCRIPTION
## Summary

- store ShaderFixes ownership in one central index per Importer
- eliminate recursive manifest searches during normal mod disable operations
- migrate existing per-mod manifests by scanning only the current Importer's Mods folder once
- keep shared, modified, and rollback-managed ShaderFixes files safe
- bump the application version to 2.52.2

## Root cause

Disabling a mod with ShaderFixes recursively searched every enabled Importer to determine whether copied files had other owners. Even after reducing repeated scans, every disable still paid the cost of a full library traversal.

## User impact

After the one-time migration, disabling ShaderFixes mods reads a single owner index and performs no recursive ownership scan. Performance no longer depends on the total size of all configured mod libraries.

## Validation

- `pnpm test` — 86 tests passed
- `pnpm lint -- src/main/services/mod-manager/shader-fixes.ts src/main/services/mod-manager/shader-fixes.test.ts`
- normal disable path verified with zero `fast-glob` calls
- migration verified to scan only the current Importer's Mods folder
- owner index write failure and rollback coverage added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shader-fix management when mods move between importers.
  - Prevented stale shader-fix files from being removed while still in use.
  - Added recovery for corrupted shader-fix tracking data.
  - Improved rollback behavior when enabling or saving shader fixes fails.
  - Added safeguards against unsafe shader-fix paths and invalid manifest files.

- **Chores**
  - Updated the application version to 2.52.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->