### PR TITLE
fix(download): replace Readable.fromWeb to avoid undici parser assertion

### DIFF
--- a/src/main/lib/download.ts
+++ b/src/main/lib/download.ts
@@ -1,8 +1,7 @@
 import { createWriteStream } from "node:fs";
 import path from "node:path";
-import { Readable, Transform } from "node:stream";
+import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import type { ReadableStream } from "node:stream/web";
 import { createGunzip, createZstdDecompress } from "node:zlib";
 
 import { eden } from "@main/client";
@@ -27,6 +26,7 @@ import {
     slowReconnectDelayMs,
     type SlowChunkTransferPhase,
 } from "./slow-chunk-monitor";
+import { webStreamToNodeReadable } from "./web-stream-to-readable";
 
 export type DownloadParams = {
     type: "download";
@@ -399,7 +399,7 @@ class FileDownloadTask {
         if (!response.body) throw new Error("No response body");
 
         const fileStream = createWriteStream(targetPath);
-        const source = Readable.fromWeb(response.body as unknown as ReadableStream);
+        const source = webStreamToNodeReadable(response.body, signal);
         const bandwidth = createBandwidthLimitTransform(
             this.desktop.service.transfer.downloadBandwidth,
             {

--- a/src/main/lib/parallel-downloader.ts
+++ b/src/main/lib/parallel-downloader.ts
@@ -1,4 +1,4 @@
-import { Readable, Transform } from "node:stream";
+import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 
 // oxlint-disable typescript/no-explicit-any
@@ -15,6 +15,7 @@ import {
     slowReconnectDelayMs,
     type SlowChunkMonitor,
 } from "./slow-chunk-monitor";
+import { webStreamToNodeReadable } from "./web-stream-to-readable";
 
 export interface ParallelDownloadOptions {
     url: string;
@@ -151,7 +152,7 @@ export class ParallelDownloader {
 
         const fileStream = fse.createWriteStream(chunkPath);
         let transferredBytes = 0;
-        const source = Readable.fromWeb(response.body as any);
+        const source = webStreamToNodeReadable(response.body, signal);
         const progressStream = new Transform({
             transform(chunk: Buffer, _encoding, callback) {
                 transferredBytes += chunk.byteLength;

--- a/src/main/lib/web-stream-to-readable.ts
+++ b/src/main/lib/web-stream-to-readable.ts
@@ -1,0 +1,52 @@
+import { Readable } from "node:stream";
+
+type WebReadableStream = {
+    getReader(): {
+        read(): Promise<{ done: boolean; value?: Uint8Array<ArrayBuffer> }>;
+        cancel(reason?: unknown): Promise<void>;
+    };
+};
+
+export function webStreamToNodeReadable(
+    webStream: WebReadableStream,
+    signal?: AbortSignal,
+): Readable {
+    const reader = webStream.getReader();
+
+    const readable = new Readable({
+        async read() {
+            try {
+                const { done, value } = await reader.read();
+                if (done) {
+                    this.push(null);
+                    return;
+                }
+                if (value) {
+                    this.push(Buffer.from(value));
+                }
+            } catch (err) {
+                this.destroy(err instanceof Error ? err : new Error(String(err)));
+            }
+        },
+    });
+
+    const cleanup = () => {
+        void reader.cancel().catch(() => {});
+    };
+
+    if (signal) {
+        const onAbort = () => {
+            cleanup();
+            readable.destroy(new DOMException("The operation was aborted.", "AbortError"));
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+        readable.once("close", () => {
+            signal.removeEventListener("abort", onAbort);
+            cleanup();
+        });
+    } else {
+        readable.once("close", cleanup);
+    }
+
+    return readable;
+}


### PR DESCRIPTION
## Problem

\\\
AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    assert(!this.paused)
    at Parser.finish (node:internal/deps/undici/undici:7380:9)
    at TLSSocket.onHttpSocketEnd (node:internal/deps/undici/undici:7819:34)
\\\

## Root Cause

\Readable.fromWeb()\ does not correctly synchronize backpressure with the undici HTTP parser. When the bandwidth limiter's async Transform holds backpressure, the parser enters a \paused\ state. If the TLS socket emits an \nd\ event while the parser is paused, the internal \ssert(!this.paused)\ assertion fails.

## Fix

Replaced \Readable.fromWeb()\ with a custom \webStreamToNodeReadable()\ that reads the Web Stream directly via \getReader()\, bypassing the undici parser backpressure path entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download stream handling and cancellation.
  * Downloads now respond more reliably to abort actions and stream read errors.
  * Preserved progress reporting and bandwidth-limiting behavior during downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->