### PR TITLE
feat: improve mod manager and GameBanana browsing

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,9 @@
 appId: com.nahida.app
 productName: Nahida Desktop
+protocols:
+    - name: Nahida Desktop
+      schemes:
+          - nahida
 directories:
     buildResources: build
 files:

--- a/native/mod-manager/src/lib.rs
+++ b/native/mod-manager/src/lib.rs
@@ -57,6 +57,7 @@ pub struct FolderGroup {
     pub mods: Vec<ModInfo>,
     pub preview: Option<String>,
     pub mod_count: u32,
+    pub enabled_mod_count: u32,
 }
 
 fn get_map_value(data: &mut HashMap<String, String>, key: &str) -> Option<String> {
@@ -542,12 +543,23 @@ pub fn get_characters_folder_sync(
 
             let path_str = group_path.to_string_lossy().to_string();
 
-            let mod_count = match fs::read_dir(group_path) {
+            let (mod_count, enabled_mod_count) = match fs::read_dir(group_path) {
                 Ok(entries) => entries
                     .filter_map(|e| e.ok())
-                    .filter(|e| e.path().is_dir() && has_any_file(&e.path()))
-                    .count() as u32,
-                Err(_) => 0,
+                    .filter_map(|entry| {
+                        let mod_path = entry.path();
+                        if !mod_path.is_dir() || !has_any_file(&mod_path) {
+                            return None;
+                        }
+
+                        Some(!is_disabled_folder_name(
+                            &entry.file_name().to_string_lossy(),
+                        ))
+                    })
+                    .fold((0, 0), |(total, enabled), is_enabled| {
+                        (total + 1, enabled + u32::from(is_enabled))
+                    }),
+                Err(_) => (0, 0),
             };
 
             let preview = find_group_preview(group_path, search_depth);
@@ -558,6 +570,7 @@ pub fn get_characters_folder_sync(
                 mods: Vec::new(),
                 preview,
                 mod_count,
+                enabled_mod_count,
             }
         })
         .collect();
@@ -712,6 +725,7 @@ pub fn get_mods_sync(group_path: String) -> FolderGroup {
     mods.sort_by(|a, b| compare_str(&a.name, &b.name));
 
     let mod_count = mods.len() as u32;
+    let enabled_mod_count = mods.iter().filter(|mod_info| mod_info.is_enabled).count() as u32;
 
     FolderGroup {
         name: group_name,
@@ -719,14 +733,16 @@ pub fn get_mods_sync(group_path: String) -> FolderGroup {
         mods,
         preview,
         mod_count,
+        enabled_mod_count,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        find_group_preview, is_disabled_folder_name, normalize_relative_path, parse_ini,
-        scan_mod_folder, strip_disabled_prefix, strip_line_comment, strip_value_comment,
+        find_group_preview, get_characters_folder_sync, is_disabled_folder_name,
+        normalize_relative_path, parse_ini, scan_mod_folder, strip_disabled_prefix,
+        strip_line_comment, strip_value_comment,
     };
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -829,6 +845,20 @@ mod tests {
             scan_mod_folder(dir.path(), &dir.path().join("DISABLED_Aino Nude toggle")).unwrap();
 
         assert!(!mod_info.is_enabled);
+    }
+
+    #[test]
+    fn character_groups_count_enabled_mods_during_the_initial_scan() {
+        let dir = TestDir::new("enabled-mod-count");
+        dir.write_file("Character/Enabled Mod/mod.ini");
+        dir.write_file("Character/DISABLED_Disabled Mod/mod.ini");
+        fs::create_dir_all(dir.path().join("Character/Empty Mod")).unwrap();
+
+        let groups = get_characters_folder_sync(&dir.path().to_string_lossy(), Some(false));
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].mod_count, 2);
+        assert_eq!(groups[0].enabled_mod_count, 1);
     }
 
     #[test]

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -233,17 +233,21 @@ export class NahidaDesktop {
 export const desktop = new NahidaDesktop();
 let pendingDeepLinkRoute = getNahidaDeepLinkRoute(process.argv);
 
-app.on("open-url", (event, url) => {
-    event.preventDefault();
-    const route = parseNahidaDeepLink(url);
-    if (!route) return;
-
+function queueOrNavigateDeepLink(route: string) {
     if (!desktop.initialized || !desktop.window.main.window) {
         pendingDeepLinkRoute = route;
         return;
     }
 
-    void desktop.window.main.focusAndNavigate(route);
+    return desktop.window.main.focusAndNavigate(route);
+}
+
+app.on("open-url", (event, url) => {
+    event.preventDefault();
+    const route = parseNahidaDeepLink(url);
+    if (!route) return;
+
+    void queueOrNavigateDeepLink(route);
 });
 
 // 딥링크
@@ -301,12 +305,7 @@ void app.whenReady().then(async () => {
         try {
             const deepLinkRoute = getNahidaDeepLinkRoute(commandLine);
             if (deepLinkRoute) {
-                if (!desktop.initialized || !desktop.window.main.window) {
-                    pendingDeepLinkRoute = deepLinkRoute;
-                    return;
-                }
-
-                await desktop.window.main.focusAndNavigate(deepLinkRoute);
+                await queueOrNavigateDeepLink(deepLinkRoute);
                 return;
             }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,6 +22,7 @@ import { IPC } from "./ipc";
 import Compressor from "./lib/compressor";
 import CryptoLib from "./lib/crypto";
 import CustomDownloader from "./lib/custom-downloader";
+import { getNahidaDeepLinkRoute, parseNahidaDeepLink } from "./lib/deep-link";
 import { FS } from "./lib/fs";
 import { PathSelector } from "./lib/path-selector";
 import Tray from "./lib/tray";
@@ -178,7 +179,7 @@ export class NahidaDesktop {
         }
     }
 
-    public async init() {
+    public async init(initialRoute?: string) {
         if (this.initialized) return;
 
         // Reconcile before services because some constructors may read persisted app state.
@@ -224,12 +225,26 @@ export class NahidaDesktop {
 
         await this.service.transfer.applyBandwidthLimitsFromSettings();
 
-        await this.window.main.createMainWindow();
+        await this.window.main.createMainWindow(initialRoute);
         void this.syncAutoLaunchSetting();
     }
 }
 
 export const desktop = new NahidaDesktop();
+let pendingDeepLinkRoute = getNahidaDeepLinkRoute(process.argv);
+
+app.on("open-url", (event, url) => {
+    event.preventDefault();
+    const route = parseNahidaDeepLink(url);
+    if (!route) return;
+
+    if (!desktop.initialized || !desktop.window.main.window) {
+        pendingDeepLinkRoute = route;
+        return;
+    }
+
+    void desktop.window.main.focusAndNavigate(route);
+});
 
 // 딥링크
 if (process.defaultApp) {
@@ -284,9 +299,15 @@ void app.whenReady().then(async () => {
 
     app.on("second-instance", async (_event, commandLine, _workingDirectory) => {
         try {
-            const deepLinkUrl = commandLine.find((arg) => arg.startsWith("nahida://"));
-            if (deepLinkUrl?.startsWith("nahida://auth")) {
-                // AuthService.handleOAuth2Callback(deepLinkUrl);
+            const deepLinkRoute = getNahidaDeepLinkRoute(commandLine);
+            if (deepLinkRoute) {
+                if (!desktop.initialized || !desktop.window.main.window) {
+                    pendingDeepLinkRoute = deepLinkRoute;
+                    return;
+                }
+
+                await desktop.window.main.focusAndNavigate(deepLinkRoute);
+                return;
             }
 
             let mainWindow = desktop.window.main.window;
@@ -316,7 +337,12 @@ void app.whenReady().then(async () => {
         optimizer.watchWindowShortcuts(window);
     });
 
-    await desktop.init();
+    const initialDeepLinkRoute = pendingDeepLinkRoute;
+    await desktop.init(initialDeepLinkRoute ?? undefined);
+    if (pendingDeepLinkRoute && pendingDeepLinkRoute !== initialDeepLinkRoute) {
+        await desktop.window.main.focusAndNavigate(pendingDeepLinkRoute);
+    }
+    pendingDeepLinkRoute = null;
 });
 
 app.on("window-all-closed", async () => {

--- a/src/main/ipc/handlers/mod.ts
+++ b/src/main/ipc/handlers/mod.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
+
 import type { NahidaDesktop } from "@main/index";
 import { rh } from "@main/ipc/helper";
+import { readGameBananaModId } from "@main/lib/mod-download-metadata";
 import { dialog } from "electron";
 
 export function registerModHandlers(desktop: NahidaDesktop) {
@@ -151,6 +153,10 @@ export function registerModHandlers(desktop: NahidaDesktop) {
 
     rh("mod:downloadFromUrl", async (url: string, groupPath: string) => {
         return await desktop.lib.customDownloader.downloadToGroup(url, groupPath);
+    });
+
+    rh("mod:getGameBananaModId", async (modPath: string) => {
+        return await readGameBananaModId(modPath);
     });
 
     rh(

--- a/src/main/lib/deep-link.test.ts
+++ b/src/main/lib/deep-link.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { getNahidaDeepLinkRoute, parseNahidaDeepLink } from "./deep-link";
+
+describe("parseNahidaDeepLink", () => {
+    it.each([
+        ["nahida://gamebanana/mods/123", "/gamebanana?mod=123"],
+        ["nahida://gamebanana/mod/456", "/gamebanana?mod=456"],
+        ["nahida://gamebanana?id=789", "/gamebanana?mod=789"],
+        [
+            "nahida://gamebanana/open?url=https%3A%2F%2Fgamebanana.com%2Fmods%2F321",
+            "/gamebanana?mod=321",
+        ],
+    ])("maps %s to the GameBanana route", (value, expected) => {
+        expect(parseNahidaDeepLink(value)).toBe(expected);
+    });
+
+    it.each([
+        "https://gamebanana.com/mods/123",
+        "nahida://gamebanana/mods/not-a-number",
+        "nahida://gamebanana?id=0",
+        "nahida://gamebanana/open?url=https%3A%2F%2Fexample.com%2Fmods%2F123",
+        "nahida://gamebanana/open?url=file%3A%2F%2Fgamebanana.com%2Fmods%2F123",
+    ])("rejects unsupported deep links", (value) => {
+        expect(parseNahidaDeepLink(value)).toBeNull();
+    });
+});
+
+describe("getNahidaDeepLinkRoute", () => {
+    it("finds a deep link among process arguments", () => {
+        expect(
+            getNahidaDeepLinkRoute(["Nahida Desktop.exe", "--flag", "nahida://gamebanana/mods/42"]),
+        ).toBe("/gamebanana?mod=42");
+    });
+});

--- a/src/main/lib/deep-link.ts
+++ b/src/main/lib/deep-link.ts
@@ -1,0 +1,36 @@
+export function getNahidaDeepLinkRoute(commandLine: string[]) {
+    return commandLine.map(parseNahidaDeepLink).find((route) => route !== null) ?? null;
+}
+
+export function parseNahidaDeepLink(value: string) {
+    try {
+        const url = new URL(value);
+        if (url.protocol !== "nahida:" || url.hostname.toLowerCase() !== "gamebanana") return null;
+
+        const pathMatch = /^\/(?:mods?|open)\/(\d+)\/?$/i.exec(url.pathname);
+        const modId = pathMatch?.[1] ?? url.searchParams.get("id");
+        if (modId && isValidModId(modId)) return `/gamebanana?mod=${modId}`;
+
+        const sourceUrl = url.searchParams.get("url");
+        if (!sourceUrl) return null;
+
+        const gameBananaUrl = new URL(sourceUrl);
+        if (
+            !["http:", "https:"].includes(gameBananaUrl.protocol) ||
+            !["gamebanana.com", "www.gamebanana.com"].includes(gameBananaUrl.hostname.toLowerCase())
+        ) {
+            return null;
+        }
+
+        const sourceMatch = /^\/mods\/(\d+)\/?$/i.exec(gameBananaUrl.pathname);
+        if (!sourceMatch || !isValidModId(sourceMatch[1])) return null;
+        return `/gamebanana?mod=${sourceMatch[1]}`;
+    } catch {
+        return null;
+    }
+}
+
+function isValidModId(value: string) {
+    const id = Number(value);
+    return Number.isSafeInteger(id) && id > 0;
+}

--- a/src/main/lib/mod-download-metadata.test.ts
+++ b/src/main/lib/mod-download-metadata.test.ts
@@ -1,0 +1,24 @@
+import os from "node:os";
+import path from "node:path";
+
+import fse from "fs-extra";
+import { describe, expect, it } from "vitest";
+
+import { MOD_DOWNLOAD_METADATA_FILE_NAME, readGameBananaModId } from "./mod-download-metadata";
+
+describe("readGameBananaModId", () => {
+    it.each([
+        [{ source: "gamebanana", mod: { id: 123 } }, 123],
+        [{ source: "mod" }, undefined],
+        [{ source: "gamebanana", mod: { id: -1 } }, undefined],
+        [{ source: "gamebanana", mod: { id: "123" } }, undefined],
+    ])("reads a valid GameBanana mod ID from %j", async (metadata, expected) => {
+        const dirPath = await fse.mkdtemp(path.join(os.tmpdir(), "nahida-mod-metadata-"));
+        await fse.writeJson(path.join(dirPath, MOD_DOWNLOAD_METADATA_FILE_NAME), metadata);
+
+        const result = await readGameBananaModId(dirPath);
+
+        await fse.remove(dirPath);
+        expect(result).toBe(expected);
+    });
+});

--- a/src/main/lib/mod-download-metadata.ts
+++ b/src/main/lib/mod-download-metadata.ts
@@ -2,6 +2,7 @@ import { execFile } from "child_process";
 import crypto from "node:crypto";
 import path from "node:path";
 import { promisify } from "util";
+
 import fse from "fs-extra";
 
 const execFileAsync = promisify(execFile);
@@ -42,6 +43,29 @@ export type ModDownloadMetadata = DirectModDownloadMetadata | GameBananaModDownl
 export type ModDownloadMetadataInput =
     | Omit<DirectModDownloadMetadata, "id">
     | Omit<GameBananaModDownloadMetadata, "id">;
+
+export async function readGameBananaModId(dirPath: string) {
+    const metadata: unknown = await fse
+        .readJson(path.join(dirPath, MOD_DOWNLOAD_METADATA_FILE_NAME))
+        .catch(() => null);
+    if (
+        !metadata ||
+        typeof metadata !== "object" ||
+        !("source" in metadata) ||
+        metadata.source !== "gamebanana" ||
+        !("mod" in metadata) ||
+        !metadata.mod ||
+        typeof metadata.mod !== "object" ||
+        !("id" in metadata.mod) ||
+        typeof metadata.mod.id !== "number" ||
+        !Number.isSafeInteger(metadata.mod.id) ||
+        metadata.mod.id <= 0
+    ) {
+        return undefined;
+    }
+
+    return metadata.mod.id;
+}
 
 export async function writeModDownloadMetadata(
     dirPath: string,

--- a/src/main/services/gamebanana/index.ts
+++ b/src/main/services/gamebanana/index.ts
@@ -35,6 +35,11 @@ export const gameBananaGames = {
 export type GameBananaGameKey = keyof typeof gameBananaGames;
 export type GameBananaCategorySort = "a_to_z" | "count";
 export type GameBananaFeedSort = "default";
+export type GameBananaModIndexSort =
+    | "Generic_Newest"
+    | "Generic_MostLiked"
+    | "Generic_MostDownloaded"
+    | "Generic_MostViewed";
 export type GameBananaModPostsSort = "popular" | "newest";
 export type GameBananaSubmissionModel = "Mod" | "Tool" | (string & {});
 type GameBananaCookieMap = Map<string, string>;
@@ -83,7 +88,7 @@ export class GameBananaService {
         },
         modCategory: {
             profilePage: `${this.apiBaseUrl}/ModCategory/{}/ProfilePage`,
-            index: `${this.apiBaseUrl}/Mod/Index?_nPerpage={}&_aFilters%5BGeneric_Category%5D={}&_nPage={}`,
+            index: `${this.apiBaseUrl}/Mod/Index?_nPerpage={}&_aFilters%5BGeneric_Category%5D={}&_nPage={}&_sSort={}`,
             categories: `${this.apiBaseUrl}/Mod/Categories?_idCategoryRow={}&_sSort={}&_bShowEmpty={}`,
         },
         mod: {
@@ -850,12 +855,20 @@ export class GameBananaService {
         categoryId,
         perPage = 15,
         page = 1,
+        sort = "Generic_Newest",
     }: {
         categoryId: number;
         perPage?: number;
         page?: number;
+        sort?: GameBananaModIndexSort;
     }) {
-        const url = this.formatUrl(this.baseUrls.modCategory.index, perPage, categoryId, page);
+        const url = this.formatUrl(
+            this.baseUrls.modCategory.index,
+            perPage,
+            categoryId,
+            page,
+            sort,
+        );
         return await this.requestJson(
             ModIndexSchema,
             url,
@@ -982,16 +995,18 @@ export class GameBananaService {
         page = 1,
         sort = "a_to_z",
         showEmpty = true,
+        modSort = "Generic_Newest",
     }: {
         categoryId: number;
         perPage?: number;
         page?: number;
         sort?: GameBananaCategorySort;
         showEmpty?: boolean;
+        modSort?: GameBananaModIndexSort;
     }) {
         const [profile, index, categories] = await Promise.all([
             this.getModCategoryProfile(categoryId),
-            this.getModIndex({ categoryId, perPage, page }),
+            this.getModIndex({ categoryId, perPage, page, sort: modSort }),
             this.getModCategories({ categoryId, sort, showEmpty }),
         ]);
 

--- a/src/main/services/mod-manager/library.ts
+++ b/src/main/services/mod-manager/library.ts
@@ -68,9 +68,7 @@ export class ModLibraryService {
             return await this.addManualSubGroupFlags(
                 game,
                 "",
-                await this.addEnabledModCounts(
-                    await getCharactersFolder(gameConfig.modFolderPath, shouldFallback),
-                ),
+                await getCharactersFolder(gameConfig.modFolderPath, shouldFallback),
             );
         } catch (error) {
             this.desktop.logger.error(error, `Mod:characters:${game}`);
@@ -94,9 +92,7 @@ export class ModLibraryService {
             return await this.addManualSubGroupFlags(
                 game?.game ?? "",
                 relativePath,
-                await this.addEnabledModCounts(
-                    await getCharactersFolder(folderPath, shouldFallback),
-                ),
+                await getCharactersFolder(folderPath, shouldFallback),
             );
         } catch (error) {
             this.desktop.logger.error(error, `Mod:subGroups:${folderPath}`);
@@ -793,35 +789,6 @@ export class ModLibraryService {
                             group.mods.filter((mod) => mod.isEnabled).length) -
                             manualChildCounts.enabled,
                     ),
-                };
-            }),
-        );
-    }
-
-    private async addEnabledModCounts(groups: FolderGroup[]) {
-        return await Promise.all(
-            groups.map(async (group) => {
-                const populatedFolders = (
-                    await Promise.all(
-                        (
-                            await fse.readdir(group.path, { withFileTypes: true }).catch(() => [])
-                        )
-                            .filter((entry) => entry.isDirectory())
-                            .map(async (entry) => ({
-                                name: entry.name,
-                                hasAnyFile: await folderHasAnyFile(
-                                    path.join(group.path, entry.name),
-                                    this.manualSubGroupFs(),
-                                ),
-                            })),
-                    )
-                ).filter((entry) => entry.hasAnyFile);
-
-                return {
-                    ...group,
-                    enabledModCount: populatedFolders.filter(
-                        (entry) => !DISABLED_PREFIX_REGEX.test(entry.name),
-                    ).length,
                 };
             }),
         );

--- a/src/main/services/mod-manager/library.ts
+++ b/src/main/services/mod-manager/library.ts
@@ -153,6 +153,7 @@ export class ModLibraryService {
                 hasManualSubGroups: await this.hasManualChildren(game.game, relativePath),
                 mods,
                 modCount: mods.length,
+                enabledModCount: mods.filter((mod) => mod.isEnabled).length,
             };
         } catch (error) {
             this.desktop.logger.error(error, `Mod:mods:${groupPath}`);
@@ -689,18 +690,19 @@ export class ModLibraryService {
                     manualPath,
                     fs,
                 );
-                const populatedPath = (
+                const populatedPaths = (
                     await Promise.all(
                         diskPaths.map(async (diskPath) => ({
                             diskPath,
                             hasAnyFile: await folderHasAnyFile(diskPath, fs),
                         })),
                     )
-                ).find((result) => result.hasAnyFile)?.diskPath;
-                if (!populatedPath) return { total: 0, enabled: 0 };
+                ).filter((result) => result.hasAnyFile);
                 return {
-                    total: 1,
-                    enabled: DISABLED_PREFIX_REGEX.test(path.basename(populatedPath)) ? 0 : 1,
+                    total: populatedPaths.length,
+                    enabled: populatedPaths.filter(
+                        (result) => !DISABLED_PREFIX_REGEX.test(path.basename(result.diskPath)),
+                    ).length,
                 };
             }),
         );

--- a/src/main/services/mod-manager/library.ts
+++ b/src/main/services/mod-manager/library.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import type { GamePathRow } from "@main/internal/db/schema";
 import { getCharactersFolder, getMods } from "@native/mod-manager";
 import { findBestFuzzyMatch } from "@shared/fuzzy-match";
-import { isNteImporter } from "@shared/mod";
+import { DISABLED_PREFIX_REGEX, isNteImporter } from "@shared/mod";
 import type { FolderGroup, NteBootstrapProgress, Preset } from "@shared/types";
 import { GAME_MATCH_CASES } from "@shared/xxmi-match";
 import fse from "fs-extra";
@@ -68,7 +68,9 @@ export class ModLibraryService {
             return await this.addManualSubGroupFlags(
                 game,
                 "",
-                await getCharactersFolder(gameConfig.modFolderPath, shouldFallback),
+                await this.addEnabledModCounts(
+                    await getCharactersFolder(gameConfig.modFolderPath, shouldFallback),
+                ),
             );
         } catch (error) {
             this.desktop.logger.error(error, `Mod:characters:${game}`);
@@ -92,7 +94,9 @@ export class ModLibraryService {
             return await this.addManualSubGroupFlags(
                 game?.game ?? "",
                 relativePath,
-                await getCharactersFolder(folderPath, shouldFallback),
+                await this.addEnabledModCounts(
+                    await getCharactersFolder(folderPath, shouldFallback),
+                ),
             );
         } catch (error) {
             this.desktop.logger.error(error, `Mod:subGroups:${folderPath}`);
@@ -676,10 +680,10 @@ export class ModLibraryService {
 
     private async countManualChildPathsInModCount(game: string, groupRelativePath: string) {
         const manualChildPaths = await this.getManualChildPaths(game, groupRelativePath);
-        if (manualChildPaths.size === 0) return 0;
+        if (manualChildPaths.size === 0) return { total: 0, enabled: 0 };
 
         const modFolderPath = await this.gamePath(game);
-        if (!modFolderPath) return 0;
+        if (!modFolderPath) return { total: 0, enabled: 0 };
 
         const fs = this.manualSubGroupFs();
         const counts = await Promise.all(
@@ -689,15 +693,29 @@ export class ModLibraryService {
                     manualPath,
                     fs,
                 );
-                return (
-                    await Promise.all(diskPaths.map((diskPath) => folderHasAnyFile(diskPath, fs)))
-                ).some(Boolean)
-                    ? 1
-                    : 0;
+                const populatedPath = (
+                    await Promise.all(
+                        diskPaths.map(async (diskPath) => ({
+                            diskPath,
+                            hasAnyFile: await folderHasAnyFile(diskPath, fs),
+                        })),
+                    )
+                ).find((result) => result.hasAnyFile)?.diskPath;
+                if (!populatedPath) return { total: 0, enabled: 0 };
+                return {
+                    total: 1,
+                    enabled: DISABLED_PREFIX_REGEX.test(path.basename(populatedPath)) ? 0 : 1,
+                };
             }),
         );
 
-        return counts.reduce<number>((total, count) => total + count, 0);
+        return counts.reduce(
+            (total, count) => ({
+                total: total.total + count.total,
+                enabled: total.enabled + count.enabled,
+            }),
+            { total: 0, enabled: 0 },
+        );
     }
 
     private async getManualChildPaths(game: string, groupRelativePath: string) {
@@ -756,7 +774,7 @@ export class ModLibraryService {
 
                 const ownManualChildPaths = await this.getManualChildPaths(game, groupRelativePath);
 
-                const manualChildPathsInModCount = await this.countManualChildPathsInModCount(
+                const manualChildCounts = await this.countManualChildPathsInModCount(
                     game,
                     groupRelativePath,
                 );
@@ -767,8 +785,43 @@ export class ModLibraryService {
                     hasManualSubGroups: ownManualChildPaths.size > 0,
                     modCount: Math.max(
                         0,
-                        (group.modCount ?? group.mods.length) - manualChildPathsInModCount,
+                        (group.modCount ?? group.mods.length) - manualChildCounts.total,
                     ),
+                    enabledModCount: Math.max(
+                        0,
+                        (group.enabledModCount ??
+                            group.mods.filter((mod) => mod.isEnabled).length) -
+                            manualChildCounts.enabled,
+                    ),
+                };
+            }),
+        );
+    }
+
+    private async addEnabledModCounts(groups: FolderGroup[]) {
+        return await Promise.all(
+            groups.map(async (group) => {
+                const populatedFolders = (
+                    await Promise.all(
+                        (
+                            await fse.readdir(group.path, { withFileTypes: true }).catch(() => [])
+                        )
+                            .filter((entry) => entry.isDirectory())
+                            .map(async (entry) => ({
+                                name: entry.name,
+                                hasAnyFile: await folderHasAnyFile(
+                                    path.join(group.path, entry.name),
+                                    this.manualSubGroupFs(),
+                                ),
+                            })),
+                    )
+                ).filter((entry) => entry.hasAnyFile);
+
+                return {
+                    ...group,
+                    enabledModCount: populatedFolders.filter(
+                        (entry) => !DISABLED_PREFIX_REGEX.test(entry.name),
+                    ).length,
                 };
             }),
         );

--- a/src/main/services/mod-manager/nte.ts
+++ b/src/main/services/mod-manager/nte.ts
@@ -177,12 +177,14 @@ export async function getNteSubGroups(
             if (await hasDirectPak(nextPath)) return null;
 
             const preview = await findPreview(nextPath);
+            const modCounts = await countDirectMods(nextPath);
             return {
                 name: groupName,
                 path: nextPath,
                 mods: [],
                 ...(preview ? { preview } : {}),
-                modCount: await countDirectMods(nextPath),
+                modCount: modCounts.total,
+                enabledModCount: modCounts.enabled,
                 hasManualSubGroups: false,
             } satisfies FolderGroup;
         }),
@@ -219,6 +221,7 @@ export async function getNteMods(
         mods,
         ...(preview ? { preview } : {}),
         modCount: mods.length,
+        enabledModCount: mods.filter((mod) => mod.isEnabled).length,
     };
 }
 
@@ -893,16 +896,22 @@ async function hasDirectPak(dirPath: string) {
 }
 
 async function countDirectMods(groupDir: string) {
-    return (
+    const mods = (
         await Promise.all(
             (
                 await listDirectoryNames(groupDir)
-            ).map(
-                async (name): Promise<number> =>
-                    (await hasDirectPak(path.join(groupDir, name))) ? 1 : 0,
-            ),
+            ).map(async (name) => {
+                const modPath = path.join(groupDir, name);
+                if (!(await hasDirectPak(modPath))) return null;
+                return await isNteModEnabled(modPath);
+            }),
         )
-    ).reduce((total, count) => total + count, 0);
+    ).filter((enabled) => enabled !== null);
+
+    return {
+        total: mods.length,
+        enabled: mods.filter(Boolean).length,
+    };
 }
 
 async function findPreview(dirPath: string) {

--- a/src/main/services/mod-manager/nte.ts
+++ b/src/main/services/mod-manager/nte.ts
@@ -906,7 +906,7 @@ async function countDirectMods(groupDir: string) {
                 return await isNteModEnabled(modPath);
             }),
         )
-    ).filter((enabled) => enabled !== null);
+    ).filter((enabled): enabled is boolean => enabled !== null);
 
     return {
         total: mods.length,

--- a/src/main/windows/main.ts
+++ b/src/main/windows/main.ts
@@ -31,6 +31,8 @@ export class MainWindow {
         let window = this.window;
         if (!window || window.isDestroyed()) {
             window = await this.createMainWindow(path);
+            if (window && !window.isDestroyed()) focus(window);
+            return window;
         }
 
         if (!window || window.isDestroyed()) {
@@ -38,9 +40,16 @@ export class MainWindow {
         }
 
         focus(window);
-        if (!window.webContents.isLoadingMainFrame()) {
-            this.desktop.ipc.postMessageToWindow(window, "fn:navi", path);
+        if (window.webContents.isLoadingMainFrame()) {
+            window.webContents.once("did-finish-load", () => {
+                if (!window.isDestroyed()) {
+                    this.desktop.ipc.postMessageToWindow(window, "fn:navi", path);
+                }
+            });
+            return window;
         }
+
+        this.desktop.ipc.postMessageToWindow(window, "fn:navi", path);
         return window;
     }
 

--- a/src/main/windows/main.ts
+++ b/src/main/windows/main.ts
@@ -28,17 +28,13 @@ export class MainWindow {
     }
 
     public async focusAndNavigate(path: string) {
-        let window = this.window;
-        if (!window || window.isDestroyed()) {
-            window = await this.createMainWindow(path);
+        if (!this.window || this.window.isDestroyed()) {
+            const window = await this.createMainWindow(path);
             if (window && !window.isDestroyed()) focus(window);
             return window;
         }
 
-        if (!window || window.isDestroyed()) {
-            return null;
-        }
-
+        const window = this.window;
         focus(window);
         if (window.webContents.isLoadingMainFrame()) {
             window.webContents.once("did-finish-load", () => {

--- a/src/renderer/src/components/download-confirmation-overlay.tsx
+++ b/src/renderer/src/components/download-confirmation-overlay.tsx
@@ -2,6 +2,7 @@ import { Button } from "@renderer/components/ui/button";
 import { Input } from "@renderer/components/ui/input";
 import { Logger } from "@renderer/lib/logger";
 import { useModStore } from "@renderer/store/mod";
+import { useNavigate } from "@tanstack/react-router";
 import { Download } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -9,6 +10,7 @@ import { toast } from "sonner";
 
 export function DownloadConfirmationOverlay() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
 
   const downloadMode = useModStore((s) => s.downloadMode);
   const setDownloadMode = useModStore((s) => s.setDownloadMode);
@@ -38,6 +40,9 @@ export function DownloadConfirmationOverlay() {
 
       setDownloadMode(null);
       resetUserSelectedDuringDownload();
+      if (downloadMode.downloadSource === "gamebanana") {
+        void navigate({ to: "/gamebanana" });
+      }
     } catch (error) {
       toast.error(t("components.download-confirmation-overlay.select_path_failed"));
       Logger.error(error, "DownloadConfirmationOverlay:handleConfirm");
@@ -125,7 +130,9 @@ export function DownloadConfirmationOverlay() {
               className="flex-1"
             >
               <Download className="mr-2 size-4" />
-              {t("g.select")}
+              {downloadMode.downloadSource === "gamebanana"
+                ? t("components.download-confirmation-overlay.download_and_return")
+                : t("g.select")}
             </Button>
           </div>
         </div>

--- a/src/renderer/src/components/mod/character-sidebar-content.tsx
+++ b/src/renderer/src/components/mod/character-sidebar-content.tsx
@@ -1,4 +1,4 @@
-import { useModStore } from "@renderer/store/mod";
+import { type FolderSortDirection, type FolderSortKey, useModStore } from "@renderer/store/mod";
 import type { FolderGroup } from "@renderer/types/mod";
 import type { SidebarLayoutMode } from "@shared/mod";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
@@ -13,7 +13,8 @@ export interface CharacterSidebarContentProps {
   onItemDrop: (group: FolderGroup, files: File[]) => void;
   canAcceptDrop: (files: File[]) => boolean;
   searchTerm: string;
-  sortByModCount: boolean;
+  sortKey: FolderSortKey;
+  sortDirection: FolderSortDirection;
   hideEmptyGroups: boolean;
   onCreateFolder: (group: FolderGroup) => void;
   onDeleteFolder: (group: FolderGroup) => void;
@@ -64,7 +65,8 @@ interface CharacterSidebarItemWithChildrenProps {
   canAcceptDrop: (files: File[]) => boolean;
   depth: number;
   searchTerm: string;
-  sortByModCount: boolean;
+  sortKey: FolderSortKey;
+  sortDirection: FolderSortDirection;
   hideEmptyGroups: boolean;
   onCreateFolder: (group: FolderGroup) => void;
   onDeleteFolder: (group: FolderGroup) => void;
@@ -91,7 +93,8 @@ const CharacterSidebarItemWithChildren = memo(function CharacterSidebarItemWithC
   canAcceptDrop,
   depth,
   searchTerm,
-  sortByModCount,
+  sortKey,
+  sortDirection,
   hideEmptyGroups,
   onCreateFolder,
   onDeleteFolder,
@@ -134,7 +137,8 @@ const CharacterSidebarItemWithChildren = memo(function CharacterSidebarItemWithC
     : manualSubGroups.length > 0 && (!isSearching || visibleChildGroups.length > 0);
   const groupsToRender = getVisibleGroups(
     showSubGroups ? childGroups : visibleChildGroups,
-    sortByModCount,
+    sortKey,
+    sortDirection,
     hideEmptyGroups,
   );
   const resolvedItemStyle = useMemo(() => itemStyle?.(depth), [depth, itemStyle]);
@@ -202,7 +206,8 @@ const CharacterSidebarItemWithChildren = memo(function CharacterSidebarItemWithC
             collapseGroupPath={group.path}
             depth={depth + 1}
             searchTerm={searchTerm}
-            sortByModCount={sortByModCount}
+            sortKey={sortKey}
+            sortDirection={sortDirection}
             hideEmptyGroups={hideEmptyGroups}
             onCreateFolder={onCreateFolder}
             onDeleteFolder={onDeleteFolder}
@@ -231,7 +236,8 @@ export function CharacterSidebarContent({
   onItemDrop,
   canAcceptDrop,
   searchTerm,
-  sortByModCount,
+  sortKey,
+  sortDirection,
   hideEmptyGroups,
   onCreateFolder,
   onDeleteFolder,
@@ -254,7 +260,7 @@ export function CharacterSidebarContent({
         ? Array.from({ length: 8 }).map((_, index) => (
             <CharacterSidebarItemSkeleton key={index.toString()} layout={layout} />
           ))
-        : getVisibleGroups(groups, sortByModCount, hideEmptyGroups).map((group) => (
+        : getVisibleGroups(groups, sortKey, sortDirection, hideEmptyGroups).map((group) => (
             <CharacterSidebarItemWithChildren
               key={group.path}
               group={group}
@@ -264,7 +270,8 @@ export function CharacterSidebarContent({
               canAcceptDrop={canAcceptDrop}
               depth={0}
               searchTerm={searchTerm}
-              sortByModCount={sortByModCount}
+              sortKey={sortKey}
+              sortDirection={sortDirection}
               hideEmptyGroups={hideEmptyGroups}
               onCreateFolder={onCreateFolder}
               onDeleteFolder={onDeleteFolder}
@@ -287,13 +294,21 @@ export function CharacterSidebarContent({
 
 function getVisibleGroups(
   groups: FolderGroup[],
-  sortByModCount: boolean,
+  sortKey: FolderSortKey,
+  sortDirection: FolderSortDirection,
   hideEmptyGroups: boolean,
 ) {
   return groups
     .filter((group) => !hideEmptyGroups || (group.modCount ?? group.mods.length) > 0)
     .toSorted((a, b) => {
-      if (!sortByModCount) return 0;
-      return (b.modCount ?? b.mods.length) - (a.modCount ?? a.mods.length);
+      const comparison =
+        sortKey === "name"
+          ? a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: "base" })
+          : sortKey === "mod-count"
+            ? (a.modCount ?? a.mods.length) - (b.modCount ?? b.mods.length)
+            : (a.enabledModCount ?? a.mods.filter((mod) => mod.isEnabled).length) -
+              (b.enabledModCount ?? b.mods.filter((mod) => mod.isEnabled).length);
+
+      return sortDirection === "ascending" ? comparison : -comparison;
     });
 }

--- a/src/renderer/src/components/mod/character-sidebar-content.tsx
+++ b/src/renderer/src/components/mod/character-sidebar-content.tsx
@@ -132,15 +132,13 @@ const CharacterSidebarItemWithChildren = memo(function CharacterSidebarItemWithC
     isSearching && !showSubGroups
       ? childGroups.filter((sub) => sub.name.toLowerCase().includes(normalizedSearch))
       : childGroups;
-  const showChildGroups = showSubGroups
-    ? childGroups.length > 0
-    : manualSubGroups.length > 0 && (!isSearching || visibleChildGroups.length > 0);
   const groupsToRender = getVisibleGroups(
     showSubGroups ? childGroups : visibleChildGroups,
     sortKey,
     sortDirection,
     hideEmptyGroups,
   );
+  const showChildGroups = groupsToRender.length > 0;
   const resolvedItemStyle = useMemo(() => itemStyle?.(depth), [depth, itemStyle]);
 
   const handleChildItemClick = useCallback(

--- a/src/renderer/src/components/mod/character-sidebar-content.tsx
+++ b/src/renderer/src/components/mod/character-sidebar-content.tsx
@@ -297,7 +297,10 @@ function getVisibleGroups(
   hideEmptyGroups: boolean,
 ) {
   return groups
-    .filter((group) => !hideEmptyGroups || (group.modCount ?? group.mods.length) > 0)
+    .filter(
+      (group) =>
+        !hideEmptyGroups || (group.modCount ?? group.mods.length) > 0 || group.hasManualSubGroups,
+    )
     .toSorted((a, b) => {
       const comparison =
         sortKey === "name"

--- a/src/renderer/src/components/mod/character-sidebar-content.tsx
+++ b/src/renderer/src/components/mod/character-sidebar-content.tsx
@@ -13,6 +13,8 @@ export interface CharacterSidebarContentProps {
   onItemDrop: (group: FolderGroup, files: File[]) => void;
   canAcceptDrop: (files: File[]) => boolean;
   searchTerm: string;
+  sortByModCount: boolean;
+  hideEmptyGroups: boolean;
   onCreateFolder: (group: FolderGroup) => void;
   onDeleteFolder: (group: FolderGroup) => void;
   onManualSubGroupChange: (group: FolderGroup, enabled: boolean) => void;
@@ -62,6 +64,8 @@ interface CharacterSidebarItemWithChildrenProps {
   canAcceptDrop: (files: File[]) => boolean;
   depth: number;
   searchTerm: string;
+  sortByModCount: boolean;
+  hideEmptyGroups: boolean;
   onCreateFolder: (group: FolderGroup) => void;
   onDeleteFolder: (group: FolderGroup) => void;
   onManualSubGroupChange: (group: FolderGroup, enabled: boolean) => void;
@@ -87,6 +91,8 @@ const CharacterSidebarItemWithChildren = memo(function CharacterSidebarItemWithC
   canAcceptDrop,
   depth,
   searchTerm,
+  sortByModCount,
+  hideEmptyGroups,
   onCreateFolder,
   onDeleteFolder,
   onManualSubGroupChange,
@@ -126,7 +132,11 @@ const CharacterSidebarItemWithChildren = memo(function CharacterSidebarItemWithC
   const showChildGroups = showSubGroups
     ? childGroups.length > 0
     : manualSubGroups.length > 0 && (!isSearching || visibleChildGroups.length > 0);
-  const groupsToRender = showSubGroups ? childGroups : visibleChildGroups;
+  const groupsToRender = getVisibleGroups(
+    showSubGroups ? childGroups : visibleChildGroups,
+    sortByModCount,
+    hideEmptyGroups,
+  );
   const resolvedItemStyle = useMemo(() => itemStyle?.(depth), [depth, itemStyle]);
 
   const handleChildItemClick = useCallback(
@@ -192,6 +202,8 @@ const CharacterSidebarItemWithChildren = memo(function CharacterSidebarItemWithC
             collapseGroupPath={group.path}
             depth={depth + 1}
             searchTerm={searchTerm}
+            sortByModCount={sortByModCount}
+            hideEmptyGroups={hideEmptyGroups}
             onCreateFolder={onCreateFolder}
             onDeleteFolder={onDeleteFolder}
             onManualSubGroupChange={onManualSubGroupChange}
@@ -219,6 +231,8 @@ export function CharacterSidebarContent({
   onItemDrop,
   canAcceptDrop,
   searchTerm,
+  sortByModCount,
+  hideEmptyGroups,
   onCreateFolder,
   onDeleteFolder,
   onManualSubGroupChange,
@@ -240,7 +254,7 @@ export function CharacterSidebarContent({
         ? Array.from({ length: 8 }).map((_, index) => (
             <CharacterSidebarItemSkeleton key={index.toString()} layout={layout} />
           ))
-        : groups.map((group) => (
+        : getVisibleGroups(groups, sortByModCount, hideEmptyGroups).map((group) => (
             <CharacterSidebarItemWithChildren
               key={group.path}
               group={group}
@@ -250,6 +264,8 @@ export function CharacterSidebarContent({
               canAcceptDrop={canAcceptDrop}
               depth={0}
               searchTerm={searchTerm}
+              sortByModCount={sortByModCount}
+              hideEmptyGroups={hideEmptyGroups}
               onCreateFolder={onCreateFolder}
               onDeleteFolder={onDeleteFolder}
               onManualSubGroupChange={onManualSubGroupChange}
@@ -267,4 +283,17 @@ export function CharacterSidebarContent({
           ))}
     </div>
   );
+}
+
+function getVisibleGroups(
+  groups: FolderGroup[],
+  sortByModCount: boolean,
+  hideEmptyGroups: boolean,
+) {
+  return groups
+    .filter((group) => !hideEmptyGroups || (group.modCount ?? group.mods.length) > 0)
+    .toSorted((a, b) => {
+      if (!sortByModCount) return 0;
+      return (b.modCount ?? b.mods.length) - (a.modCount ?? a.mods.length);
+    });
 }

--- a/src/renderer/src/components/mod/character-sidebar-item-grid.tsx
+++ b/src/renderer/src/components/mod/character-sidebar-item-grid.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next";
+
 // oxlint-disable no-unused-vars
 import { Preview } from "./preview";
 
@@ -6,7 +8,8 @@ interface CharacterSidebarItemGridProps {
     name: string;
     preview?: string;
     modCount?: number;
-    mods: unknown[];
+    enabledModCount?: number;
+    mods: { isEnabled: boolean }[];
   };
   depth: number;
   parentGroupName?: string;
@@ -19,7 +22,10 @@ export function CharacterSidebarItemGrid({
   parentGroupName,
   previewCacheKey,
 }: CharacterSidebarItemGridProps) {
+  const { t } = useTranslation();
   const isNestedGridItem = depth > 0;
+  const total = group.modCount ?? group.mods.length;
+  const enabled = group.enabledModCount ?? group.mods.filter((mod) => mod.isEnabled).length;
 
   return (
     <>
@@ -45,6 +51,13 @@ export function CharacterSidebarItemGrid({
             }
             allowPlay={true}
           />
+          <span
+            className="absolute right-1.5 bottom-1.5 flex items-center gap-1 rounded bg-background/85 px-1.5 py-0.5 text-[11px] text-muted-foreground shadow-sm backdrop-blur-sm"
+            title={t("page.mod.character-sidebar.active-mod-count", { enabled, total })}
+          >
+            <span className="size-1.5 rounded-full bg-emerald-500" />
+            {enabled} / {total}
+          </span>
         </div>
         <div className="flex min-w-0 items-center justify-center">
           <div className="truncate text-center text-xs font-medium text-foreground">

--- a/src/renderer/src/components/mod/character-sidebar-item-grid.tsx
+++ b/src/renderer/src/components/mod/character-sidebar-item-grid.tsx
@@ -1,6 +1,5 @@
-import { useTranslation } from "react-i18next";
-
 // oxlint-disable no-unused-vars
+import { CharacterSidebarModCountBadge } from "./character-sidebar-mod-count-badge";
 import { Preview } from "./preview";
 
 interface CharacterSidebarItemGridProps {
@@ -22,10 +21,7 @@ export function CharacterSidebarItemGrid({
   parentGroupName,
   previewCacheKey,
 }: CharacterSidebarItemGridProps) {
-  const { t } = useTranslation();
   const isNestedGridItem = depth > 0;
-  const total = group.modCount ?? group.mods.length;
-  const enabled = group.enabledModCount ?? group.mods.filter((mod) => mod.isEnabled).length;
 
   return (
     <>
@@ -51,13 +47,10 @@ export function CharacterSidebarItemGrid({
             }
             allowPlay={true}
           />
-          <span
-            className="absolute right-1.5 bottom-1.5 flex items-center gap-1 rounded bg-background/85 px-1.5 py-0.5 text-[11px] text-muted-foreground shadow-sm backdrop-blur-sm"
-            title={t("page.mod.character-sidebar.active-mod-count", { enabled, total })}
-          >
-            <span className="size-1.5 rounded-full bg-emerald-500" />
-            {enabled} / {total}
-          </span>
+          <CharacterSidebarModCountBadge
+            group={group}
+            className="absolute right-1.5 bottom-1.5 gap-1 rounded bg-background/85 px-1.5 py-0.5 text-[11px] shadow-sm backdrop-blur-sm"
+          />
         </div>
         <div className="flex min-w-0 items-center justify-center">
           <div className="truncate text-center text-xs font-medium text-foreground">

--- a/src/renderer/src/components/mod/character-sidebar-item-row.tsx
+++ b/src/renderer/src/components/mod/character-sidebar-item-row.tsx
@@ -1,5 +1,4 @@
-import { useTranslation } from "react-i18next";
-
+import { CharacterSidebarModCountBadge } from "./character-sidebar-mod-count-badge";
 import { Preview } from "./preview";
 
 interface CharacterSidebarItemRowProps {
@@ -19,10 +18,6 @@ export function CharacterSidebarItemRow({
   depth,
   previewCacheKey,
 }: CharacterSidebarItemRowProps) {
-  const { t } = useTranslation();
-  const total = group.modCount ?? group.mods.length;
-  const enabled = group.enabledModCount ?? group.mods.filter((mod) => mod.isEnabled).length;
-
   return (
     <>
       {depth > 0 && (
@@ -44,13 +39,7 @@ export function CharacterSidebarItemRow({
       </div>
 
       <span className="min-w-0 truncate text-left text-sm text-foreground">{group.name}</span>
-      <span
-        className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground"
-        title={t("page.mod.character-sidebar.active-mod-count", { enabled, total })}
-      >
-        <span className="size-1.5 rounded-full bg-emerald-500" />
-        {enabled} / {total}
-      </span>
+      <CharacterSidebarModCountBadge group={group} />
     </>
   );
 }

--- a/src/renderer/src/components/mod/character-sidebar-item-row.tsx
+++ b/src/renderer/src/components/mod/character-sidebar-item-row.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next";
+
 import { Preview } from "./preview";
 
 interface CharacterSidebarItemRowProps {
@@ -5,7 +7,8 @@ interface CharacterSidebarItemRowProps {
     name: string;
     preview?: string;
     modCount?: number;
-    mods: unknown[];
+    enabledModCount?: number;
+    mods: { isEnabled: boolean }[];
   };
   depth: number;
   previewCacheKey?: number;
@@ -16,11 +19,15 @@ export function CharacterSidebarItemRow({
   depth,
   previewCacheKey,
 }: CharacterSidebarItemRowProps) {
+  const { t } = useTranslation();
+  const total = group.modCount ?? group.mods.length;
+  const enabled = group.enabledModCount ?? group.mods.filter((mod) => mod.isEnabled).length;
+
   return (
     <>
       {depth > 0 && (
         <div
-          className="absolute left-0 top-0 bottom-0 w-px bg-border/50"
+          className="absolute top-0 bottom-0 left-0 w-px bg-border/50"
           style={{ left: `${(depth - 1) * 16 + 16}px` }}
         />
       )}
@@ -37,8 +44,12 @@ export function CharacterSidebarItemRow({
       </div>
 
       <span className="min-w-0 truncate text-left text-sm text-foreground">{group.name}</span>
-      <span className="shrink-0 text-sm text-muted-foreground">
-        {group.modCount ?? group.mods.length}
+      <span
+        className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground"
+        title={t("page.mod.character-sidebar.active-mod-count", { enabled, total })}
+      >
+        <span className="size-1.5 rounded-full bg-emerald-500" />
+        {enabled} / {total}
       </span>
     </>
   );

--- a/src/renderer/src/components/mod/character-sidebar-mod-count-badge.tsx
+++ b/src/renderer/src/components/mod/character-sidebar-mod-count-badge.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@renderer/lib/utils";
+import { useTranslation } from "react-i18next";
+
+interface CharacterSidebarModCountBadgeProps {
+  group: {
+    enabledModCount?: number;
+    modCount?: number;
+    mods: { isEnabled: boolean }[];
+  };
+  className?: string;
+}
+
+export function CharacterSidebarModCountBadge({
+  group,
+  className,
+}: CharacterSidebarModCountBadgeProps) {
+  const { t } = useTranslation();
+  const total = group.modCount ?? group.mods.length;
+  const enabled = group.enabledModCount ?? group.mods.filter((mod) => mod.isEnabled).length;
+
+  return (
+    <span
+      className={cn("flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground", className)}
+      title={t("page.mod.character-sidebar.active-mod-count", { enabled, total })}
+    >
+      <span className="size-1.5 rounded-full bg-emerald-500" />
+      {enabled} / {total}
+    </span>
+  );
+}

--- a/src/renderer/src/components/mod/character-sidebar.tsx
+++ b/src/renderer/src/components/mod/character-sidebar.tsx
@@ -451,8 +451,8 @@ export const CharacterSidebar = memo(function CharacterSidebar({
               </TooltipContent>
             </Tooltip>
             <DropdownMenuContent align="end" className="w-56" finalFocus={false}>
-              <DropdownMenuLabel>{t("page.mod.character-sidebar.sort.field")}</DropdownMenuLabel>
               <DropdownMenuRadioGroup value={sortKey}>
+                <DropdownMenuLabel>{t("page.mod.character-sidebar.sort.field")}</DropdownMenuLabel>
                 {(["name", "mod-count", "enabled-mod-count"] as const).map((value) => (
                   <DropdownMenuRadioItem
                     key={value}
@@ -464,10 +464,10 @@ export const CharacterSidebar = memo(function CharacterSidebar({
                 ))}
               </DropdownMenuRadioGroup>
               <DropdownMenuSeparator />
-              <DropdownMenuLabel>
-                {t("page.mod.character-sidebar.sort.direction")}
-              </DropdownMenuLabel>
               <DropdownMenuRadioGroup value={sortDirection}>
+                <DropdownMenuLabel>
+                  {t("page.mod.character-sidebar.sort.direction")}
+                </DropdownMenuLabel>
                 <DropdownMenuRadioItem
                   value="ascending"
                   onClick={() => setSortDirection("ascending")}

--- a/src/renderer/src/components/mod/character-sidebar.tsx
+++ b/src/renderer/src/components/mod/character-sidebar.tsx
@@ -21,15 +21,24 @@ import {
 } from "@renderer/components/ui/dialog";
 import { Field, FieldError } from "@renderer/components/ui/field";
 import { Input } from "@renderer/components/ui/input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@renderer/components/ui/tooltip";
 import { useConfirmTrash } from "@renderer/hooks/use-confirm-trash";
 import { useDelayedSkeleton } from "@renderer/hooks/use-delayed-skeleton";
 import { useSidebarLayoutSetting } from "@renderer/hooks/use-settings";
+import { setSetting } from "@renderer/lib/settings";
 import { useModStore } from "@renderer/store/mod";
 import type { FolderGroup } from "@renderer/types/mod";
 import { toErrorMessage } from "@shared/utils";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Loader2Icon, Search } from "lucide-react";
+import {
+  ArrowDown10Icon,
+  LayoutGridIcon,
+  ListFilterIcon,
+  ListIcon,
+  Loader2Icon,
+  Search,
+} from "lucide-react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -97,6 +106,8 @@ export const CharacterSidebar = memo(function CharacterSidebar({
   const selectedGroup = useModStore((s) => s.selectedGroup);
   const setExpandedGroup = useModStore((s) => s.setExpandedGroup);
   const [searchTerm, setSearchTerm] = useState("");
+  const [sortByModCount, setSortByModCount] = useState(false);
+  const [hideEmptyGroups, setHideEmptyGroups] = useState(false);
   const [createFolderTarget, setCreateFolderTarget] = useState<FolderGroup | null>(null);
   const [pendingPreviewDrop, setPendingPreviewDrop] = useState<{
     group: FolderGroup;
@@ -107,6 +118,8 @@ export const CharacterSidebar = memo(function CharacterSidebar({
   const showSkeleton = useDelayedSkeleton(isLoading);
   const { confirmTrash, confirmTrashDialog } = useConfirmTrash();
   const { data: sidebarLayout = "row" } = useSidebarLayoutSetting();
+  const nextSidebarLayout = sidebarLayout === "grid" ? "row" : "grid";
+  const nextSidebarLayoutLabel = t(`page.setting.mod.layout.sidebar.modes.${nextSidebarLayout}`);
   const createFolderForm = useForm({
     defaultValues: {
       name: "",
@@ -375,6 +388,8 @@ export const CharacterSidebar = memo(function CharacterSidebar({
     onItemDrop: handleItemDrop,
     canAcceptDrop: canAcceptPreviewDrop,
     searchTerm,
+    sortByModCount,
+    hideEmptyGroups,
     onCreateFolder: handleCreateFolderOpen,
     onDeleteFolder: handleDeleteFolder,
     onManualSubGroupChange: handleManualSubGroupChange,
@@ -387,8 +402,8 @@ export const CharacterSidebar = memo(function CharacterSidebar({
   return (
     <>
       <div className="flex h-full flex-col">
-        <div className="h-12 p-2">
-          <div className="relative">
+        <div className="flex h-12 items-center gap-1 p-2">
+          <div className="relative min-w-0 flex-1">
             <Search className="absolute top-1/2 right-2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
               id="character-search-input"
@@ -398,6 +413,66 @@ export const CharacterSidebar = memo(function CharacterSidebar({
               onChange={(e) => handleSearchChange(e.target.value)}
             />
           </div>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  size="icon-sm"
+                  variant={sortByModCount ? "secondary" : "ghost"}
+                  aria-pressed={sortByModCount}
+                  onClick={() => setSortByModCount((value) => !value)}
+                />
+              }
+            >
+              <ArrowDown10Icon />
+              <span className="sr-only">{t("page.mod.character-sidebar.sort-by-mod-count")}</span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {t("page.mod.character-sidebar.sort-by-mod-count")}
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  size="icon-sm"
+                  variant={hideEmptyGroups ? "secondary" : "ghost"}
+                  aria-pressed={hideEmptyGroups}
+                  onClick={() => setHideEmptyGroups((value) => !value)}
+                />
+              }
+            >
+              <ListFilterIcon />
+              <span className="sr-only">{t("page.mod.character-sidebar.hide-empty-folders")}</span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {t("page.mod.character-sidebar.hide-empty-folders")}
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  size="icon-sm"
+                  variant="ghost"
+                  aria-label={nextSidebarLayoutLabel}
+                  onClickPromise={async () => {
+                    try {
+                      await setSetting("mod.sidebarLayout", nextSidebarLayout);
+                    } catch (error) {
+                      toast.error(toErrorMessage(error));
+                    }
+                  }}
+                />
+              }
+            >
+              {sidebarLayout === "grid" ? <ListIcon /> : <LayoutGridIcon />}
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{nextSidebarLayoutLabel}</TooltipContent>
+          </Tooltip>
         </div>
 
         <ScrollArea className="flex-1 overflow-hidden">

--- a/src/renderer/src/components/mod/character-sidebar.tsx
+++ b/src/renderer/src/components/mod/character-sidebar.tsx
@@ -19,6 +19,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@renderer/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@renderer/components/ui/dropdown-menu";
 import { Field, FieldError } from "@renderer/components/ui/field";
 import { Input } from "@renderer/components/ui/input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@renderer/components/ui/tooltip";
@@ -32,7 +41,9 @@ import { toErrorMessage } from "@shared/utils";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
-  ArrowDown10Icon,
+  ArrowDownIcon,
+  ArrowUpDownIcon,
+  ArrowUpIcon,
   LayoutGridIcon,
   ListFilterIcon,
   ListIcon,
@@ -106,7 +117,10 @@ export const CharacterSidebar = memo(function CharacterSidebar({
   const selectedGroup = useModStore((s) => s.selectedGroup);
   const setExpandedGroup = useModStore((s) => s.setExpandedGroup);
   const [searchTerm, setSearchTerm] = useState("");
-  const [sortByModCount, setSortByModCount] = useState(false);
+  const sortKey = useModStore((s) => s.folderSortKey);
+  const setSortKey = useModStore((s) => s.setFolderSortKey);
+  const sortDirection = useModStore((s) => s.folderSortDirection);
+  const setSortDirection = useModStore((s) => s.setFolderSortDirection);
   const [hideEmptyGroups, setHideEmptyGroups] = useState(false);
   const [createFolderTarget, setCreateFolderTarget] = useState<FolderGroup | null>(null);
   const [pendingPreviewDrop, setPendingPreviewDrop] = useState<{
@@ -388,7 +402,8 @@ export const CharacterSidebar = memo(function CharacterSidebar({
     onItemDrop: handleItemDrop,
     canAcceptDrop: canAcceptPreviewDrop,
     searchTerm,
-    sortByModCount,
+    sortKey,
+    sortDirection,
     hideEmptyGroups,
     onCreateFolder: handleCreateFolderOpen,
     onDeleteFolder: handleDeleteFolder,
@@ -413,25 +428,63 @@ export const CharacterSidebar = memo(function CharacterSidebar({
               onChange={(e) => handleSearchChange(e.target.value)}
             />
           </div>
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  type="button"
-                  size="icon-sm"
-                  variant={sortByModCount ? "secondary" : "ghost"}
-                  aria-pressed={sortByModCount}
-                  onClick={() => setSortByModCount((value) => !value)}
-                />
-              }
-            >
-              <ArrowDown10Icon />
-              <span className="sr-only">{t("page.mod.character-sidebar.sort-by-mod-count")}</span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              {t("page.mod.character-sidebar.sort-by-mod-count")}
-            </TooltipContent>
-          </Tooltip>
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <DropdownMenuTrigger
+                    render={
+                      <Button
+                        type="button"
+                        size="icon-sm"
+                        variant="ghost"
+                        aria-label={t("page.mod.character-sidebar.sort.label")}
+                      />
+                    }
+                  />
+                }
+              >
+                <ArrowUpDownIcon />
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {t("page.mod.character-sidebar.sort.label")}
+              </TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="end" className="w-56" finalFocus={false}>
+              <DropdownMenuLabel>{t("page.mod.character-sidebar.sort.field")}</DropdownMenuLabel>
+              <DropdownMenuRadioGroup value={sortKey}>
+                {(["name", "mod-count", "enabled-mod-count"] as const).map((value) => (
+                  <DropdownMenuRadioItem
+                    key={value}
+                    value={value}
+                    onClick={() => setSortKey(value)}
+                  >
+                    {t(`page.mod.character-sidebar.sort.${value}`)}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel>
+                {t("page.mod.character-sidebar.sort.direction")}
+              </DropdownMenuLabel>
+              <DropdownMenuRadioGroup value={sortDirection}>
+                <DropdownMenuRadioItem
+                  value="ascending"
+                  onClick={() => setSortDirection("ascending")}
+                >
+                  <ArrowUpIcon />
+                  {t("page.mod.character-sidebar.sort.ascending")}
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem
+                  value="descending"
+                  onClick={() => setSortDirection("descending")}
+                >
+                  <ArrowDownIcon />
+                  {t("page.mod.character-sidebar.sort.descending")}
+                </DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
           <Tooltip>
             <TooltipTrigger
               render={

--- a/src/renderer/src/components/mod/mod-context-menu.tsx
+++ b/src/renderer/src/components/mod/mod-context-menu.tsx
@@ -11,10 +11,13 @@ import {
   ContextMenuTrigger,
 } from "@renderer/components/ui/context-menu";
 import type { ModActionApi } from "@renderer/hooks/use-mod-actions";
+import { Logger } from "@renderer/lib/logger";
 import type { ModInfo } from "@renderer/types/mod";
+import { useNavigate } from "@tanstack/react-router";
 import {
   BoxIcon,
   ClipboardIcon,
+  ExternalLinkIcon,
   FolderIcon,
   FolderTreeIcon,
   ImageIcon,
@@ -23,8 +26,9 @@ import {
   TerminalSquareIcon,
   TrashIcon,
 } from "lucide-react";
-import { type ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import { useTranslation } from "react-i18next";
+
 import wuwaModFixerIcon from "@/renderer/assets/img/wuwa-mod-fixer-icon.png";
 
 interface ModContextMenuProps {
@@ -35,12 +39,50 @@ interface ModContextMenuProps {
 
 export function ModContextMenu({ mod, actions, children }: ModContextMenuProps) {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [gameBananaSource, setGameBananaSource] = useState<{
+    modPath: string;
+    modId?: number;
+  } | null>(null);
+  const gameBananaModId =
+    gameBananaSource?.modPath === mod.path ? gameBananaSource.modId : undefined;
   const isConvertingModel = actions.convertingModelPath === mod.path;
 
+  const loadGameBananaModId = () => {
+    if (gameBananaSource?.modPath === mod.path) return;
+
+    const modPath = mod.path;
+    setGameBananaSource({ modPath });
+    void window.api
+      .invoke("mod:getGameBananaModId", modPath)
+      .then((modId) => setGameBananaSource({ modPath, modId }))
+      .catch((error) => Logger.error(error, "ModContextMenu:loadGameBananaModId"));
+  };
+
   return (
-    <ContextMenu>
-      <ContextMenuTrigger>{children}</ContextMenuTrigger>
+    <ContextMenu
+      onOpenChange={(open) => {
+        if (open) loadGameBananaModId();
+      }}
+    >
+      <ContextMenuTrigger onPointerEnter={loadGameBananaModId}>{children}</ContextMenuTrigger>
       <ContextMenuContent className="w-56">
+        {gameBananaModId && (
+          <>
+            <ContextMenuItem
+              onClick={() =>
+                void navigate({
+                  to: "/gamebanana",
+                  search: { mod: gameBananaModId },
+                })
+              }
+            >
+              <ExternalLinkIcon className="mr-2 size-4" />
+              {t("page.mod.context-menu.open-gamebanana")}
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+          </>
+        )}
         {(mod.preview?.match(/\.(jpeg|jpg|gif|png|webp|bmp|mp4|webm|ogg)$/i) ?? false) && (
           <>
             <ContextMenuGroup>

--- a/src/renderer/src/components/sidebar.tsx
+++ b/src/renderer/src/components/sidebar.tsx
@@ -156,7 +156,7 @@ export function Sidebar({ className }: { className?: string }) {
                   aria-current={isGameBananaPage ? "page" : undefined}
                   onPointerDown={handlePointerDown}
                   onClick={() => {
-                    if (isModPage) {
+                    if (isModPage && !gameBananaStore.getState().selectedGame) {
                       gameBananaStore.getState().requestModGameSync();
                     }
                     void navi({ to: "/gamebanana" });

--- a/src/renderer/src/hooks/use-gamebanana-data.ts
+++ b/src/renderer/src/hooks/use-gamebanana-data.ts
@@ -12,6 +12,11 @@ type GameBananaModPosts = Awaited<ReturnType<IpcHandlers["gamebanana:getModPosts
 
 export type GameBananaGameKey = keyof GameBananaGames;
 export type GameBananaModPostsSort = "popular" | "newest";
+export type GameBananaModIndexSort =
+    | "Generic_Newest"
+    | "Generic_MostLiked"
+    | "Generic_MostDownloaded"
+    | "Generic_MostViewed";
 export interface GameBananaSubmissionSelection {
     id: number;
     modelName: string;
@@ -44,13 +49,19 @@ export function useGameBananaGameSubfeed(gameId?: number, page = 1, enabled = tr
     });
 }
 
-export function useGameBananaModCategoryOverview(categoryId?: number, page = 1, enabled = true) {
+export function useGameBananaModCategoryOverview(
+    categoryId?: number,
+    page = 1,
+    sort: GameBananaModIndexSort = "Generic_Newest",
+    enabled = true,
+) {
     return useQuery<GameBananaModCategoryOverview>({
-        queryKey: ["gamebanana", "modCategoryOverview", categoryId, page],
+        queryKey: ["gamebanana", "modCategoryOverview", categoryId, page, sort],
         queryFn: () =>
             window.api.invoke("gamebanana:getModCategoryOverview", {
                 categoryId: categoryId as number,
                 page,
+                modSort: sort,
             }),
         enabled: enabled && Number.isFinite(categoryId),
         // placeholderData: keepPreviousData,

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -238,6 +238,9 @@
         "open-in-explorer": "Open in File Explorer",
         "create-folder": "Create New Folder",
         "delete-folder": "Delete Folder",
+        "sort-by-mod-count": "Sort by most mods",
+        "hide-empty-folders": "Hide empty folders",
+        "active-mod-count": "{{enabled}} active / {{total}} total",
         "collapse-subgroups": "Collapse subgroups",
         "expand-subgroups": "Expand subgroups",
         "unpersist-subgroups": "Unpersist subgroups",
@@ -612,6 +615,13 @@
       "mods": "Mods",
       "mods_description": "Browse paged mod listings for the selected category.",
       "search_mods": "Search mods...",
+      "mod_sort": {
+        "label": "Sort mods",
+        "Generic_Newest": "Newest",
+        "Generic_MostLiked": "Most liked",
+        "Generic_MostDownloaded": "Most downloaded",
+        "Generic_MostViewed": "Most viewed"
+      },
       "previous": "Previous",
       "next": "Next",
       "retry_later": "Retry later",
@@ -1229,7 +1239,8 @@
       "file_name_placeholder": "Enter file name",
       "download_location": "Download Location",
       "need_select_character_folder": "Select a character folder on the left",
-      "select_path_failed": "Failed to select path."
+      "select_path_failed": "Failed to select path.",
+      "download_and_return": "Download and return to GameBanana"
     }
   },
   "updater": {

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -238,7 +238,16 @@
         "open-in-explorer": "Open in File Explorer",
         "create-folder": "Create New Folder",
         "delete-folder": "Delete Folder",
-        "sort-by-mod-count": "Sort by most mods",
+        "sort": {
+          "label": "Sort folders",
+          "field": "Sort by",
+          "name": "Name",
+          "mod-count": "Mod count",
+          "enabled-mod-count": "Active mod count",
+          "direction": "Direction",
+          "ascending": "Ascending",
+          "descending": "Descending"
+        },
         "hide-empty-folders": "Hide empty folders",
         "active-mod-count": "{{enabled}} active / {{total}} total",
         "collapse-subgroups": "Collapse subgroups",

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -516,6 +516,7 @@
         "delete-preview": "Delete preview",
         "open-cmd": "Open CMD",
         "open-folder": "Open folder",
+        "open-gamebanana": "View on GameBanana",
         "mark-manual-subgroup": "Mark as subgroup",
         "rename": "Rename"
       },

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -218,6 +218,9 @@
         "open-in-explorer": "ファイルエクスプローラーで開く",
         "create-folder": "新しいフォルダーを作成",
         "delete-folder": "削除",
+        "sort-by-mod-count": "MOD 数の多い順に並べ替え",
+        "hide-empty-folders": "空のフォルダーを非表示",
+        "active-mod-count": "有効 {{enabled}} 件 / 全 {{total}} 件",
         "collapse-subgroups": "サブフォルダーを折りたたむ",
         "expand-subgroups": "サブフォルダーを探索",
         "unpersist-subgroups": "サブフォルダー指定を解除",
@@ -586,6 +589,13 @@
       "mods": "MOD",
       "mods_description": "選択したカテゴリの MOD 一覧をページ単位で表示します。",
       "search_mods": "MOD を検索...",
+      "mod_sort": {
+        "label": "MOD の並べ替え",
+        "Generic_Newest": "新着順",
+        "Generic_MostLiked": "高評価順",
+        "Generic_MostDownloaded": "ダウンロード順",
+        "Generic_MostViewed": "閲覧数順"
+      },
       "previous": "前へ",
       "next": "次へ",
       "retry_later": "後でもう一度お試しください",
@@ -1192,7 +1202,8 @@
       "file_name_placeholder": "ファイル名を入力してください",
       "download_location": "ダウンロード先",
       "need_select_character_folder": "左側でキャラクターフォルダーを選択してください",
-      "select_path_failed": "パスの選択に失敗しました。"
+      "select_path_failed": "パスの選択に失敗しました。",
+      "download_and_return": "ダウンロードして GameBanana に戻る"
     }
   },
   "updater": {

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -218,7 +218,16 @@
         "open-in-explorer": "ファイルエクスプローラーで開く",
         "create-folder": "新しいフォルダーを作成",
         "delete-folder": "削除",
-        "sort-by-mod-count": "MOD 数の多い順に並べ替え",
+        "sort": {
+          "label": "フォルダーを並べ替え",
+          "field": "並べ替え基準",
+          "name": "名前",
+          "mod-count": "MOD 数",
+          "enabled-mod-count": "有効な MOD 数",
+          "direction": "並べ替え方向",
+          "ascending": "昇順",
+          "descending": "降順"
+        },
         "hide-empty-folders": "空のフォルダーを非表示",
         "active-mod-count": "有効 {{enabled}} 件 / 全 {{total}} 件",
         "collapse-subgroups": "サブフォルダーを折りたたむ",

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -490,6 +490,7 @@
         "delete-preview": "プレビューを削除",
         "open-cmd": "CMDを開く",
         "open-folder": "フォルダーを開く",
+        "open-gamebanana": "GameBananaで表示",
         "mark-manual-subgroup": "サブグループとして指定",
         "rename": "名前を変更"
       },

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -217,6 +217,9 @@
         "open-in-explorer": "파일 탐색기에서 열기",
         "create-folder": "새 폴더 만들기",
         "delete-folder": "삭제",
+        "sort-by-mod-count": "모드가 많은 순으로 정렬",
+        "hide-empty-folders": "빈 폴더 숨기기",
+        "active-mod-count": "활성 {{enabled}}개 / 전체 {{total}}개",
         "collapse-subgroups": "서브폴더 접기",
         "expand-subgroups": "서브폴더로 탐색",
         "unpersist-subgroups": "서브폴더 지정 해제",
@@ -592,6 +595,13 @@
       "mods": "모드",
       "mods_description": "선택한 카테고리의 모드 목록을 페이지별로 탐색합니다.",
       "search_mods": "모드 검색...",
+      "mod_sort": {
+        "label": "모드 정렬",
+        "Generic_Newest": "최신순",
+        "Generic_MostLiked": "좋아요순",
+        "Generic_MostDownloaded": "다운로드순",
+        "Generic_MostViewed": "조회순"
+      },
       "previous": "이전",
       "next": "다음",
       "retry_later": "잠시 후 다시 시도하세요",
@@ -1211,7 +1221,8 @@
       "file_name_placeholder": "파일 이름을 입력하세요",
       "download_location": "다운로드 위치",
       "need_select_character_folder": "좌측에서 캐릭터 폴더를 선택하세요",
-      "select_path_failed": "경로 선택에 실패했습니다."
+      "select_path_failed": "경로 선택에 실패했습니다.",
+      "download_and_return": "다운로드 후 GameBanana로 돌아가기"
     }
   },
   "updater": {

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -496,6 +496,7 @@
         "delete-preview": "프리뷰 삭제",
         "open-cmd": "CMD 열기",
         "open-folder": "폴더 열기",
+        "open-gamebanana": "GameBanana에서 보기",
         "mark-manual-subgroup": "서브그룹으로 지정",
         "rename": "이름 변경"
       },

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -217,7 +217,16 @@
         "open-in-explorer": "파일 탐색기에서 열기",
         "create-folder": "새 폴더 만들기",
         "delete-folder": "삭제",
-        "sort-by-mod-count": "모드가 많은 순으로 정렬",
+        "sort": {
+          "label": "폴더 정렬",
+          "field": "정렬 기준",
+          "name": "이름",
+          "mod-count": "전체 모드 수",
+          "enabled-mod-count": "활성 모드 수",
+          "direction": "정렬 방향",
+          "ascending": "오름차순",
+          "descending": "내림차순"
+        },
         "hide-empty-folders": "빈 폴더 숨기기",
         "active-mod-count": "활성 {{enabled}}개 / 전체 {{total}}개",
         "collapse-subgroups": "서브폴더 접기",

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -217,7 +217,16 @@
         "open-in-explorer": "在文件资源管理器中打开",
         "create-folder": "新建文件夹",
         "delete-folder": "删除",
-        "sort-by-mod-count": "按模组数量降序排列",
+        "sort": {
+          "label": "文件夹排序",
+          "field": "排序依据",
+          "name": "名称",
+          "mod-count": "模组数量",
+          "enabled-mod-count": "已启用模组数量",
+          "direction": "排序方向",
+          "ascending": "升序",
+          "descending": "降序"
+        },
         "hide-empty-folders": "隐藏空文件夹",
         "active-mod-count": "已启用 {{enabled}} 个 / 共 {{total}} 个",
         "collapse-subgroups": "折叠子文件夹",

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -217,6 +217,9 @@
         "open-in-explorer": "在文件资源管理器中打开",
         "create-folder": "新建文件夹",
         "delete-folder": "删除",
+        "sort-by-mod-count": "按模组数量降序排列",
+        "hide-empty-folders": "隐藏空文件夹",
+        "active-mod-count": "已启用 {{enabled}} 个 / 共 {{total}} 个",
         "collapse-subgroups": "折叠子文件夹",
         "expand-subgroups": "探索子文件夹",
         "unpersist-subgroups": "取消子文件夹指定",
@@ -585,6 +588,13 @@
       "mods": "模组",
       "mods_description": "分页浏览所选分类下的模组列表。",
       "search_mods": "搜索模组...",
+      "mod_sort": {
+        "label": "模组排序",
+        "Generic_Newest": "最新",
+        "Generic_MostLiked": "最多点赞",
+        "Generic_MostDownloaded": "最多下载",
+        "Generic_MostViewed": "最多浏览"
+      },
       "previous": "上一页",
       "next": "下一页",
       "retry_later": "请稍后重试",
@@ -1191,7 +1201,8 @@
       "file_name_placeholder": "输入文件名",
       "download_location": "下载位置",
       "need_select_character_folder": "请在左侧选择角色文件夹",
-      "select_path_failed": "选择路径失败。"
+      "select_path_failed": "选择路径失败。",
+      "download_and_return": "下载并返回 GameBanana"
     }
   },
   "updater": {

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -489,6 +489,7 @@
         "delete-preview": "删除预览",
         "open-cmd": "打开 CMD",
         "open-folder": "打开文件夹",
+        "open-gamebanana": "在 GameBanana 中查看",
         "mark-manual-subgroup": "指定为子分组",
         "rename": "重命名"
       },

--- a/src/renderer/src/routes/gamebanana/-components/gamebanana-toolbar.tsx
+++ b/src/renderer/src/routes/gamebanana/-components/gamebanana-toolbar.tsx
@@ -17,8 +17,15 @@ import {
   MenubarTrigger,
 } from "@renderer/components/ui/menubar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@renderer/components/ui/tooltip";
-import { ArrowLeftIcon, ExternalLinkIcon, LinkIcon, LogOutIcon } from "lucide-react";
+import {
+  ArrowLeftIcon,
+  ChevronDownIcon,
+  ExternalLinkIcon,
+  LinkIcon,
+  LogOutIcon,
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
+
 import type { GameBananaBreadcrumbItem, GameOption } from "../-types";
 
 export function GameBananaToolbar({
@@ -34,7 +41,8 @@ export function GameBananaToolbar({
   canGoBack,
   isLoggingOut,
   onSelectGame,
-  onOpenModUrlDialog,
+  isModUrlOpen,
+  onToggleModUrl,
   onOpenGameProfile,
   onLogout,
   onGoBack,
@@ -53,8 +61,9 @@ export function GameBananaToolbar({
   canOpenProfile: boolean;
   canGoBack: boolean;
   isLoggingOut: boolean;
+  isModUrlOpen: boolean;
   onSelectGame: (game: GameOption["key"]) => void;
-  onOpenModUrlDialog: () => void;
+  onToggleModUrl: () => void;
   onOpenGameProfile: () => void;
   onLogout: () => void;
   onGoBack: () => void;
@@ -167,8 +176,15 @@ export function GameBananaToolbar({
           {stageLabel}
         </ButtonGroupText>
         <Tooltip>
-          <TooltipTrigger render={<Button variant="outline" onClick={onOpenModUrlDialog} />}>
+          <TooltipTrigger
+            render={
+              <Button variant="outline" onClick={onToggleModUrl} aria-expanded={isModUrlOpen} />
+            }
+          >
             <LinkIcon />
+            <ChevronDownIcon
+              className={isModUrlOpen ? "rotate-180 transition-transform" : "transition-transform"}
+            />
             <span className="sr-only">{t("page.gamebanana.open_mod_url.button")}</span>
           </TooltipTrigger>
           <TooltipContent side="bottom">{t("page.gamebanana.open_mod_url.button")}</TooltipContent>

--- a/src/renderer/src/routes/gamebanana/-panels/category-panel.tsx
+++ b/src/renderer/src/routes/gamebanana/-panels/category-panel.tsx
@@ -1,17 +1,27 @@
 import { Card, CardContent, CardHeader } from "@renderer/components/ui/card";
 import { Input } from "@renderer/components/ui/input";
 import { ScrollArea } from "@renderer/components/ui/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@renderer/components/ui/select";
+import type { GameBananaModIndexSort } from "@renderer/hooks/use-gamebanana-data";
 import { cn } from "@renderer/lib/utils";
 import type { TFunction } from "i18next";
 import { SearchIcon } from "lucide-react";
-import { ModGridCard } from "../-cards/mod-grid-card";
-import { ErrorState, OverviewSkeleton, PaginationButtons } from "../-shared/common";
-import { getGameBananaErrorPresentation } from "../-shared/errors";
+
 import type {
   CategoryOverviewQuery,
   GameBananaSubmissionSelection,
   SubmissionListItem,
 } from "../-types";
+
+import { ModGridCard } from "../-cards/mod-grid-card";
+import { ErrorState, OverviewSkeleton, PaginationButtons } from "../-shared/common";
+import { getGameBananaErrorPresentation } from "../-shared/errors";
 
 export function CategoryPanel({
   t,
@@ -20,10 +30,12 @@ export function CategoryPanel({
   filteredMods,
   modSearch,
   modsPage,
+  modsSort,
   hasSidebar,
   onChangeModSearch,
   onSelectMod,
   onModsPage,
+  onModsSort,
 }: {
   t: TFunction;
   language: string;
@@ -31,10 +43,12 @@ export function CategoryPanel({
   filteredMods: SubmissionListItem[];
   modSearch: string;
   modsPage: number;
+  modsSort: GameBananaModIndexSort;
   hasSidebar: boolean;
   onChangeModSearch: (value: string) => void;
   onSelectMod: (submission: GameBananaSubmissionSelection) => void;
   onModsPage: (page: number) => void;
+  onModsSort: (sort: GameBananaModIndexSort) => void;
 }) {
   const errorPresentation = getGameBananaErrorPresentation(categoryOverviewQuery.error, t);
   const metadata = categoryOverviewQuery.data?.index._aMetadata;
@@ -57,87 +71,102 @@ export function CategoryPanel({
   };
 
   return (
-    <>
-      <ScrollArea
-        className="h-full min-h-0 min-w-0"
-        viewportClassName="overflow-x-hidden [&>div]:!block [&>div]:!min-w-0 [&>div]:!w-full [&>div]:max-w-full"
-      >
-        <div className="min-w-0 max-w-full space-y-4 p-4">
-          <Card className="flex h-full min-h-0 flex-col">
-            <CardHeader>
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <div></div>
-                <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-                  <div className="relative w-full sm:w-64">
-                    <SearchIcon className="pointer-events-none absolute left-2 top-2.5 size-4 text-muted-foreground" />
-                    <Input
-                      className="pl-8"
-                      value={modSearch}
-                      onChange={(event) => onChangeModSearch(event.target.value)}
-                      placeholder={t("page.gamebanana.search_mods")}
-                    />
-                  </div>
-                  <PaginationButtons
-                    page={paginationPage}
-                    totalPages={paginationTotalPages}
-                    onPrev={() => handleModsPageChange(modsPage - 1)}
-                    onNext={() => handleModsPageChange(modsPage + 1)}
-                    onPageChange={handleModsPageChange}
-                    disablePrev={disablePrev}
-                    disableNext={disableNext}
-                  />
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent className="min-h-0 flex-1">
-              <ScrollArea className="h-full min-h-0 pr-4">
-                <div className="space-y-4">
-                  {categoryOverviewQuery.isLoading && <OverviewSkeleton />}
-                  {categoryOverviewQuery.error && (
-                    <ErrorState
-                      title={t("page.gamebanana.error_title")}
-                      description={errorPresentation.description}
-                      details={errorPresentation.details}
-                    />
+    <div className="h-full min-h-0 min-w-0 p-4">
+      <Card className="flex h-full min-h-0 flex-col">
+        <CardHeader className="shrink-0">
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <Select
+              value={modsSort}
+              onValueChange={(value) => onModsSort(value as GameBananaModIndexSort)}
+            >
+              <SelectTrigger
+                className="w-full sm:w-48"
+                aria-label={t("page.gamebanana.mod_sort.label")}
+              >
+                <SelectValue>
+                  {(value) => t(`page.gamebanana.mod_sort.${value ?? "Generic_Newest"}`)}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent align="start">
+                {[
+                  "Generic_Newest",
+                  "Generic_MostLiked",
+                  "Generic_MostDownloaded",
+                  "Generic_MostViewed",
+                ].map((sort) => (
+                  <SelectItem key={sort} value={sort}>
+                    {t(`page.gamebanana.mod_sort.${sort}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <div className="relative w-full sm:w-64">
+              <SearchIcon className="pointer-events-none absolute top-2.5 left-2 size-4 text-muted-foreground" />
+              <Input
+                className="pl-8"
+                value={modSearch}
+                onChange={(event) => onChangeModSearch(event.target.value)}
+                placeholder={t("page.gamebanana.search_mods")}
+              />
+            </div>
+            <PaginationButtons
+              page={paginationPage}
+              totalPages={paginationTotalPages}
+              onPrev={() => handleModsPageChange(modsPage - 1)}
+              onNext={() => handleModsPageChange(modsPage + 1)}
+              onPageChange={handleModsPageChange}
+              disablePrev={disablePrev}
+              disableNext={disableNext}
+            />
+          </div>
+        </CardHeader>
+        <CardContent className="min-h-0 flex-1 p-0 pl-6">
+          <ScrollArea className="h-full min-h-0 pr-4">
+            <div className="space-y-4">
+              {categoryOverviewQuery.isLoading && <OverviewSkeleton />}
+              {categoryOverviewQuery.error && (
+                <ErrorState
+                  title={t("page.gamebanana.error_title")}
+                  description={errorPresentation.description}
+                  details={errorPresentation.details}
+                />
+              )}
+              {categoryOverviewQuery.data && (
+                <section className="space-y-3">
+                  {filteredMods.length === 0 && (
+                    <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                      {t("page.gamebanana.no_results")}
+                    </div>
                   )}
-                  {categoryOverviewQuery.data && (
-                    <section className="space-y-3">
-                      {filteredMods.length === 0 && (
-                        <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
-                          {t("page.gamebanana.no_results")}
-                        </div>
-                      )}
 
-                      <div
-                        className={cn(
-                          "grid gap-4",
-                          hasSidebar
-                            ? "sm:grid-cols-3 2xl:grid-cols-4"
-                            : "sm:grid-cols-4 2xl:grid-cols-5",
-                        )}
-                      >
-                        {filteredMods.map((mod) => (
-                          <ModGridCard
-                            key={`mod-${mod._idRow}`}
-                            mod={mod}
-                            language={language}
-                            onClick={() =>
-                              onSelectMod({
-                                id: mod._idRow,
-                                modelName: mod._sModelName,
-                              })
-                            }
-                          />
-                        ))}
-                      </div>
-                    </section>
-                  )}
-                </div>
-              </ScrollArea>
-            </CardContent>
-          </Card>
-        </div>
-      </ScrollArea>
-    </>
+                  <div
+                    className={cn(
+                      "grid gap-4",
+                      hasSidebar
+                        ? "sm:grid-cols-3 2xl:grid-cols-4"
+                        : "sm:grid-cols-4 2xl:grid-cols-5",
+                    )}
+                  >
+                    {filteredMods.map((mod) => (
+                      <ModGridCard
+                        key={`mod-${mod._idRow}`}
+                        mod={mod}
+                        language={language}
+                        onClick={() =>
+                          onSelectMod({
+                            id: mod._idRow,
+                            modelName: mod._sModelName,
+                          })
+                        }
+                      />
+                    ))}
+                  </div>
+                </section>
+              )}
+            </div>
+          </ScrollArea>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/renderer/src/routes/gamebanana/-panels/game-home-panel.tsx
+++ b/src/renderer/src/routes/gamebanana/-panels/game-home-panel.tsx
@@ -33,62 +33,55 @@ export function GameHomePanel({
   const disableNext = subfeedQuery.data == null || Boolean(metadata?._bIsComplete);
 
   return (
-    <>
-      <ScrollArea
-        className="h-full min-h-0 min-w-0"
-        viewportClassName="overflow-x-hidden [&>div]:!block [&>div]:!min-w-0 [&>div]:!w-full [&>div]:max-w-full"
-      >
-        <div className="max-w-full min-w-0 space-y-4 p-4">
-          <Card className="flex h-full min-h-0 flex-col p-0">
-            <CardHeader>
-              <div className="flex items-center justify-between gap-3 pt-3">
-                <div>
-                  <CardTitle className="text-base">{t("page.gamebanana.latest_feed")}</CardTitle>
-                </div>
-                <PaginationButtons
-                  page={subfeedPage}
-                  totalPages={totalPages}
-                  onPrev={() => onSubfeedPage(subfeedPage - 1)}
-                  onNext={() => onSubfeedPage(subfeedPage + 1)}
-                  onPageChange={onSubfeedPage}
-                  disablePrev={subfeedPage <= 1}
-                  disableNext={disableNext}
+    <div className="h-full min-h-0 min-w-0 p-4">
+      <Card className="flex h-full min-h-0 flex-col p-0">
+        <CardHeader className="shrink-0">
+          <div className="flex items-center justify-between gap-3 pt-3">
+            <div>
+              <CardTitle className="text-base">{t("page.gamebanana.latest_feed")}</CardTitle>
+            </div>
+            <PaginationButtons
+              page={subfeedPage}
+              totalPages={totalPages}
+              onPrev={() => onSubfeedPage(subfeedPage - 1)}
+              onNext={() => onSubfeedPage(subfeedPage + 1)}
+              onPageChange={onSubfeedPage}
+              disablePrev={subfeedPage <= 1}
+              disableNext={disableNext}
+            />
+          </div>
+        </CardHeader>
+        <CardContent className="min-h-0 flex-1 p-0 px-1">
+          <ScrollArea className="h-full min-h-0">
+            <div className="space-y-3 p-4">
+              {subfeedQuery.isLoading && <OverviewSkeleton />}
+              {subfeedQuery.error && (
+                <ErrorState
+                  title={t("page.gamebanana.error_title")}
+                  description={errorPresentation.description}
+                  details={errorPresentation.details}
                 />
+              )}
+              <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 2xl:grid-cols-4">
+                {getFeedRecords(subfeedQuery).map((submission) => (
+                  <SubmissionCard
+                    key={`feed-${submission._idRow}-${getSubmissionDateKey(submission)}`}
+                    submission={submission}
+                    language={language}
+                    onClick={() =>
+                      onSelectMod({
+                        id: submission._idRow,
+                        modelName: submission._sModelName,
+                      })
+                    }
+                  />
+                ))}
               </div>
-            </CardHeader>
-            <CardContent className="min-h-0 flex-1 p-0 px-1">
-              <ScrollArea className="h-full min-h-0">
-                <div className="space-y-3 p-4">
-                  {subfeedQuery.isLoading && <OverviewSkeleton />}
-                  {subfeedQuery.error && (
-                    <ErrorState
-                      title={t("page.gamebanana.error_title")}
-                      description={errorPresentation.description}
-                      details={errorPresentation.details}
-                    />
-                  )}
-                  <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 2xl:grid-cols-4">
-                    {getFeedRecords(subfeedQuery).map((submission) => (
-                      <SubmissionCard
-                        key={`feed-${submission._idRow}-${getSubmissionDateKey(submission)}`}
-                        submission={submission}
-                        language={language}
-                        onClick={() =>
-                          onSelectMod({
-                            id: submission._idRow,
-                            modelName: submission._sModelName,
-                          })
-                        }
-                      />
-                    ))}
-                  </div>
-                </div>
-              </ScrollArea>
-            </CardContent>
-          </Card>
-        </div>
-      </ScrollArea>
-    </>
+            </div>
+          </ScrollArea>
+        </CardContent>
+      </Card>
+    </div>
   );
 }
 

--- a/src/renderer/src/routes/gamebanana/index.tsx
+++ b/src/renderer/src/routes/gamebanana/index.tsx
@@ -90,7 +90,6 @@ function RouteComponent() {
   const [manualRmcValue, setManualRmcValue] = useState("");
   const [manualRmcError, setManualRmcError] = useState<string | null>(null);
   const [isSavingManualRmc, setIsSavingManualRmc] = useState(false);
-  const [isModUrlOpen, setIsModUrlOpen] = useState(false);
   const [modUrlValue, setModUrlValue] = useState("");
   const [modUrlError, setModUrlError] = useState<string | null>(null);
   const isAuthReady = authStatus === "ready";
@@ -108,6 +107,7 @@ function RouteComponent() {
   const modsPage = useGameBananaStore((state) => state.modsPage);
   const modSearch = useGameBananaStore((state) => state.modSearch);
   const modsSort = useGameBananaStore((state) => state.modsSort);
+  const isModUrlOpen = useGameBananaStore((state) => state.isModUrlOpen);
   const setInitialGame = useGameBananaStore((state) => state.setInitialGame);
   const setSelectedGame = useGameBananaStore((state) => state.setSelectedGame);
   const selectCategory = useGameBananaStore((state) => state.selectCategory);
@@ -119,6 +119,7 @@ function RouteComponent() {
   const setModsPage = useGameBananaStore((state) => state.setModsPage);
   const setModSearch = useGameBananaStore((state) => state.setModSearch);
   const setModsSort = useGameBananaStore((state) => state.setModsSort);
+  const toggleModUrl = useGameBananaStore((state) => state.toggleModUrl);
 
   const games = useMemo<GameOption[]>(
     () =>
@@ -271,7 +272,7 @@ function RouteComponent() {
 
   const handleToggleModUrl = () => {
     setModUrlError(null);
-    setIsModUrlOpen((open) => !open);
+    toggleModUrl();
   };
 
   const handleOpenModUrl = () => {
@@ -282,7 +283,6 @@ function RouteComponent() {
     }
 
     selectMod(selection);
-    setIsModUrlOpen(false);
     setModUrlValue("");
     setModUrlError(null);
   };

--- a/src/renderer/src/routes/gamebanana/index.tsx
+++ b/src/renderer/src/routes/gamebanana/index.tsx
@@ -27,6 +27,9 @@ import { Loader2Icon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import isURL from "validator/lib/isURL";
+
+import type { GameOption } from "./-types";
+
 import { GameBananaToolbar } from "./-components/gamebanana-toolbar";
 import { CategoryPanel } from "./-panels/category-panel";
 import { GameHomePanel } from "./-panels/game-home-panel";
@@ -34,11 +37,20 @@ import { ModDetailPanel } from "./-panels/mod-detail-panel";
 import { GameBananaAuthState } from "./-shared/common";
 import { CategorySidebar } from "./-sidebars/category-sidebar";
 import { ModFilesSidebar } from "./-sidebars/mod-files-sidebar";
-import type { GameOption } from "./-types";
 
 const EMPTY_GAMES_MAP: Record<string, number> = {};
 
 export const Route = createFileRoute("/gamebanana/")({
+  validateSearch: (search: Record<string, unknown>) => {
+    const mod =
+      typeof search.mod === "number"
+        ? search.mod
+        : typeof search.mod === "string" && /^\d+$/.test(search.mod)
+          ? Number(search.mod)
+          : undefined;
+
+    return mod && Number.isSafeInteger(mod) ? { mod } : {};
+  },
   component: RouteComponent,
 });
 
@@ -48,7 +60,7 @@ function parseGameBananaModUrl(value: string) {
     !isURL(trimmedValue, {
       protocols: ["http", "https"],
       require_protocol: true,
-      host_whitelist: ["gamebanana.com"],
+      host_whitelist: ["gamebanana.com", "www.gamebanana.com"],
       disallow_auth: true,
       allow_fragments: true,
       allow_query_components: true,
@@ -69,6 +81,8 @@ function parseGameBananaModUrl(value: string) {
 
 function RouteComponent() {
   const { t, i18n } = useTranslation();
+  const { mod: deepLinkedModId } = Route.useSearch();
+  const navigate = Route.useNavigate();
   const [authStatus, setAuthStatus] = useState<"checking" | "ready" | "error">("checking");
   const [authErrorCode, setAuthErrorCode] = useState<string | null>(null);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
@@ -76,7 +90,7 @@ function RouteComponent() {
   const [manualRmcValue, setManualRmcValue] = useState("");
   const [manualRmcError, setManualRmcError] = useState<string | null>(null);
   const [isSavingManualRmc, setIsSavingManualRmc] = useState(false);
-  const [isModUrlDialogOpen, setIsModUrlDialogOpen] = useState(false);
+  const [isModUrlOpen, setIsModUrlOpen] = useState(false);
   const [modUrlValue, setModUrlValue] = useState("");
   const [modUrlError, setModUrlError] = useState<string | null>(null);
   const isAuthReady = authStatus === "ready";
@@ -93,6 +107,7 @@ function RouteComponent() {
   const subfeedPage = useGameBananaStore((state) => state.subfeedPage);
   const modsPage = useGameBananaStore((state) => state.modsPage);
   const modSearch = useGameBananaStore((state) => state.modSearch);
+  const modsSort = useGameBananaStore((state) => state.modsSort);
   const setInitialGame = useGameBananaStore((state) => state.setInitialGame);
   const setSelectedGame = useGameBananaStore((state) => state.setSelectedGame);
   const selectCategory = useGameBananaStore((state) => state.selectCategory);
@@ -103,6 +118,7 @@ function RouteComponent() {
   const setSubfeedPage = useGameBananaStore((state) => state.setSubfeedPage);
   const setModsPage = useGameBananaStore((state) => state.setModsPage);
   const setModSearch = useGameBananaStore((state) => state.setModSearch);
+  const setModsSort = useGameBananaStore((state) => state.setModsSort);
 
   const games = useMemo<GameOption[]>(
     () =>
@@ -121,6 +137,7 @@ function RouteComponent() {
   const categoryOverviewQuery = useGameBananaModCategoryOverview(
     selectedCategoryId,
     modsPage,
+    modsSort,
     isAuthReady,
   );
   const modOverviewQuery = useGameBananaModOverview(selectedMod, isAuthReady);
@@ -185,6 +202,16 @@ function RouteComponent() {
     setSelectedGame(gameBananaKey as GameBananaGameKey);
   }, [games, modGames, isModGamesLoading, setSelectedGame]);
 
+  useEffect(() => {
+    if (!isAuthReady || !deepLinkedModId) return;
+
+    selectMod({ id: deepLinkedModId, modelName: "Mod" });
+    void navigate({
+      replace: true,
+      search: (previous) => ({ ...previous, mod: undefined }),
+    });
+  }, [deepLinkedModId, isAuthReady, navigate, selectMod]);
+
   const rootCategories = gameOverviewQuery.data?.profile._aModRootCategories ?? [];
   const categoryChildren = categoryOverviewQuery.data?.categories ?? [];
   const mods = categoryOverviewQuery.data?.index._aRecords ?? [];
@@ -242,9 +269,9 @@ function RouteComponent() {
     void window.api.invoke("util:openExternal", currentProfileUrl);
   };
 
-  const handleOpenModUrlDialog = () => {
+  const handleToggleModUrl = () => {
     setModUrlError(null);
-    setIsModUrlDialogOpen(true);
+    setIsModUrlOpen((open) => !open);
   };
 
   const handleOpenModUrl = () => {
@@ -255,7 +282,7 @@ function RouteComponent() {
     }
 
     selectMod(selection);
-    setIsModUrlDialogOpen(false);
+    setIsModUrlOpen(false);
     setModUrlValue("");
     setModUrlError(null);
   };
@@ -454,7 +481,7 @@ function RouteComponent() {
     <>
       <Titlebar title={{ text: "GameBanana", position: "center" }} />
       <main className="flex h-full flex-1 flex-col overflow-hidden bg-background">
-        <div className="lg:hidden flex h-full items-center justify-center p-4">
+        <div className="flex h-full items-center justify-center p-4 lg:hidden">
           <div className="w-full max-w-md rounded-xl border border-dashed p-6 text-center">
             <div className="text-base font-medium">{t("page.gamebanana.narrow_window.title")}</div>
             <div className="mt-2 text-sm text-muted-foreground">
@@ -463,7 +490,7 @@ function RouteComponent() {
           </div>
         </div>
 
-        <div className="hidden lg:flex lg:flex-col lg:flex-1 lg:overflow-hidden">
+        <div className="hidden lg:flex lg:flex-1 lg:flex-col lg:overflow-hidden">
           <div className="border-b px-4 py-3">
             <GameBananaToolbar
               games={games}
@@ -481,7 +508,8 @@ function RouteComponent() {
               isGamesLoading={isGamesLoading}
               gamesError={Boolean(gamesError)}
               onSelectGame={setSelectedGame}
-              onOpenModUrlDialog={handleOpenModUrlDialog}
+              isModUrlOpen={isModUrlOpen}
+              onToggleModUrl={handleToggleModUrl}
               onOpenGameProfile={handleOpenGameProfile}
               isLoggingOut={isLoggingOut}
               onLogout={handleLogout}
@@ -492,6 +520,27 @@ function RouteComponent() {
               canOpenProfile={Boolean(currentProfileUrl)}
               onResetToGameHome={resetToGameHome}
             />
+            {isModUrlOpen && (
+              <form
+                className="mt-3 flex items-start gap-2 border-t pt-3"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  handleOpenModUrl();
+                }}
+              >
+                <div className="min-w-0 flex-1 space-y-1">
+                  <Input
+                    value={modUrlValue}
+                    placeholder={t("page.gamebanana.open_mod_url.placeholder")}
+                    onChange={(event) => setModUrlValue(event.target.value)}
+                    aria-label={t("page.gamebanana.open_mod_url.title")}
+                    autoFocus
+                  />
+                  {modUrlError && <p className="text-sm text-destructive">{modUrlError}</p>}
+                </div>
+                <Button type="submit">{t("page.gamebanana.open_mod_url.confirm")}</Button>
+              </form>
+            )}
           </div>
 
           <div
@@ -520,10 +569,12 @@ function RouteComponent() {
                   filteredMods={filteredMods}
                   modSearch={modSearch}
                   modsPage={modsPage}
+                  modsSort={modsSort}
                   hasSidebar={showCategorySidebar}
                   onChangeModSearch={setModSearch}
                   onSelectMod={selectMod}
                   onModsPage={setModsPage}
+                  onModsSort={setModsSort}
                 />
               )}
 
@@ -538,7 +589,7 @@ function RouteComponent() {
             </div>
 
             {showCategorySidebar && (
-              <div className="min-h-0 min-w-0 pr-4 py-4">
+              <div className="min-h-0 min-w-0 py-4 pr-4">
                 {isViewingMod ? (
                   <ModFilesSidebar
                     t={t}
@@ -567,43 +618,6 @@ function RouteComponent() {
             )}
           </div>
         </div>
-        <Dialog
-          open={isModUrlDialogOpen}
-          onOpenChange={(open) => {
-            setIsModUrlDialogOpen(open);
-            if (!open) {
-              setModUrlError(null);
-            }
-          }}
-        >
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>{t("page.gamebanana.open_mod_url.title")}</DialogTitle>
-            </DialogHeader>
-            <div className="space-y-2">
-              <Input
-                value={modUrlValue}
-                placeholder={t("page.gamebanana.open_mod_url.placeholder")}
-                onChange={(event) => setModUrlValue(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    event.preventDefault();
-                    handleOpenModUrl();
-                  }
-                }}
-              />
-              {modUrlError && <p className="text-sm text-destructive">{modUrlError}</p>}
-            </div>
-            <DialogFooter>
-              <Button variant="outline" onClick={() => setIsModUrlDialogOpen(false)}>
-                {t("g.cancel")}
-              </Button>
-              <Button onClick={handleOpenModUrl}>
-                {t("page.gamebanana.open_mod_url.confirm")}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
       </main>
     </>
   );

--- a/src/renderer/src/store/gamebanana.ts
+++ b/src/renderer/src/store/gamebanana.ts
@@ -1,4 +1,7 @@
-import type { GameBananaGameKey } from "@renderer/hooks/use-gamebanana-data";
+import type {
+    GameBananaGameKey,
+    GameBananaModIndexSort,
+} from "@renderer/hooks/use-gamebanana-data";
 import { createStore, useStore } from "zustand";
 
 const DEFAULT_SUBFEED_PAGE = 1;
@@ -23,6 +26,7 @@ interface GameBananaState {
     subfeedPage: number;
     modsPage: number;
     modSearch: string;
+    modsSort: GameBananaModIndexSort;
     setSelectedGame: (game: GameBananaGameKey) => void;
     setInitialGame: (game: GameBananaGameKey) => void;
     requestModGameSync: () => void;
@@ -35,6 +39,7 @@ interface GameBananaState {
     setSubfeedPage: (page: number) => void;
     setModsPage: (page: number) => void;
     setModSearch: (query: string) => void;
+    setModsSort: (sort: GameBananaModIndexSort) => void;
 }
 
 export const gameBananaStore = createStore<GameBananaState>((set, get) => ({
@@ -46,6 +51,7 @@ export const gameBananaStore = createStore<GameBananaState>((set, get) => ({
     subfeedPage: DEFAULT_SUBFEED_PAGE,
     modsPage: DEFAULT_MODS_PAGE,
     modSearch: "",
+    modsSort: "Generic_Newest",
     setSelectedGame: (selectedGame) =>
         set({
             selectedGame,
@@ -114,6 +120,7 @@ export const gameBananaStore = createStore<GameBananaState>((set, get) => ({
     setSubfeedPage: (subfeedPage) => set({ subfeedPage: Math.max(1, subfeedPage) }),
     setModsPage: (modsPage) => set({ modsPage: Math.max(1, modsPage) }),
     setModSearch: (modSearch) => set({ modSearch }),
+    setModsSort: (modsSort) => set({ modsSort, modsPage: DEFAULT_MODS_PAGE }),
 }));
 
 export function useGameBananaStore<T>(selector: (state: GameBananaState) => T): T {

--- a/src/renderer/src/store/gamebanana.ts
+++ b/src/renderer/src/store/gamebanana.ts
@@ -27,6 +27,7 @@ interface GameBananaState {
     modsPage: number;
     modSearch: string;
     modsSort: GameBananaModIndexSort;
+    isModUrlOpen: boolean;
     setSelectedGame: (game: GameBananaGameKey) => void;
     setInitialGame: (game: GameBananaGameKey) => void;
     requestModGameSync: () => void;
@@ -40,6 +41,7 @@ interface GameBananaState {
     setModsPage: (page: number) => void;
     setModSearch: (query: string) => void;
     setModsSort: (sort: GameBananaModIndexSort) => void;
+    toggleModUrl: () => void;
 }
 
 export const gameBananaStore = createStore<GameBananaState>((set, get) => ({
@@ -52,6 +54,7 @@ export const gameBananaStore = createStore<GameBananaState>((set, get) => ({
     modsPage: DEFAULT_MODS_PAGE,
     modSearch: "",
     modsSort: "Generic_Newest",
+    isModUrlOpen: false,
     setSelectedGame: (selectedGame) =>
         set({
             selectedGame,
@@ -121,6 +124,7 @@ export const gameBananaStore = createStore<GameBananaState>((set, get) => ({
     setModsPage: (modsPage) => set({ modsPage: Math.max(1, modsPage) }),
     setModSearch: (modSearch) => set({ modSearch }),
     setModsSort: (modsSort) => set({ modsSort, modsPage: DEFAULT_MODS_PAGE }),
+    toggleModUrl: () => set((state) => ({ isModUrlOpen: !state.isModUrlOpen })),
 }));
 
 export function useGameBananaStore<T>(selector: (state: GameBananaState) => T): T {

--- a/src/renderer/src/store/mod.ts
+++ b/src/renderer/src/store/mod.ts
@@ -2,6 +2,9 @@ import type { DownloadSource } from "@shared/mod";
 import type { FolderGroup, GameConfig, Preset } from "@shared/types";
 import { createStore, useStore } from "zustand";
 
+export type FolderSortKey = "name" | "mod-count" | "enabled-mod-count";
+export type FolderSortDirection = "ascending" | "descending";
+
 interface ModState {
     selectedGame: string;
     setSelectedGame: (game: string) => void;
@@ -58,6 +61,10 @@ interface ModState {
     setSortType: (type: "name" | "date" | "size") => void;
     sortOrder: "asc" | "desc";
     setSortOrder: (order: "asc" | "desc") => void;
+    folderSortKey: FolderSortKey;
+    setFolderSortKey: (key: FolderSortKey) => void;
+    folderSortDirection: FolderSortDirection;
+    setFolderSortDirection: (direction: FolderSortDirection) => void;
     expandedGroups: Set<string>;
     persistentGroups: Set<string>;
     iniListExpandedByGroupPath: Record<string, Record<string, boolean>>;
@@ -112,6 +119,10 @@ export const modStore = createStore<ModState>((set) => ({
     setSortType: (sortType) => set({ sortType }),
     sortOrder: "asc",
     setSortOrder: (sortOrder) => set({ sortOrder }),
+    folderSortKey: "name",
+    setFolderSortKey: (folderSortKey) => set({ folderSortKey }),
+    folderSortDirection: "ascending",
+    setFolderSortDirection: (folderSortDirection) => set({ folderSortDirection }),
 
     expandedGroups: new Set<string>(),
     persistentGroups: new Set<string>(),

--- a/src/renderer/src/types/mod.ts
+++ b/src/renderer/src/types/mod.ts
@@ -36,6 +36,7 @@ export interface FolderGroup {
     mods: ModInfo[];
     preview?: string;
     modCount?: number;
+    enabledModCount?: number;
     isManualSubGroup?: boolean;
     hasManualSubGroups?: boolean;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -170,6 +170,7 @@ export interface FolderGroup {
     mods: ModInfo[];
     preview?: string;
     modCount?: number;
+    enabledModCount?: number;
     isManualSubGroup?: boolean;
     hasManualSubGroups?: boolean;
 }


### PR DESCRIPTION
## Summary
- Add mod-folder sorting by name, total mod count, or active mod count with ascending and descending order controls.
- Add empty-folder filtering, enabled/total counts, and a persistent list/grid folder layout toggle.
- Preserve GameBanana browsing and mod URL panel state when navigating away and back.
- Keep feed and pagination controls outside scrolling content and replace the mod URL dialog with an inline collapsible form.
- Add GameBanana sorting by newest, most liked, most downloaded, and most viewed.
- Register and handle `nahida://gamebanana/...` deep links for browser-extension integration.

## Pre-Landing Review
No blocking issues found.

## Test Plan
- [x] `pnpm fmt -- <changed files>`
- [x] `pnpm lint -- <changed TypeScript files>`
- [x] `pnpm test` (97 tests passed)
- [x] `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deep links for opening GameBanana mods directly in the desktop app.
  * Added GameBanana sorting by newest, most liked, most downloaded, or most viewed.
  * Added character-folder sorting, empty-folder filtering, and enabled/total mod count badges.
  * Added inline GameBanana URL entry with validation and improved navigation.
  * Added an “Open GameBanana” action for compatible downloaded mods.
  * Download confirmation can now return to GameBanana.

* **Bug Fixes**
  * Improved window focusing and navigation when opening links.
  * Corrected enabled mod counts for disabled folders and mods.
  * Improved GameBanana URL handling and synchronization behavior.

* **Localization**
  * Added English, Japanese, Korean, and Chinese translations for the new controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->