### PR TITLE
feat(sidebar): add creator site link

### DIFF
--- a/src/renderer/src/components/sidebar.tsx
+++ b/src/renderer/src/components/sidebar.tsx
@@ -12,6 +12,7 @@ import {
   BookOpenIcon,
   BugIcon,
   BugPlayIcon,
+  ExternalLinkIcon,
   GamepadIcon,
   HardDriveIcon,
   SettingsIcon,
@@ -36,6 +37,8 @@ function getDocumentationUrl(language: string) {
       return "https://desktop.nahida.live";
   }
 }
+
+const creatorSiteUrl = "https://nhl.fanbox.cc/";
 
 export function Sidebar({ className }: { className?: string }) {
   const navi = useNavigate();
@@ -385,6 +388,25 @@ export function Sidebar({ className }: { className?: string }) {
               <TooltipContent side="right">{t("page.setting.title")}</TooltipContent>
             </Tooltip>
           )}
+
+          <Tooltip disableHoverablePopup>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-lg"
+                  aria-label={t("page.creator_site.title")}
+                  onPointerDown={handlePointerDown}
+                  onClick={() => {
+                    void window.api.invoke("util:openExternal", creatorSiteUrl);
+                  }}
+                />
+              }
+            >
+              <ExternalLinkIcon className={cn(iconSize)} />
+            </TooltipTrigger>
+            <TooltipContent side="right">{t("page.creator_site.title")}</TooltipContent>
+          </Tooltip>
         </div>
       </div>
     </div>

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -1534,6 +1534,9 @@
     },
     "docs": {
       "title": "Documentation"
+    },
+    "creator_site": {
+      "title": "Creator website"
     }
   },
   "components": {

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -1501,6 +1501,9 @@
     },
     "docs": {
       "title": "使い方"
+    },
+    "creator_site": {
+      "title": "作者のサイト"
     }
   },
   "components": {

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -1520,6 +1520,9 @@
     },
     "docs": {
       "title": "사용 방법"
+    },
+    "creator_site": {
+      "title": "제작자 사이트"
     }
   },
   "components": {

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -1500,6 +1500,9 @@
     },
     "docs": {
       "title": "使用说明"
+    },
+    "creator_site": {
+      "title": "作者网站"
     }
   },
   "components": {


### PR DESCRIPTION
## 변경 사항
- 사이드바 하단에 제작자 사이트(https://nhl.fanbox.cc/) 외부 링크 버튼 추가
- 툴팁과 접근성 라벨을 한국어/영어/일본어/중국어로 추가

## 검증
- pnpm lint -- src/renderer/src/components/sidebar.tsx
- 로케일 JSON 파싱
