### PR TITLE
feat: add GameBanana likes and search tools

### DIFF
--- a/src/main/ipc/handlers/gamebanana.ts
+++ b/src/main/ipc/handlers/gamebanana.ts
@@ -16,6 +16,17 @@ export function registerGameBananaHandlers(d: NahidaDesktop) {
     );
     rh("gamebanana:getModIndex", async (input) => d.service.gamebanana.getModIndex(input));
     rh("gamebanana:getModOverview", async (input) => d.service.gamebanana.getModOverview(input));
+    rh("gamebanana:toggleModLike", async (input) => {
+        try {
+            return await d.service.gamebanana.toggleModLike(input);
+        } catch (error) {
+            d.logger.error(
+                error,
+                `GameBanana:toggleModLike:${input.modelName ?? "Mod"}:${input.itemId}`,
+            );
+            throw error;
+        }
+    });
     rh("gamebanana:getModPosts", async (input) => d.service.gamebanana.getModPosts(input));
     rh("gamebanana:logout", async () => d.service.gamebanana.logout());
 }

--- a/src/main/ipc/handlers/mod.ts
+++ b/src/main/ipc/handlers/mod.ts
@@ -162,7 +162,15 @@ export function registerModHandlers(desktop: NahidaDesktop) {
     rh(
         "mod:downloadGameBananaFile",
         async (props: { itemId: number; fileId: number; modelName?: string }) => {
-            return await desktop.lib.customDownloader.GBDownloader(props);
+            try {
+                return await desktop.lib.customDownloader.GBDownloader(props);
+            } catch (error) {
+                desktop.logger.error(
+                    error,
+                    `Mod:downloadGameBananaFile:${props.modelName ?? "Mod"}:${props.itemId}:${props.fileId}`,
+                );
+                throw error;
+            }
         },
     );
 

--- a/src/main/lib/custom-downloader/index.ts
+++ b/src/main/lib/custom-downloader/index.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 
 import type { ResolvedArchiveExtractPathMode } from "@shared/mod";
 import type { TransferData } from "@shared/types";
+import { toErrorMessage } from "@shared/utils";
 import { throttle } from "es-toolkit";
 import fse from "fs-extra";
 import ky from "ky";
@@ -351,10 +352,14 @@ export class CustomDownloader {
             headers: await this.desktop.httpService.getHeaders(fileUrl),
         });
 
-        const resp = await respPromise;
+        const resp = await respPromise.catch((error) => {
+            throw new Error(`GAMEBANANA_DOWNLOAD_HEAD_FAILED:${toErrorMessage(error)}`);
+        });
 
         if (!resp.ok) {
-            throw new Error(`Failed to get real file URL: ${resp.statusText}`);
+            throw new Error(
+                `GAMEBANANA_DOWNLOAD_HEAD_FAILED:${resp.status}:${resp.statusText || "UNKNOWN"}`,
+            );
         }
 
         const realFileUrl = resp.url;
@@ -526,7 +531,10 @@ export class CustomDownloader {
                     void this.desktop.service.transfer.updateTransfer(pid, { status: "canceled" });
                 } else {
                     this.desktop.logger.error(err, "GameBanana:downloadFromGB");
-                    void this.desktop.service.transfer.updateTransfer(pid, { status: "error" });
+                    void this.desktop.service.transfer.updateTransfer(pid, {
+                        status: "error",
+                        error: toErrorMessage(err),
+                    });
                 }
             } finally {
                 await fse.remove(stagingPath).catch(() => {});

--- a/src/main/services/gamebanana/index.ts
+++ b/src/main/services/gamebanana/index.ts
@@ -942,6 +942,32 @@ export class GameBananaService {
         );
     }
 
+    public async toggleModLike({
+        itemId,
+        modelName = "Mod",
+    }: {
+        itemId: number;
+        modelName?: GameBananaSubmissionModel;
+    }) {
+        const profile =
+            this.getLastViewedModProfile(itemId, modelName) ??
+            (await this.getModProfile(itemId, modelName));
+        const wasLiked =
+            profile._bAccessorHasLiked ??
+            (await this.getModConfig(itemId, modelName))._aAccess?.Like_Trash === true;
+        const url = this.formatUrl(`${this.apiBaseUrl}/${modelName}/{}/Like`, itemId);
+
+        await this.request(url, {
+            method: wasLiked ? "DELETE" : "POST",
+            headers: {
+                Referer: this.getSubmissionReferer(modelName, itemId),
+            },
+        });
+
+        this.lastViewedModProfile = null;
+        return { liked: !wasLiked };
+    }
+
     public async getModPosts({
         modId,
         modelName = "Mod",

--- a/src/main/services/gamebanana/model.ts
+++ b/src/main/services/gamebanana/model.ts
@@ -187,6 +187,8 @@ export const ModProfileSchema = z
         _sText: z.string().optional(),
         _nLikeCount: z.number().optional(),
         _nViewCount: z.number().optional(),
+        _bAccessorHasLiked: z.boolean().optional(),
+        _bAccessorHasUnliked: z.boolean().optional(),
         _aSubmitter: MemberSchema,
         _aGame: GameSchema,
         _aCategory: NestedCategorySchema,

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -586,6 +586,8 @@
       "category_panel_description_nested": "Browse subcategories in the current category.",
       "category_panel_description_selected": "Browse subcategories in \"{{name}}\".",
       "no_categories": "There are no categories to display.",
+      "search_categories": "Search categories...",
+      "no_category_results": "No matching categories found.",
       "stage": {
         "game": "Game",
         "category": "Category",
@@ -615,6 +617,12 @@
         "views": "Views",
         "downloads": "Downloads"
       },
+      "like": "Like",
+      "liked": "Liked",
+      "unlike": "Unlike",
+      "like_unavailable": "Like is unavailable for this mod.",
+      "like_failed": "Failed to update the like.",
+      "download_failed": "GameBanana download failed.",
       "top_submissions": "Top Submissions",
       "latest_feed": "Latest Feed",
       "latest_feed_description": "Recent submissions for the selected game.",
@@ -1215,7 +1223,9 @@
       "adv": {
         "title": "Advanced",
         "warning_title": "Caution",
-        "warning_description": "Changing settings here may affect app behavior."
+        "warning_description": "Changing settings here may affect app behavior.",
+        "search_placeholder": "Search setting keys...",
+        "no_results": "No matching setting keys found."
       }
     },
     "docs": {

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -560,6 +560,8 @@
       "category_panel_description_nested": "現在のカテゴリのサブカテゴリを探索します。",
       "category_panel_description_selected": "\"{{name}}\" のサブカテゴリを探索します。",
       "no_categories": "表示できるカテゴリがありません。",
+      "search_categories": "カテゴリを検索...",
+      "no_category_results": "一致するカテゴリはありません。",
       "stage": {
         "game": "ゲーム",
         "category": "カテゴリ",
@@ -589,6 +591,12 @@
         "views": "閲覧数",
         "downloads": "ダウンロード"
       },
+      "like": "いいね",
+      "liked": "いいね済み",
+      "unlike": "いいねを取り消す",
+      "like_unavailable": "この MOD ではいいねを利用できません。",
+      "like_failed": "いいねの更新に失敗しました。",
+      "download_failed": "GameBanana のダウンロードに失敗しました。",
       "top_submissions": "注目投稿",
       "latest_feed": "最新フィード",
       "latest_feed_description": "選択したゲームの最近の投稿です。",
@@ -1135,7 +1143,9 @@
       "adv": {
         "title": "詳細設定",
         "warning_title": "注意",
-        "warning_description": "ここでの設定を変更すると、アプリの動作に影響を与える可能性があります。"
+        "warning_description": "ここでの設定を変更すると、アプリの動作に影響を与える可能性があります。",
+        "search_placeholder": "設定キーを検索...",
+        "no_results": "一致する設定キーはありません。"
       },
       "transfer": {
         "title": "転送",

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -566,6 +566,8 @@
       "category_panel_description_nested": "현재 카테고리의 하위 카테고리를 탐색합니다.",
       "category_panel_description_selected": "\"{{name}}\"의 하위 카테고리를 탐색합니다.",
       "no_categories": "표시할 카테고리가 없습니다.",
+      "search_categories": "카테고리 검색...",
+      "no_category_results": "일치하는 카테고리가 없습니다.",
       "stage": {
         "game": "게임",
         "category": "카테고리",
@@ -595,6 +597,12 @@
         "views": "조회수",
         "downloads": "다운로드"
       },
+      "like": "좋아요",
+      "liked": "좋아요 누름",
+      "unlike": "좋아요 취소",
+      "like_unavailable": "이 모드에는 좋아요를 사용할 수 없습니다.",
+      "like_failed": "좋아요 상태를 변경하지 못했습니다.",
+      "download_failed": "GameBanana 다운로드에 실패했습니다.",
       "top_submissions": "주요 제출물",
       "latest_feed": "최신 피드",
       "latest_feed_description": "선택한 게임의 최근 제출물입니다.",
@@ -1154,7 +1162,9 @@
       "adv": {
         "title": "고급",
         "warning_title": "주의",
-        "warning_description": "이 곳의 설정을 변경하면 앱 동작에 영향을 줄 수 있습니다."
+        "warning_description": "이 곳의 설정을 변경하면 앱 동작에 영향을 줄 수 있습니다.",
+        "search_placeholder": "설정 key 검색...",
+        "no_results": "일치하는 설정 key가 없습니다."
       },
       "transfer": {
         "title": "전송",

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -559,6 +559,8 @@
       "category_panel_description_nested": "浏览当前分类下的子分类。",
       "category_panel_description_selected": "浏览“{{name}}”下的子分类。",
       "no_categories": "没有可显示的分类。",
+      "search_categories": "搜索分类...",
+      "no_category_results": "没有匹配的分类。",
       "stage": {
         "game": "游戏",
         "category": "分类",
@@ -588,6 +590,12 @@
         "views": "浏览量",
         "downloads": "下载量"
       },
+      "like": "点赞",
+      "liked": "已点赞",
+      "unlike": "取消点赞",
+      "like_unavailable": "此模组无法点赞。",
+      "like_failed": "更新点赞状态失败。",
+      "download_failed": "GameBanana 下载失败。",
       "top_submissions": "热门投稿",
       "latest_feed": "最新动态",
       "latest_feed_description": "所选游戏的最新投稿。",
@@ -1134,7 +1142,9 @@
       "adv": {
         "title": "高级设置",
         "warning_title": "注意",
-        "warning_description": "更改此处的设置可能会影响应用行为。"
+        "warning_description": "更改此处的设置可能会影响应用行为。",
+        "search_placeholder": "搜索设置键...",
+        "no_results": "没有匹配的设置键。"
       },
       "transfer": {
         "title": "传输",

--- a/src/renderer/src/routes/gamebanana/-panels/mod-detail-panel.tsx
+++ b/src/renderer/src/routes/gamebanana/-panels/mod-detail-panel.tsx
@@ -17,12 +17,14 @@ import {
   type GameBananaModPostsSort,
   type GameBananaSubmissionSelection,
 } from "@renderer/hooks/use-gamebanana-data";
+import { Logger } from "@renderer/lib/logger";
 import { cn } from "@renderer/lib/utils";
 import DOMPurify from "dompurify";
 import type { TFunction } from "i18next";
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
+  HeartIcon,
   ImageIcon,
   Loader2Icon,
   MessageSquareIcon,
@@ -30,6 +32,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
+import { toast } from "sonner";
 
 import type { ModOverviewQuery } from "../-types";
 
@@ -240,11 +243,36 @@ export function ModDetailPanel({
   const hiddenPreviewCount = previews.length - (maxVisiblePreviews - 1);
   const [lightboxPreviewIndex, setLightboxPreviewIndex] = useState<number | null>(null);
   const [commentSort, setCommentSort] = useState<GameBananaModPostsSort>("popular");
+  const [isLikePending, setIsLikePending] = useState(false);
   const commentsQuery = useGameBananaModPosts(modId, modelName, 1, commentSort, Boolean(modId));
   const modErrorPresentation = getGameBananaErrorPresentation(modOverviewQuery.error, t);
   const commentsErrorPresentation = getGameBananaErrorPresentation(commentsQuery.error, t);
   const lightboxPreview =
     lightboxPreviewIndex === null ? null : (previews[lightboxPreviewIndex] ?? null);
+  const profile = modOverviewQuery.data?.profile;
+  const likeAccess = modOverviewQuery.data?.config._aAccess;
+  const isLiked = profile?._bAccessorHasLiked ?? likeAccess?.Like_Trash === true;
+  const canToggleLike = likeAccess?.Like_Add === true || likeAccess?.Like_Trash === true;
+
+  const handleLike = async () => {
+    if (!modId || !canToggleLike || isLikePending) return;
+
+    setIsLikePending(true);
+    try {
+      await window.api.invoke("gamebanana:toggleModLike", {
+        itemId: modId,
+        modelName,
+      });
+      await modOverviewQuery.refetch();
+    } catch (error) {
+      toast.error(t("page.gamebanana.like_failed"), {
+        description: String(error instanceof Error ? error.message : error),
+      });
+      Logger.error(error, "ModDetailPanel:handleLike");
+    } finally {
+      setIsLikePending(false);
+    }
+  };
 
   useEffect(() => {
     setLightboxPreviewIndex(null);
@@ -252,6 +280,10 @@ export function ModDetailPanel({
 
   useEffect(() => {
     setCommentSort("popular");
+  }, [modId, modelName]);
+
+  useEffect(() => {
+    setIsLikePending(false);
   }, [modId, modelName]);
 
   const comments = useMemo(() => {
@@ -314,8 +346,37 @@ export function ModDetailPanel({
                     </Badge>
                     <Badge variant="outline">{modOverviewQuery.data.profile._aGame._sName}</Badge>
                   </div>
-                  <div className="text-2xl font-semibold">
-                    {modOverviewQuery.data.profile._sName}
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="min-w-0 text-2xl font-semibold">
+                      {modOverviewQuery.data.profile._sName}
+                    </div>
+                    <Button
+                      type="button"
+                      variant={isLiked ? "default" : "outline"}
+                      size="sm"
+                      disabled={!canToggleLike || isLikePending}
+                      aria-pressed={isLiked}
+                      title={
+                        canToggleLike
+                          ? isLiked
+                            ? t("page.gamebanana.unlike")
+                            : t("page.gamebanana.like")
+                          : t("page.gamebanana.like_unavailable")
+                      }
+                      onClick={() => void handleLike()}
+                    >
+                      {isLikePending ? (
+                        <Loader2Icon className="size-4 animate-spin" />
+                      ) : (
+                        <HeartIcon className={cn("size-4", isLiked && "fill-current")} />
+                      )}
+                      <span>
+                        {formatNumber(modOverviewQuery.data.profile._nLikeCount ?? 0, language)}
+                      </span>
+                      <span className="sr-only">
+                        {isLiked ? t("page.gamebanana.liked") : t("page.gamebanana.like")}
+                      </span>
+                    </Button>
                   </div>
                 </div>
               ) : null}

--- a/src/renderer/src/routes/gamebanana/-sidebars/category-sidebar.tsx
+++ b/src/renderer/src/routes/gamebanana/-sidebars/category-sidebar.tsx
@@ -1,10 +1,12 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@renderer/components/ui/avatar";
 import { Button } from "@renderer/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@renderer/components/ui/card";
+import { Input } from "@renderer/components/ui/input";
 import { ScrollArea } from "@renderer/components/ui/scroll-area";
 import { Skeleton } from "@renderer/components/ui/skeleton";
 import { cn } from "@renderer/lib/utils";
 import type { TFunction } from "i18next";
+import { SearchIcon } from "lucide-react";
 
 import type { CategoryChildItem, RootCategoryItem } from "../-types";
 
@@ -25,7 +27,9 @@ export function CategorySidebar({
   rootCategories,
   categoryChildren,
   selectedCategoryId,
+  categorySearch,
   onSelectCategory,
+  onChangeCategorySearch,
   onResetToGameHome,
 }: {
   t: TFunction;
@@ -40,10 +44,18 @@ export function CategorySidebar({
   rootCategories: RootCategoryItem[];
   categoryChildren: CategoryChildItem[];
   selectedCategoryId?: number;
+  categorySearch: string;
   onSelectCategory: (categoryId: number, categoryName: string) => void;
+  onChangeCategorySearch: (value: string) => void;
   onResetToGameHome: () => void;
 }) {
   const categories = hasCategoryContext ? categoryChildren : rootCategories;
+  const normalizedCategorySearch = categorySearch.trim().toLocaleLowerCase();
+  const filteredCategories = normalizedCategorySearch
+    ? categories.filter((category) =>
+        category._sName.toLocaleLowerCase().includes(normalizedCategorySearch),
+      )
+    : categories;
   const isLoading = hasCategoryContext ? isCategoryOverviewLoading : isGameOverviewLoading;
   const hasError = hasCategoryContext ? categoryOverviewError : gameOverviewError;
   const errorPresentation = getGameBananaErrorPresentation(
@@ -64,6 +76,15 @@ export function CategorySidebar({
             </Button>
           )}
         </div>
+        <div className="relative mt-3">
+          <SearchIcon className="pointer-events-none absolute top-2.5 left-3 size-4 text-muted-foreground" />
+          <Input
+            value={categorySearch}
+            onChange={(event) => onChangeCategorySearch(event.target.value)}
+            placeholder={t("page.gamebanana.search_categories")}
+            className="pl-9"
+          />
+        </div>
       </CardHeader>
       <CardContent className="min-h-0 flex-1 p-0">
         <ScrollArea className="h-full min-h-0">
@@ -82,14 +103,16 @@ export function CategorySidebar({
                 details={errorPresentation.details}
               />
             )}
-            {!isLoading && !hasError && categories.length === 0 && (
+            {!isLoading && !hasError && filteredCategories.length === 0 && (
               <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
-                {t("page.gamebanana.no_categories")}
+                {categorySearch.trim()
+                  ? t("page.gamebanana.no_category_results")
+                  : t("page.gamebanana.no_categories")}
               </div>
             )}
             {!isLoading &&
               !hasError &&
-              categories.map((category) => {
+              filteredCategories.map((category) => {
                 const isActive = selectedCategoryId === category._idRow;
 
                 return (

--- a/src/renderer/src/routes/gamebanana/-sidebars/mod-files-sidebar.tsx
+++ b/src/renderer/src/routes/gamebanana/-sidebars/mod-files-sidebar.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@renderer/components/u
 import { ScrollArea } from "@renderer/components/ui/scroll-area";
 import { Skeleton } from "@renderer/components/ui/skeleton";
 import { Logger } from "@renderer/lib/logger";
+import { toErrorMessage } from "@shared/utils";
 import type { TFunction } from "i18next";
 import {
   FileArchiveIcon,
@@ -13,9 +14,11 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+
+import type { ModOverviewQuery } from "../-types";
+
 import { ErrorState, StatCard } from "../-shared/common";
 import { getGameBananaErrorPresentation } from "../-shared/errors";
-import type { ModOverviewQuery } from "../-types";
 import { formatEpoch, formatNumber } from "../-utils";
 
 export function ModFilesSidebar({
@@ -46,7 +49,9 @@ export function ModFilesSidebar({
         modelName: "Mod",
       });
     } catch (error) {
-      toast.error("다운로드를 시작하지 못했습니다.");
+      toast.error(t("page.gamebanana.download_failed"), {
+        description: toErrorMessage(error),
+      });
       Logger.error(error, "ModFilesSidebar:handleDownload");
     } finally {
       setPendingFileId(null);
@@ -147,10 +152,10 @@ export function ModFilesSidebar({
                           <Loader2Icon className="mt-0.5 size-4 shrink-0 animate-spin text-muted-foreground" />
                         )}
                         <div className="min-w-0 flex-1">
-                          <div className="line-clamp-2 break-all text-sm font-medium">
+                          <div className="line-clamp-2 text-sm font-medium break-all">
                             {file._sFile}
                           </div>
-                          <div className="mt-2 min-w-0 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                          <div className="mt-2 flex min-w-0 flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
                             <span>
                               {t("page.gamebanana.file_downloads", {
                                 count: formatNumber(file._nDownloadCount, language),

--- a/src/renderer/src/routes/gamebanana/index.tsx
+++ b/src/renderer/src/routes/gamebanana/index.tsx
@@ -102,6 +102,7 @@ function RouteComponent() {
   const selectedGameKey = useGameBananaStore((state) => state.selectedGame);
   const selectedCategoryId = useGameBananaStore((state) => state.selectedCategoryId);
   const categoryBreadcrumbs = useGameBananaStore((state) => state.categoryBreadcrumbs);
+  const categorySearch = useGameBananaStore((state) => state.categorySearch);
   const selectedMod = useGameBananaStore((state) => state.selectedMod);
   const subfeedPage = useGameBananaStore((state) => state.subfeedPage);
   const modsPage = useGameBananaStore((state) => state.modsPage);
@@ -118,6 +119,7 @@ function RouteComponent() {
   const setSubfeedPage = useGameBananaStore((state) => state.setSubfeedPage);
   const setModsPage = useGameBananaStore((state) => state.setModsPage);
   const setModSearch = useGameBananaStore((state) => state.setModSearch);
+  const setCategorySearch = useGameBananaStore((state) => state.setCategorySearch);
   const setModsSort = useGameBananaStore((state) => state.setModsSort);
   const toggleModUrl = useGameBananaStore((state) => state.toggleModUrl);
 
@@ -610,7 +612,9 @@ function RouteComponent() {
                     rootCategories={rootCategories}
                     categoryChildren={categoryChildren}
                     selectedCategoryId={selectedCategoryId}
+                    categorySearch={categorySearch}
                     onSelectCategory={selectCategory}
+                    onChangeCategorySearch={setCategorySearch}
                     onResetToGameHome={resetToGameHome}
                   />
                 )}

--- a/src/renderer/src/routes/setting/adv.tsx
+++ b/src/renderer/src/routes/setting/adv.tsx
@@ -4,7 +4,7 @@ import { Input } from "@renderer/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@renderer/components/ui/popover";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { InfoIcon, Pencil, Save, X } from "lucide-react";
+import { InfoIcon, Pencil, Save, SearchIcon, X } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -21,6 +21,7 @@ interface SettingItem {
 function RouteComponent() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
+  const [searchQuery, setSearchQuery] = useState("");
   const { data: settings, isLoading } = useQuery<SettingItem[]>({
     queryKey: ["settings", "advanced"],
     queryFn: async () => {
@@ -41,6 +42,10 @@ function RouteComponent() {
     },
   });
 
+  const filteredSettings = settings?.filter((setting) =>
+    setting.key.toLocaleLowerCase().includes(searchQuery.trim().toLocaleLowerCase()),
+  );
+
   if (isLoading) {
     return <div className="p-4">Loading...</div>;
   }
@@ -53,6 +58,16 @@ function RouteComponent() {
         <AlertDescription>{t("page.setting.adv.warning_description")}</AlertDescription>
       </Alert>
 
+      <div className="relative">
+        <SearchIcon className="pointer-events-none absolute top-2.5 left-3 size-4 text-muted-foreground" />
+        <Input
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          placeholder={t("page.setting.adv.search_placeholder")}
+          className="pl-9"
+        />
+      </div>
+
       <div className="overflow-hidden rounded-md border text-[13px]">
         <div className="grid grid-cols-[minmax(150px,1fr)_minmax(200px,3fr)_80px] border-b bg-muted/50 font-medium text-muted-foreground">
           <div className="p-3 tracking-wider uppercase">Key</div>
@@ -60,7 +75,7 @@ function RouteComponent() {
           <div className="p-3 text-center tracking-wider uppercase">Action</div>
         </div>
         <div className="grid grid-cols-[minmax(150px,1fr)_minmax(200px,3fr)_80px]">
-          {settings?.map((setting) => (
+          {filteredSettings?.map((setting) => (
             <SettingRow
               key={setting.key}
               setting={setting}
@@ -69,6 +84,11 @@ function RouteComponent() {
           ))}
         </div>
       </div>
+      {filteredSettings?.length === 0 && (
+        <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+          {t("page.setting.adv.no_results")}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/renderer/src/routes/transfer.tsx
+++ b/src/renderer/src/routes/transfer.tsx
@@ -75,8 +75,6 @@ function RouteComponent() {
   }, []);
 
   const transferItems: TransferItemProps[] = transfers.map((t) => {
-    const error = "error" in t ? t.error : undefined;
-
     return {
       id: t.pid,
       fileName: t.name,
@@ -91,7 +89,7 @@ function RouteComponent() {
       totalFiles: t.totalFiles,
       processedFiles: t.transferedFiles,
       failedFiles: t.failedFiles,
-      error: typeof error === "string" ? error : undefined,
+      error: t.error,
     };
   });
 

--- a/src/renderer/src/store/gamebanana.ts
+++ b/src/renderer/src/store/gamebanana.ts
@@ -22,6 +22,7 @@ interface GameBananaState {
     pendingModGameSync: boolean;
     selectedCategoryId?: number;
     categoryBreadcrumbs: GameBananaBreadcrumb[];
+    categorySearch: string;
     selectedMod?: GameBananaSelectedSubmission;
     subfeedPage: number;
     modsPage: number;
@@ -33,6 +34,7 @@ interface GameBananaState {
     requestModGameSync: () => void;
     consumeModGameSync: () => boolean;
     selectCategory: (categoryId: number, categoryName: string) => void;
+    setCategorySearch: (query: string) => void;
     selectMod: (submission: GameBananaSelectedSubmission) => void;
     clearSelectedMod: () => void;
     selectBreadcrumbCategory: (index: number) => void;
@@ -49,6 +51,7 @@ export const gameBananaStore = createStore<GameBananaState>((set, get) => ({
     pendingModGameSync: false,
     selectedCategoryId: undefined,
     categoryBreadcrumbs: [],
+    categorySearch: "",
     selectedMod: undefined,
     subfeedPage: DEFAULT_SUBFEED_PAGE,
     modsPage: DEFAULT_MODS_PAGE,
@@ -60,6 +63,7 @@ export const gameBananaStore = createStore<GameBananaState>((set, get) => ({
             selectedGame,
             selectedCategoryId: undefined,
             categoryBreadcrumbs: [],
+            categorySearch: "",
             selectedMod: undefined,
             subfeedPage: DEFAULT_SUBFEED_PAGE,
             modsPage: DEFAULT_MODS_PAGE,
@@ -88,6 +92,7 @@ export const gameBananaStore = createStore<GameBananaState>((set, get) => ({
             return {
                 selectedCategoryId: categoryId,
                 categoryBreadcrumbs: nextBreadcrumbs,
+                categorySearch: "",
                 selectedMod: undefined,
                 modsPage: DEFAULT_MODS_PAGE,
                 modSearch: "",
@@ -106,6 +111,7 @@ export const gameBananaStore = createStore<GameBananaState>((set, get) => ({
             return {
                 selectedCategoryId: nextCategory.id,
                 categoryBreadcrumbs: nextBreadcrumbs,
+                categorySearch: "",
                 selectedMod: undefined,
                 modsPage: DEFAULT_MODS_PAGE,
                 modSearch: "",
@@ -115,6 +121,7 @@ export const gameBananaStore = createStore<GameBananaState>((set, get) => ({
         set({
             selectedCategoryId: undefined,
             categoryBreadcrumbs: [],
+            categorySearch: "",
             selectedMod: undefined,
             subfeedPage: DEFAULT_SUBFEED_PAGE,
             modsPage: DEFAULT_MODS_PAGE,
@@ -123,6 +130,7 @@ export const gameBananaStore = createStore<GameBananaState>((set, get) => ({
     setSubfeedPage: (subfeedPage) => set({ subfeedPage: Math.max(1, subfeedPage) }),
     setModsPage: (modsPage) => set({ modsPage: Math.max(1, modsPage) }),
     setModSearch: (modSearch) => set({ modSearch }),
+    setCategorySearch: (categorySearch) => set({ categorySearch }),
     setModsSort: (modsSort) => set({ modsSort, modsPage: DEFAULT_MODS_PAGE }),
     toggleModUrl: () => set((state) => ({ isModUrlOpen: !state.isModUrlOpen })),
 }));

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -388,6 +388,7 @@ export interface Transfer {
     transferedFiles: number;
     failedFiles: number;
     path?: string;
+    error?: string;
 }
 
 export type TransferWithoutData = Omit<Transfer, "data">;


### PR DESCRIPTION
## Summary\n- add category name search in GameBanana and key search in Advanced settings\n- add authenticated GameBanana like/unlike state and toggle action\n- preserve GameBanana download failure reasons in toasts and transfer details\n\n## Verification\n- pnpm build\n- pnpm test (101 passed)\n- pnpm lint -- changed files\n\nThe full lint command still reports existing backend Eden type errors in unrelated files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Like/Unlike controls to GameBanana mod pages, including status, counts, loading states, and error handling.
  - Added category search with filtered results and empty-state messaging.
  - Added search for Advanced settings keys.
- **Bug Fixes**
  - Improved download and transfer error messages with clearer failure details.
  - Fixed error notifications to use localized text.
- **Localization**
  - Added translations for GameBanana actions, searches, errors, and Advanced settings in English, Japanese, Korean, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->