### PR TITLE
fix(drive): decode Base64 source URLs

### DIFF
--- a/src/main/services/drive-url.test.ts
+++ b/src/main/services/drive-url.test.ts
@@ -5,6 +5,7 @@ import { encodeNahidaPassword, NAHIDA_SOURCE_HOSTNAMES, parseDriveSourceUrl } fr
 
 const sourceUrl = (hostname: string, pathname: string, protocol = "https:") =>
     new URL(pathname, `${protocol}//${hostname}`).toString();
+const base64 = (value: string) => Buffer.from(value).toString("base64");
 
 const testSourceUrls = [
     {
@@ -32,6 +33,16 @@ const testSourceUrls = [
         url: "aHR0cHM6Ly9uYWhpZGEubGl2ZS9ha2FzaGEvbGluay9xanNFZHZMcGNBeHI=",
         expected: { type: "link", id: "qjsEdvLpcAxr" },
     },
+    {
+        label: "multi-encoded public folder",
+        url: base64(base64("https://nahida.live/akasha/link/qjsEdvLpcAxr")),
+        expected: { type: "link", id: "qjsEdvLpcAxr" },
+    },
+    {
+        label: "Base64-encoded Nahida host",
+        url: base64("nahida.live/akasha/link/qjsEdvLpcAxr"),
+        expected: { type: "link", id: "qjsEdvLpcAxr" },
+    },
 ] as const;
 
 describe("encodeNahidaPassword", () => {
@@ -44,6 +55,13 @@ describe("encodeNahidaPassword", () => {
 describe("parseDriveSourceUrl", () => {
     it.each(testSourceUrls)("parses $label fixture", ({ url, expected }) => {
         expect(parseDriveSourceUrl(url)).toEqual(expected);
+    });
+
+    it("adds HTTPS to a Nahida host without a protocol", () => {
+        expect(parseDriveSourceUrl("nahida.live/akasha/link/qjsEdvLpcAxr")).toEqual({
+            type: "link",
+            id: "qjsEdvLpcAxr",
+        });
     });
 
     it.each([

--- a/src/main/services/drive-url.test.ts
+++ b/src/main/services/drive-url.test.ts
@@ -6,6 +6,10 @@ import { encodeNahidaPassword, NAHIDA_SOURCE_HOSTNAMES, parseDriveSourceUrl } fr
 const sourceUrl = (hostname: string, pathname: string, protocol = "https:") =>
     new URL(pathname, `${protocol}//${hostname}`).toString();
 const base64 = (value: string) => Buffer.from(value).toString("base64");
+const base64Url = (value: string) =>
+    base64(value).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+const encodeBase64Layers = (value: string, layers: number) =>
+    Array.from({ length: layers }).reduce<string>((encoded) => base64(encoded), value);
 
 const testSourceUrls = [
     {
@@ -43,6 +47,11 @@ const testSourceUrls = [
         url: base64("nahida.live/akasha/link/qjsEdvLpcAxr"),
         expected: { type: "link", id: "qjsEdvLpcAxr" },
     },
+    {
+        label: "Base64-encoded www Nahida host",
+        url: base64("www.nahida.live/akasha/link/qjsEdvLpcAxr"),
+        expected: { type: "link", id: "qjsEdvLpcAxr" },
+    },
 ] as const;
 
 describe("encodeNahidaPassword", () => {
@@ -62,6 +71,42 @@ describe("parseDriveSourceUrl", () => {
             type: "link",
             id: "qjsEdvLpcAxr",
         });
+        expect(parseDriveSourceUrl("www.nahida.live/akasha/link/qjsEdvLpcAxr")).toEqual({
+            type: "link",
+            id: "qjsEdvLpcAxr",
+        });
+    });
+
+    it.each([
+        "https://www.nahida.live/akasha/link/abc?x=😀",
+        "https://www.nahida.live/akasha/link/abc#😀",
+    ])("parses unpadded URL-safe Base64 source %s", (value) => {
+        expect(base64(value)).toMatch(/[+/]/);
+        expect(parseDriveSourceUrl(base64Url(value))).toEqual({ type: "link", id: "abc" });
+    });
+
+    it("ignores whitespace around an unpadded URL-safe Base64 source", () => {
+        const value = "https://nahida.live/akasha/link/qjsEdvLpcAxr";
+        expect(parseDriveSourceUrl(`  \n${base64Url(value)}\t `)).toEqual({
+            type: "link",
+            id: "qjsEdvLpcAxr",
+        });
+    });
+
+    it("decodes exactly ten Base64 layers", () => {
+        expect(
+            parseDriveSourceUrl(
+                encodeBase64Layers("https://nahida.live/akasha/link/qjsEdvLpcAxr", 10),
+            ),
+        ).toEqual({ type: "link", id: "qjsEdvLpcAxr" });
+    });
+
+    it("rejects an eleventh Base64 layer", () => {
+        expect(() =>
+            parseDriveSourceUrl(
+                encodeBase64Layers("https://nahida.live/akasha/link/qjsEdvLpcAxr", 11),
+            ),
+        ).toThrow("DRIVE_INVALID_SOURCE_URL");
     });
 
     it.each([
@@ -85,6 +130,9 @@ describe("parseDriveSourceUrl", () => {
         sourceUrl(NAHIDA_SOURCE_HOSTNAMES[0], "/akasha/link/"),
         sourceUrl(NAHIDA_SOURCE_HOSTNAMES[0], "/akasha/unknown/abc"),
         sourceUrl(NAHIDA_SOURCE_HOSTNAMES[0], "/akasha/mod/abc/extra"),
+        "invalid-base64*",
+        null,
+        42,
     ])("rejects unsupported source %s", (value) => {
         expect(() => parseDriveSourceUrl(value)).toThrowError(DriveApiError);
         expect(() => parseDriveSourceUrl(value)).toThrow("DRIVE_INVALID_SOURCE_URL");

--- a/src/main/services/drive-url.test.ts
+++ b/src/main/services/drive-url.test.ts
@@ -27,6 +27,11 @@ const testSourceUrls = [
         url: "https://nahida.live/akasha/mod/-fpnEyi_nPNB-Mf97p5_k",
         expected: { type: "mod", id: "-fpnEyi_nPNB-Mf97p5_k" },
     },
+    {
+        label: "Base64-encoded public folder",
+        url: "aHR0cHM6Ly9uYWhpZGEubGl2ZS9ha2FzaGEvbGluay9xanNFZHZMcGNBeHI=",
+        expected: { type: "link", id: "qjsEdvLpcAxr" },
+    },
 ] as const;
 
 describe("encodeNahidaPassword", () => {

--- a/src/main/services/drive-url.ts
+++ b/src/main/services/drive-url.ts
@@ -20,6 +20,20 @@ export function encodeNahidaPassword(value: string) {
 }
 
 export function parseDriveSourceUrl(value: string): DriveSource {
+    const source = parseNahidaSourceUrl(value);
+    if (source) return source;
+
+    const decodedSource = decodeBase64(value);
+    const decoded = decodedSource ? parseNahidaSourceUrl(decodedSource) : undefined;
+    if (decoded) return decoded;
+
+    throw new DriveApiError(
+        "DRIVE_INVALID_SOURCE_URL",
+        "Enter a Nahida shared link or collection URL.",
+    );
+}
+
+function parseNahidaSourceUrl(value: string): DriveSource | undefined {
     try {
         const url = new URL(value.trim());
         if (url.protocol !== "https:") throw new Error("unsupported protocol");
@@ -36,8 +50,20 @@ export function parseDriveSourceUrl(value: string): DriveSource {
         // Normalize malformed external input to the same user-facing error below.
     }
 
-    throw new DriveApiError(
-        "DRIVE_INVALID_SOURCE_URL",
-        "Enter a Nahida shared link or collection URL.",
-    );
+    return;
+}
+
+function decodeBase64(value: string) {
+    const normalized = value.trim().replace(/\s+/g, "").replace(/-/g, "+").replace(/_/g, "/");
+    if (
+        normalized.length === 0 ||
+        normalized.length % 4 === 1 ||
+        !/^[A-Za-z0-9+/]*={0,2}$/.test(normalized)
+    ) {
+        return;
+    }
+
+    return Buffer.from(normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "="), "base64")
+        .toString("utf8")
+        .trim();
 }

--- a/src/main/services/drive-url.ts
+++ b/src/main/services/drive-url.ts
@@ -6,6 +6,8 @@ export type DriveSource = {
 };
 
 export const NAHIDA_SOURCE_HOSTNAMES = ["nahida.live", "www.nahida.live"] as const;
+// Bound nested decoding so malformed input cannot trigger unbounded work.
+const MAX_SOURCE_URL_DECODING_DEPTH = 10;
 
 /** Match the web client's URL-safe Base64 password encoding. */
 export function encodeNahidaPassword(value: string) {
@@ -20,17 +22,26 @@ export function encodeNahidaPassword(value: string) {
 }
 
 export function parseDriveSourceUrl(value: string): DriveSource {
-    const source = parseNahidaSourceUrl(value);
+    const sourceUrl = resolveSourceUrl(value);
+    const source = sourceUrl ? parseNahidaSourceUrl(sourceUrl) : undefined;
     if (source) return source;
-
-    const decodedSource = decodeBase64(value);
-    const decoded = decodedSource ? parseNahidaSourceUrl(decodedSource) : undefined;
-    if (decoded) return decoded;
 
     throw new DriveApiError(
         "DRIVE_INVALID_SOURCE_URL",
         "Enter a Nahida shared link or collection URL.",
     );
+}
+
+function resolveSourceUrl(value: string, depth = 0): string | undefined {
+    const normalized = value.trim();
+    if (/^http/i.test(normalized)) return normalized;
+    if (/^nahida/i.test(normalized)) return `https://${normalized}`;
+    if (depth >= MAX_SOURCE_URL_DECODING_DEPTH) return;
+
+    const decoded = decodeBase64(normalized);
+    if (!decoded || decoded === normalized) return;
+
+    return resolveSourceUrl(decoded, depth + 1);
 }
 
 function parseNahidaSourceUrl(value: string): DriveSource | undefined {

--- a/src/main/services/drive-url.ts
+++ b/src/main/services/drive-url.ts
@@ -21,7 +21,7 @@ export function encodeNahidaPassword(value: string) {
         .replace(/=+$/, "");
 }
 
-export function parseDriveSourceUrl(value: string): DriveSource {
+export function parseDriveSourceUrl(value: unknown): DriveSource {
     const sourceUrl = resolveSourceUrl(value);
     const source = sourceUrl ? parseNahidaSourceUrl(sourceUrl) : undefined;
     if (source) return source;
@@ -32,10 +32,19 @@ export function parseDriveSourceUrl(value: string): DriveSource {
     );
 }
 
-function resolveSourceUrl(value: string, depth = 0): string | undefined {
+function resolveSourceUrl(value: unknown, depth = 0): string | undefined {
+    if (typeof value !== "string") return;
+
     const normalized = value.trim();
     if (/^http/i.test(normalized)) return normalized;
-    if (/^nahida/i.test(normalized)) return `https://${normalized}`;
+    const lowercase = normalized.toLowerCase();
+    if (
+        NAHIDA_SOURCE_HOSTNAMES.some(
+            (hostname) => lowercase === hostname || lowercase.startsWith(`${hostname}/`),
+        )
+    ) {
+        return `https://${normalized}`;
+    }
     if (depth >= MAX_SOURCE_URL_DECODING_DEPTH) return;
 
     const decoded = decodeBase64(normalized);


### PR DESCRIPTION
드라이브 가져오기 입력값이 Base64로 인코딩된 Nahida URL인 경우 디코드 후 기존 URL 검증/파싱을 수행합니다. 표준 및 URL-safe Base64 형식을 지원하며, 일반 URL 동작은 유지합니다.

테스트: pnpm test -- src/main/services/drive-url.test.ts
검증: pnpm lint -- src/main/services/drive-url.ts src/main/services/drive-url.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for protocol-less Nahida URLs, securely interpreted as HTTPS links.
  * Added support for nested Base64-encoded source URLs, including URL-safe formats, up to 10 layers.
  * Source URLs are now trimmed automatically before processing.

* **Bug Fixes**
  * Improved handling of malformed, unsupported, and invalid encoded URLs.
  * Added safeguards against excessive Base64 decoding.
  * Invalid source URLs continue to receive clear validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->