### PR TITLE
fix(download): reconcile transfer size with file manifest

### DIFF
--- a/src/main/lib/download.ts
+++ b/src/main/lib/download.ts
@@ -175,6 +175,7 @@ class DownloadStreamer {
         }
 
         const listedFileBytes = downloadData.files.reduce((total, file) => total + file.size, 0);
+        const effectiveTotalBytes = listedFileBytes > 0 ? listedFileBytes : downloadData.totalBytes;
         if (
             metadataTotalBytes !== undefined &&
             Number.isFinite(metadataTotalBytes) &&
@@ -191,6 +192,8 @@ class DownloadStreamer {
                     fileCount: downloadData.files.length,
                     directoryCount: downloadData.dirs.length,
                     linkId: link?.linkId,
+                    effectiveTotalBytes,
+                    totalBytesSource: listedFileBytes > 0 ? "file-manifest" : "metadata",
                 },
                 "Download:MetadataMismatch",
             );
@@ -199,6 +202,7 @@ class DownloadStreamer {
         return {
             root: rootDir,
             ...downloadData,
+            totalBytes: effectiveTotalBytes,
         };
     }
 
@@ -836,9 +840,25 @@ export class DownloadLib {
             }),
         );
 
+        const listedFileBytes = mergedFiles.reduce((total, file) => total + file.size, 0);
+        const effectiveTotalBytes = listedFileBytes > 0 ? listedFileBytes : totalBytes;
+        if (effectiveTotalBytes !== totalBytes) {
+            this.desktop.logger.warn(
+                {
+                    itemIds: items.map((item) => item.id),
+                    metadataTotalBytes: totalBytes,
+                    listedFileBytes,
+                    deltaBytes: totalBytes - listedFileBytes,
+                    fileCount: mergedFiles.length,
+                    directoryCount: mergedDirs.length,
+                },
+                "Download:MergedMetadataMismatch",
+            );
+        }
+
         return {
             root: { id: BATCH_ROOT_ID, parentId: null, name: "" },
-            totalBytes,
+            totalBytes: effectiveTotalBytes,
             files: mergedFiles,
             dirs: mergedDirs,
         };

--- a/src/main/services/drive.ts
+++ b/src/main/services/drive.ts
@@ -1086,17 +1086,30 @@ export class DriveService {
                   });
         }
 
+        const metadataTotalBytes = data.totalBytes;
+        const manifestTotalBytes = data.files.reduce((total, file) => total + file.size, 0);
+        const effectiveTotalBytes =
+            manifestTotalBytes > 0 ? manifestTotalBytes : metadataTotalBytes;
         const listedContentBytes = items.every((item) => typeof item.size === "number")
             ? items.reduce((total, item) => total + (item.size ?? 0), 0)
             : undefined;
-        if (listedContentBytes !== undefined && listedContentBytes !== data.totalBytes) {
+        if (
+            effectiveTotalBytes !== metadataTotalBytes ||
+            (listedContentBytes !== undefined && listedContentBytes !== effectiveTotalBytes)
+        ) {
             this.desktop.logger.warn(
                 {
                     itemIds: items.map((item) => item.id),
                     itemNames: items.map((item) => item.name),
                     listedContentBytes,
-                    downloadMetadataBytes: data.totalBytes,
-                    deltaBytes: listedContentBytes - data.totalBytes,
+                    downloadMetadataBytes: metadataTotalBytes,
+                    manifestTotalBytes,
+                    effectiveTotalBytes,
+                    metadataDeltaBytes: manifestTotalBytes - metadataTotalBytes,
+                    listedContentDeltaBytes:
+                        listedContentBytes === undefined
+                            ? undefined
+                            : listedContentBytes - manifestTotalBytes,
                     fileCount: data.files.length,
                     directoryCount: data.dirs.length,
                     savePath,
@@ -1105,6 +1118,7 @@ export class DriveService {
                 "Drive:Download:ContentSizeMismatch",
             );
         }
+        data.totalBytes = effectiveTotalBytes;
 
         if (data.root) {
             if (suggestedName && isSingle) {


### PR DESCRIPTION
## 변경 내용
- 다운로드 메타데이터의 `totalBytes`와 파일 목록(`files[].size`) 합계가 다를 때 파일 매니페스트 합계를 전송 총 용량으로 사용합니다.
- 단일 폴더 스트림과 여러 폴더를 병합하는 경로 모두 동일한 보정 규칙을 적용합니다.
- 서버 메타데이터, 매니페스트 합계, 선택 항목 합계, 최종 적용값을 진단 로그에 남겨 원인을 추적할 수 있도록 했습니다.

## 원인 및 범위
일부 폴더 다운로드 응답에서 서버가 제공하는 `metadata.totalBytes`가 실제 파일 목록 합계보다 작게 내려와 전송창에 약 300GB로 표시되지만 실제 파일은 약 971GB가 내려받아지는 문제가 있었습니다. 파일 다운로드 자체의 누락을 의미하는 현상은 아니며, 클라이언트가 매니페스트 합계를 사용해 표시 및 진행률 기준을 보정합니다. 서버 측 원인은 #190에서 추적합니다.

## 검증
- `pnpm build`
- `pnpm exec oxlint src/main/lib/download.ts src/main/services/drive.ts`
- `pnpm exec vitest run src/main/services/drive-errors.test.ts src/main/lib/web-stream-to-readable.test.ts` (9 tests)

Refs #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download size accuracy by reconciling metadata with the sizes of listed files.
  * Downloads now use the calculated file total when available, while preserving metadata totals when no files are listed.
  * Improved mismatch reporting to make download size discrepancies clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->