### PR TITLE
Release 2.59.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nahida-desktop",
-  "version": "2.58.0",
+  "version": "2.59.0",
   "description": "Native app for nahida.live",
   "homepage": "https://nahida.live",
   "author": "nahida.live",

--- a/src/main/ipc/handlers/drive.ts
+++ b/src/main/ipc/handlers/drive.ts
@@ -33,6 +33,19 @@ export function registerDriveHandlers(d: NahidaDesktop) {
         );
     });
 
+    rh("drive:get:search", async (itemId, params) => {
+        return await safeDriveCall(
+            d,
+            "get:search",
+            {
+                entity: "drive items",
+                stage: "search-descendants",
+                itemId,
+            },
+            () => d.service.drive.get.search(itemId, params),
+        );
+    });
+
     rh("drive:patch:rename", async (itemId, name) => {
         return await safeDriveCall(
             d,

--- a/src/main/services/drive.ts
+++ b/src/main/services/drive.ts
@@ -180,6 +180,14 @@ export class DriveService {
             if (error) throw error;
             return data;
         },
+
+        search: async (itemId: string, params: { q: string; limit?: number; cursor?: string }) => {
+            const { data, error } = await eden.akasha.content({ id: itemId }).search.get({
+                query: params,
+            });
+            if (error) throw error;
+            return data;
+        },
     };
 
     post = {

--- a/src/renderer/src/components/akasha/index.tsx
+++ b/src/renderer/src/components/akasha/index.tsx
@@ -35,6 +35,7 @@ import {
   FileIcon,
   FileTextIcon,
   FolderIcon,
+  FolderTree,
   LinkIcon,
   LayoutGridIcon,
   ListIcon,
@@ -189,8 +190,16 @@ export function AkashaHeadButtons({ currentId }: { currentId?: string }) {
   const setLayout = useViewStore((s) => s.setLayout);
   const searchInDirQuery = useViewStore((s) => s.searchInDirQuery);
   const setSearchInDirQuery = useViewStore((s) => s.setSearchInDirQuery);
+  const includeSubdirs = useViewStore((s) => s.includeSubdirs);
+  const setIncludeSubdirs = useViewStore((s) => s.setIncludeSubdirs);
   const setFocusSearchInputState = useViewStore((s) => s.setFocusSearchInputState);
   const setImportOverlay = useViewStore((s) => s.setImportOverlay);
+
+  const canSearchSubdirs = !!currentId && currentId !== "share";
+  const searchPlaceholder =
+    canSearchSubdirs && includeSubdirs
+      ? t("page.drive.head_buttons.search_in_subdirs_placeholder")
+      : t("page.drive.head_buttons.search_in_dir_placeholder");
 
   const handleDownload = () => {
     if (selectedItems.length === 0) return;
@@ -215,12 +224,29 @@ export function AkashaHeadButtons({ currentId }: { currentId?: string }) {
         <Input
           id="drive-search-input"
           className="h-9 w-50 pl-7 dark:bg-transparent"
-          placeholder={t("page.drive.head_buttons.search_in_dir_placeholder")}
+          placeholder={searchPlaceholder}
           value={searchInDirQuery}
           onChange={(e) => setSearchInDirQuery(e.target.value)}
           onFocus={() => setFocusSearchInputState(true)}
           onBlur={() => setFocusSearchInputState(false)}
         />
+        {canSearchSubdirs && (
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-pressed={includeSubdirs}
+            aria-label={t("page.drive.head_buttons.search_include_subdirs")}
+            title={t("page.drive.head_buttons.search_include_subdirs")}
+            className={cn(
+              "ml-1 h-9 w-9 shrink-0",
+              includeSubdirs && "bg-muted text-primary",
+              !includeSubdirs && "text-muted-foreground",
+            )}
+            onClick={() => setIncludeSubdirs(!includeSubdirs)}
+          >
+            <FolderTree size={20} />
+          </Button>
+        )}
       </div>
 
       <div className="flex shrink-0 flex-row items-center gap-1">

--- a/src/renderer/src/components/mod/mod-card-header.tsx
+++ b/src/renderer/src/components/mod/mod-card-header.tsx
@@ -20,6 +20,7 @@ import {
   Loader2Icon,
   PersonStandingIcon,
   SparklesIcon,
+  SwordsIcon,
   TerminalSquareIcon,
   TrashIcon,
   WrenchIcon,
@@ -87,6 +88,18 @@ export const ModCardHeader = memo(function ModCardHeader({ mod, actions }: ModCa
                 <SparklesIcon className="size-4" />
                 {t("page.tools.touch_profile.title")} ({t("g.beta")})
               </DropdownMenuItem>
+
+              {!actions.isNteGame && (
+                <DropdownMenuItem
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    actions.openConflictFinder(mod);
+                  }}
+                >
+                  <SwordsIcon className="size-4" />
+                  {t("page.mod.context-menu.find-conflict")}
+                </DropdownMenuItem>
+              )}
 
               {actions.runner.showWuwaFixer && (
                 <DropdownMenuItem

--- a/src/renderer/src/components/mod/mod-conflict-finder-dialog.tsx
+++ b/src/renderer/src/components/mod/mod-conflict-finder-dialog.tsx
@@ -94,8 +94,9 @@ export function ModConflictFinderDialog({
 
   const status = snapshot?.status ?? "idle";
   const isActive = status === "scanning" || status === "round";
-  const sessionActive = isActive || status === "reverting" || status === "done";
-  const canStart = !!game && !!mod?.isEnabled && !sessionActive;
+  const sessionActive = isActive || status === "reverting";
+  const hasUnfinalizedResult = status === "done" && !!snapshot?.finalBadPath;
+  const canStart = !!game && !!mod?.isEnabled && !sessionActive && !hasUnfinalizedResult;
   const canCancel = !!snapshot && status !== "idle" && status !== "done" && status !== "cancelled";
   const isBusy =
     starting ||
@@ -114,7 +115,7 @@ export function ModConflictFinderDialog({
         <DialogHeader>
           <DialogTitle>{t("page.mod.dialog.find-conflict.title")}</DialogTitle>
           <DialogDescription>
-            {sessionActive
+            {sessionActive || hasUnfinalizedResult
               ? t("page.mod.dialog.find-conflict.session-active")
               : t("page.mod.dialog.find-conflict.description", { name: mod?.name ?? "" })}
           </DialogDescription>
@@ -129,7 +130,14 @@ export function ModConflictFinderDialog({
         <div className="flex flex-wrap items-center gap-2">
           <Button
             onClick={() => {
-              if (!game || !mod?.isEnabled || sessionActive || startingRef.current) return;
+              if (
+                !game ||
+                !mod?.isEnabled ||
+                sessionActive ||
+                hasUnfinalizedResult ||
+                startingRef.current
+              )
+                return;
               startingRef.current = true;
               setStarting(true);
               void startMutation

--- a/src/renderer/src/components/mod/mod-conflict-finder-dialog.tsx
+++ b/src/renderer/src/components/mod/mod-conflict-finder-dialog.tsx
@@ -94,7 +94,8 @@ export function ModConflictFinderDialog({
 
   const status = snapshot?.status ?? "idle";
   const isActive = status === "scanning" || status === "round";
-  const canStart = !!game && !!mod && !isActive && status !== "reverting";
+  const sessionActive = isActive || status === "reverting" || status === "done";
+  const canStart = !!game && !!mod?.isEnabled && !sessionActive;
   const canCancel = !!snapshot && status !== "idle" && status !== "done" && status !== "cancelled";
   const isBusy =
     starting ||
@@ -113,7 +114,7 @@ export function ModConflictFinderDialog({
         <DialogHeader>
           <DialogTitle>{t("page.mod.dialog.find-conflict.title")}</DialogTitle>
           <DialogDescription>
-            {isActive || status === "reverting"
+            {sessionActive
               ? t("page.mod.dialog.find-conflict.session-active")
               : t("page.mod.dialog.find-conflict.description", { name: mod?.name ?? "" })}
           </DialogDescription>
@@ -128,7 +129,7 @@ export function ModConflictFinderDialog({
         <div className="flex flex-wrap items-center gap-2">
           <Button
             onClick={() => {
-              if (!game || !mod || startingRef.current) return;
+              if (!game || !mod?.isEnabled || sessionActive || startingRef.current) return;
               startingRef.current = true;
               setStarting(true);
               void startMutation

--- a/src/renderer/src/components/mod/mod-conflict-finder-dialog.tsx
+++ b/src/renderer/src/components/mod/mod-conflict-finder-dialog.tsx
@@ -1,0 +1,170 @@
+import {
+  BisectStatusCards,
+  isExcludeValidationMessage,
+  statusColor,
+} from "@renderer/components/tools/mod-bisect-views";
+import { Button } from "@renderer/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@renderer/components/ui/dialog";
+import type { ModInfo } from "@renderer/types/mod";
+import type { BisectSnapshot } from "@shared/types";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+interface ModConflictFinderDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  game: string;
+  mod: ModInfo | null;
+}
+
+export function ModConflictFinderDialog({
+  open,
+  onOpenChange,
+  game,
+  mod,
+}: ModConflictFinderDialogProps) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const [starting, setStarting] = useState(false);
+  const startingRef = useRef(false);
+
+  const { data: snapshot } = useQuery<BisectSnapshot | null>({
+    queryKey: ["tools:bisectState"],
+    queryFn: () => window.api.invoke("tools:bisectGetState"),
+    enabled: open,
+    refetchInterval: (query) => {
+      const value = query.state.data;
+      if (!value) return false;
+      if (value.status === "scanning" || value.status === "reverting") return 500;
+      return false;
+    },
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    const unsubscribe = window.api.on("tools:bisectState", (next) => {
+      queryClient.setQueryData(["tools:bisectState"], next);
+    });
+    return unsubscribe;
+  }, [queryClient, open]);
+
+  const startMutation = useMutation({
+    mutationFn: ({ game, modPath }: { game: string; modPath: string }) =>
+      window.api.invoke("tools:bisectStart", game, [modPath]),
+    onError: (err) => {
+      if (isExcludeValidationMessage(err.message)) {
+        toast.warning(t("page.tools.mod_bisect.exclude_invalid"));
+      } else {
+        toast.error(err.message);
+      }
+      void queryClient.invalidateQueries({ queryKey: ["tools:bisectState"] });
+    },
+  });
+
+  const respondMutation = useMutation({
+    mutationFn: (fixed: boolean) => window.api.invoke("tools:bisectRespond", fixed),
+    onError: (err) => {
+      toast.error(err.message);
+      void queryClient.invalidateQueries({ queryKey: ["tools:bisectState"] });
+    },
+  });
+
+  const undoMutation = useMutation({
+    mutationFn: () => window.api.invoke("tools:bisectUndoLastRound"),
+    onError: (err) => toast.error(err.message),
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: () => window.api.invoke("tools:bisectCancel"),
+    onError: (err) => toast.error(err.message),
+  });
+
+  const finalizeMutation = useMutation({
+    mutationFn: (keepDisabled: string[]) => window.api.invoke("tools:bisectFinalize", keepDisabled),
+    onError: (err) => toast.error(err.message),
+  });
+
+  const status = snapshot?.status ?? "idle";
+  const isActive = status === "scanning" || status === "round";
+  const canStart = !!game && !!mod && !isActive && status !== "reverting";
+  const canCancel = !!snapshot && status !== "idle" && status !== "done" && status !== "cancelled";
+  const isBusy =
+    starting ||
+    startMutation.isPending ||
+    respondMutation.isPending ||
+    undoMutation.isPending ||
+    cancelMutation.isPending ||
+    finalizeMutation.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="w-[min(44rem,calc(100%-2rem))] max-w-none"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <DialogHeader>
+          <DialogTitle>{t("page.mod.dialog.find-conflict.title")}</DialogTitle>
+          <DialogDescription>
+            {isActive || status === "reverting"
+              ? t("page.mod.dialog.find-conflict.session-active")
+              : t("page.mod.dialog.find-conflict.description", { name: mod?.name ?? "" })}
+          </DialogDescription>
+        </DialogHeader>
+
+        {mod && !mod.isEnabled ? (
+          <div className="rounded-md border border-amber-500/20 bg-amber-500/10 p-2 text-xs text-amber-600 dark:text-amber-400">
+            {t("page.mod.dialog.find-conflict.mod-disabled-warning")}
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            onClick={() => {
+              if (!game || !mod || startingRef.current) return;
+              startingRef.current = true;
+              setStarting(true);
+              void startMutation
+                .mutateAsync({ game, modPath: mod.path })
+                .catch(() => {
+                  // startMutation.onError already reported the failure
+                })
+                .finally(() => {
+                  startingRef.current = false;
+                  setStarting(false);
+                });
+            }}
+            disabled={!canStart || isBusy}
+          >
+            {t("page.tools.mod_bisect.start")}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => cancelMutation.mutate()}
+            disabled={!canCancel || isBusy}
+          >
+            {t("page.tools.mod_bisect.cancel")}
+          </Button>
+          <span className={`font-mono text-xs ${statusColor(status)}`}>
+            {t(`page.tools.mod_bisect.status.${status}`)}
+          </span>
+        </div>
+
+        <BisectStatusCards
+          snapshot={snapshot}
+          busy={isBusy}
+          onRespond={(fixed) => respondMutation.mutate(fixed)}
+          onUndo={() => undoMutation.mutate()}
+          onFinalize={(keepDisabled) => finalizeMutation.mutate(keepDisabled)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/renderer/src/components/mod/mod-context-menu.tsx
+++ b/src/renderer/src/components/mod/mod-context-menu.tsx
@@ -25,6 +25,7 @@ import {
   PencilIcon,
   PersonStandingIcon,
   SparklesIcon,
+  SwordsIcon,
   TerminalSquareIcon,
   TrashIcon,
 } from "lucide-react";
@@ -239,6 +240,10 @@ export function ModContextMenu({ mod, actions, children }: ModContextMenuProps) 
               <ContextMenuItem onClick={() => actions.openTouchProfileDialog(mod)}>
                 <SparklesIcon className="mr-2 size-4" />
                 {t("page.tools.touch_profile.title")} ({t("g.beta")})
+              </ContextMenuItem>
+              <ContextMenuItem onClick={() => actions.openConflictFinder(mod)}>
+                <SwordsIcon className="mr-2 size-4" />
+                {t("page.mod.context-menu.find-conflict")}
               </ContextMenuItem>
             </ContextMenuGroup>
             <ContextMenuSeparator />

--- a/src/renderer/src/components/tools/mod-bisect-views.tsx
+++ b/src/renderer/src/components/tools/mod-bisect-views.tsx
@@ -1,0 +1,219 @@
+import { Button } from "@renderer/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@renderer/components/ui/card";
+import { useSetting } from "@renderer/hooks/use-settings";
+import { disabledPrefixString } from "@shared/mod";
+import type { BisectSnapshot } from "@shared/types";
+import { useTranslation } from "react-i18next";
+
+import { ScrollArea } from "../ui/scroll-area";
+
+const ALL_EXCLUDED_ERROR = "All enabled INIs were excluded";
+
+export function relativeDisplay(rootPath: string | null, iniPath: string): string {
+  if (!rootPath) return iniPath;
+  const prefix = rootPath.replace(/[\\/]+$/, "");
+  if (iniPath.toLowerCase().startsWith(prefix.toLowerCase())) {
+    const relative = iniPath.slice(prefix.length);
+    return relative.replace(/^[\\/]+/, "");
+  }
+  return iniPath;
+}
+
+export function statusColor(status: BisectSnapshot["status"]) {
+  switch (status) {
+    case "round":
+      return "text-amber-600 dark:text-amber-400";
+    case "done":
+      return "text-green-600 dark:text-green-400";
+    case "cancelled":
+      return "text-muted-foreground";
+    case "reverting":
+      return "text-blue-600 dark:text-blue-400";
+    case "scanning":
+      return "text-blue-600 dark:text-blue-400";
+    default:
+      return "text-muted-foreground";
+  }
+}
+
+export function isExcludeValidationMessage(message: string) {
+  return (
+    message.includes("Exclude path is empty.") ||
+    message.includes("Exclude path must be inside the selected importer.") ||
+    message.includes("Exclude path cannot be the importer root.") ||
+    message.includes("Exclude path does not exist.")
+  );
+}
+
+function StatusCard({ text }: { text: string }) {
+  return (
+    <Card>
+      <CardContent className="text-sm text-muted-foreground">{text}</CardContent>
+    </Card>
+  );
+}
+
+export function RoundView({
+  snapshot,
+  busy,
+  onRespond,
+  onUndo,
+}: {
+  snapshot: BisectSnapshot;
+  busy: boolean;
+  onRespond: (fixed: boolean) => void;
+  onUndo: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          {t("page.tools.mod_bisect.round_title", {
+            round: snapshot.round,
+            batchSize: snapshot.batchSize,
+            remaining: snapshot.candidates.length,
+          })}
+        </CardTitle>
+        <CardDescription>{t("page.tools.mod_bisect.round_description")}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <div className="text-xs text-muted-foreground">
+          {t("page.tools.mod_bisect.disabled_count", {
+            count: snapshot.currentBatch.length,
+          })}
+        </div>
+        {snapshot.excludePaths.length > 0 ? (
+          <div className="text-xs text-muted-foreground">
+            {t("page.tools.mod_bisect.exclude_count", {
+              count: snapshot.excludePaths.length,
+            })}
+          </div>
+        ) : null}
+        <ScrollArea className="h-56 rounded border bg-muted/30 p-2">
+          <ul className="space-y-0.5 font-mono text-xs break-all">
+            {snapshot.currentBatch.map((iniPath) => (
+              <li key={iniPath}>{relativeDisplay(snapshot.modRootPath, iniPath)}</li>
+            ))}
+          </ul>
+        </ScrollArea>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="outline"
+            onClick={onUndo}
+            disabled={busy || snapshot.undoStackDepth === 0}
+          >
+            {t("page.tools.mod_bisect.undo")}
+          </Button>
+          <Button variant="destructive" onClick={() => onRespond(false)} disabled={busy}>
+            {t("page.tools.mod_bisect.still_broken")}
+          </Button>
+          <Button onClick={() => onRespond(true)} disabled={busy}>
+            {t("page.tools.mod_bisect.problem_fixed")}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function DoneView({
+  snapshot,
+  busy,
+  onFinalize,
+}: {
+  snapshot: BisectSnapshot;
+  busy: boolean;
+  onFinalize: (keepDisabled: string[]) => void;
+}) {
+  const { t } = useTranslation();
+  const { data: disabledPrefixStyle = "space" } = useSetting("mod.disabledPrefixStyle");
+  const originalPath = snapshot.finalBadPath ?? "";
+  const basename = originalPath ? (originalPath.split(/[\\/]+/).pop() ?? originalPath) : "";
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("page.tools.mod_bisect.done_title")}</CardTitle>
+        <CardDescription>
+          {t("page.tools.mod_bisect.done_description", {
+            path: relativeDisplay(snapshot.modRootPath, originalPath),
+          })}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <div className="text-xs text-muted-foreground">
+          {t("page.tools.mod_bisect.keep_disabled_hint", {
+            from: basename,
+            to: `${disabledPrefixString(disabledPrefixStyle)}${basename}`,
+          })}
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {t("page.tools.mod_bisect.new_bisect_hint")}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="outline"
+            onClick={() => onFinalize(snapshot.finalBadPath ? [snapshot.finalBadPath] : [])}
+            disabled={busy}
+          >
+            {t("page.tools.mod_bisect.keep_disabled")}
+          </Button>
+          <Button onClick={() => onFinalize([])} disabled={busy}>
+            {t("page.tools.mod_bisect.re_enable_all")}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function BisectStatusCards({
+  snapshot,
+  busy,
+  onRespond,
+  onUndo,
+  onFinalize,
+}: {
+  snapshot: BisectSnapshot | null | undefined;
+  busy: boolean;
+  onRespond: (fixed: boolean) => void;
+  onUndo: () => void;
+  onFinalize: (keepDisabled: string[]) => void;
+}) {
+  const { t } = useTranslation();
+  if (!snapshot) return null;
+
+  const { status } = snapshot;
+  if (status === "round") {
+    return <RoundView snapshot={snapshot} busy={busy} onRespond={onRespond} onUndo={onUndo} />;
+  }
+  if (status === "scanning") {
+    return <StatusCard text={t("page.tools.mod_bisect.scanning")} />;
+  }
+  if (status === "done" && snapshot.finalBadPath) {
+    return <DoneView snapshot={snapshot} busy={busy} onFinalize={onFinalize} />;
+  }
+  if (status === "done" && !snapshot.finalBadPath && snapshot.error === ALL_EXCLUDED_ERROR) {
+    return <StatusCard text={t("page.tools.mod_bisect.all_excluded")} />;
+  }
+  if (status === "done" && !snapshot.finalBadPath && snapshot.error) {
+    return <StatusCard text={t("page.tools.mod_bisect.bisect_inconclusive")} />;
+  }
+  if (status === "done" && !snapshot.finalBadPath && !snapshot.error) {
+    return <StatusCard text={t("page.tools.mod_bisect.no_inis_found")} />;
+  }
+  if (status === "cancelled") {
+    return <StatusCard text={t("page.tools.mod_bisect.cancelled")} />;
+  }
+  if (status === "reverting") {
+    return <StatusCard text={t("page.tools.mod_bisect.reverting")} />;
+  }
+  return null;
+}

--- a/src/renderer/src/components/tools/mod-bisect.tsx
+++ b/src/renderer/src/components/tools/mod-bisect.tsx
@@ -20,7 +20,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@renderer/components/ui
 import { useGames } from "@renderer/hooks/use-mod-data";
 import { useSetting } from "@renderer/hooks/use-settings";
 import { setSetting } from "@renderer/lib/settings";
-import { disabledPrefixString, isNteImporter } from "@shared/mod";
+import { isNteImporter } from "@shared/mod";
 import type { BisectSnapshot, GameConfig } from "@shared/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { PlusIcon, XIcon } from "lucide-react";
@@ -28,45 +28,7 @@ import { useEffect, useImperativeHandle, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
-import { ScrollArea } from "../ui/scroll-area";
-
-function relativeDisplay(rootPath: string | null, iniPath: string): string {
-  if (!rootPath) return iniPath;
-  const prefix = rootPath.replace(/[\\/]+$/, "");
-  if (iniPath.toLowerCase().startsWith(prefix.toLowerCase())) {
-    const relative = iniPath.slice(prefix.length);
-    return relative.replace(/^[\\/]+/, "");
-  }
-  return iniPath;
-}
-
-function statusColor(status: BisectSnapshot["status"]) {
-  switch (status) {
-    case "round":
-      return "text-amber-600 dark:text-amber-400";
-    case "done":
-      return "text-green-600 dark:text-green-400";
-    case "cancelled":
-      return "text-muted-foreground";
-    case "reverting":
-      return "text-blue-600 dark:text-blue-400";
-    case "scanning":
-      return "text-blue-600 dark:text-blue-400";
-    default:
-      return "text-muted-foreground";
-  }
-}
-
-function isExcludeValidationMessage(message: string) {
-  return (
-    message.includes("Exclude path is empty.") ||
-    message.includes("Exclude path must be inside the selected importer.") ||
-    message.includes("Exclude path cannot be the importer root.") ||
-    message.includes("Exclude path does not exist.")
-  );
-}
-
-const ALL_EXCLUDED_ERROR = "All enabled INIs were excluded";
+import { BisectStatusCards, isExcludeValidationMessage, statusColor } from "./mod-bisect-views";
 
 type ExcludeRow = {
   id: string;
@@ -279,77 +241,13 @@ export default function ModBisect() {
         </CardContent>
       </Card>
 
-      {snapshot && status === "round" ? (
-        <RoundView
-          snapshot={snapshot}
-          busy={isBusy}
-          onRespond={(fixed) => respondMutation.mutate(fixed)}
-          onUndo={() => undoMutation.mutate()}
-        />
-      ) : null}
-
-      {snapshot && status === "scanning" ? (
-        <Card>
-          <CardContent className="text-sm text-muted-foreground">
-            {t("page.tools.mod_bisect.scanning")}
-          </CardContent>
-        </Card>
-      ) : null}
-
-      {snapshot && status === "done" && snapshot.finalBadPath ? (
-        <DoneView
-          snapshot={snapshot}
-          busy={isBusy}
-          onFinalize={(keepDisabled) => finalizeMutation.mutate(keepDisabled)}
-        />
-      ) : null}
-
-      {snapshot &&
-      status === "done" &&
-      !snapshot.finalBadPath &&
-      snapshot.error === ALL_EXCLUDED_ERROR ? (
-        <Card>
-          <CardContent className="text-sm text-muted-foreground">
-            {t("page.tools.mod_bisect.all_excluded")}
-          </CardContent>
-        </Card>
-      ) : null}
-
-      {snapshot &&
-      status === "done" &&
-      !snapshot.finalBadPath &&
-      snapshot.error &&
-      snapshot.error !== ALL_EXCLUDED_ERROR ? (
-        <Card>
-          <CardContent className="text-sm text-muted-foreground">
-            {t("page.tools.mod_bisect.bisect_inconclusive")}
-          </CardContent>
-        </Card>
-      ) : null}
-
-      {snapshot && status === "done" && !snapshot.finalBadPath && !snapshot.error ? (
-        <Card>
-          <CardContent className="text-sm text-muted-foreground">
-            {t("page.tools.mod_bisect.no_inis_found")}
-          </CardContent>
-        </Card>
-      ) : null}
-
-      {snapshot && status === "cancelled" ? (
-        <Card>
-          <CardContent className="text-sm text-muted-foreground">
-            {t("page.tools.mod_bisect.cancelled")}
-          </CardContent>
-        </Card>
-      ) : null}
-
-      {snapshot && status === "reverting" ? (
-        <Card>
-          <CardContent className="text-sm text-muted-foreground">
-            {t("page.tools.mod_bisect.reverting")}
-          </CardContent>
-        </Card>
-      ) : null}
+      <BisectStatusCards
+        snapshot={snapshot}
+        busy={isBusy}
+        onRespond={(fixed) => respondMutation.mutate(fixed)}
+        onUndo={() => undoMutation.mutate()}
+        onFinalize={(keepDisabled) => finalizeMutation.mutate(keepDisabled)}
+      />
     </div>
   );
 }
@@ -593,120 +491,5 @@ function GameSelect({
         </SelectGroup>
       </SelectContent>
     </Select>
-  );
-}
-
-function RoundView({
-  snapshot,
-  busy,
-  onRespond,
-  onUndo,
-}: {
-  snapshot: BisectSnapshot;
-  busy: boolean;
-  onRespond: (fixed: boolean) => void;
-  onUndo: () => void;
-}) {
-  const { t } = useTranslation();
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>
-          {t("page.tools.mod_bisect.round_title", {
-            round: snapshot.round,
-            batchSize: snapshot.batchSize,
-            remaining: snapshot.candidates.length,
-          })}
-        </CardTitle>
-        <CardDescription>{t("page.tools.mod_bisect.round_description")}</CardDescription>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-3">
-        <div className="text-xs text-muted-foreground">
-          {t("page.tools.mod_bisect.disabled_count", {
-            count: snapshot.currentBatch.length,
-          })}
-        </div>
-        {snapshot.excludePaths.length > 0 ? (
-          <div className="text-xs text-muted-foreground">
-            {t("page.tools.mod_bisect.exclude_count", {
-              count: snapshot.excludePaths.length,
-            })}
-          </div>
-        ) : null}
-        <ScrollArea className="h-56 rounded border bg-muted/30 p-2">
-          <ul className="space-y-0.5 font-mono text-xs break-all">
-            {snapshot.currentBatch.map((iniPath) => (
-              <li key={iniPath}>{relativeDisplay(snapshot.modRootPath, iniPath)}</li>
-            ))}
-          </ul>
-        </ScrollArea>
-
-        <div className="flex flex-wrap gap-2">
-          <Button
-            variant="outline"
-            onClick={onUndo}
-            disabled={busy || snapshot.undoStackDepth === 0}
-          >
-            {t("page.tools.mod_bisect.undo")}
-          </Button>
-          <Button variant="destructive" onClick={() => onRespond(false)} disabled={busy}>
-            {t("page.tools.mod_bisect.still_broken")}
-          </Button>
-          <Button onClick={() => onRespond(true)} disabled={busy}>
-            {t("page.tools.mod_bisect.problem_fixed")}
-          </Button>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-function DoneView({
-  snapshot,
-  busy,
-  onFinalize,
-}: {
-  snapshot: BisectSnapshot;
-  busy: boolean;
-  onFinalize: (keepDisabled: string[]) => void;
-}) {
-  const { t } = useTranslation();
-  const { data: disabledPrefixStyle = "space" } = useSetting("mod.disabledPrefixStyle");
-  const originalPath = snapshot.finalBadPath ?? "";
-  const basename = originalPath ? (originalPath.split(/[\\/]+/).pop() ?? originalPath) : "";
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{t("page.tools.mod_bisect.done_title")}</CardTitle>
-        <CardDescription>
-          {t("page.tools.mod_bisect.done_description", {
-            path: relativeDisplay(snapshot.modRootPath, originalPath),
-          })}
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-3">
-        <div className="text-xs text-muted-foreground">
-          {t("page.tools.mod_bisect.keep_disabled_hint", {
-            from: basename,
-            to: `${disabledPrefixString(disabledPrefixStyle)}${basename}`,
-          })}
-        </div>
-        <div className="text-xs text-muted-foreground">
-          {t("page.tools.mod_bisect.new_bisect_hint")}
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Button
-            variant="outline"
-            onClick={() => onFinalize(snapshot.finalBadPath ? [snapshot.finalBadPath] : [])}
-            disabled={busy}
-          >
-            {t("page.tools.mod_bisect.keep_disabled")}
-          </Button>
-          <Button onClick={() => onFinalize([])} disabled={busy}>
-            {t("page.tools.mod_bisect.re_enable_all")}
-          </Button>
-        </div>
-      </CardContent>
-    </Card>
   );
 }

--- a/src/renderer/src/hooks/use-drive-clipboard.ts
+++ b/src/renderer/src/hooks/use-drive-clipboard.ts
@@ -69,6 +69,9 @@ export function useDriveClipboardActions(destinationId: string) {
                     void queryClient.invalidateQueries({
                         queryKey: ["drive", "share", destinationId],
                     });
+                    void queryClient.invalidateQueries({
+                        queryKey: ["drive", "search"],
+                    });
                     setCopyOrCuts(null, []);
                     return t("page.drive.clipboard.move_success");
                 },
@@ -96,6 +99,9 @@ export function useDriveClipboardActions(destinationId: string) {
                     });
                     void queryClient.invalidateQueries({
                         queryKey: ["drive", "share", destinationId],
+                    });
+                    void queryClient.invalidateQueries({
+                        queryKey: ["drive", "search"],
                     });
                     return t("page.drive.clipboard.copy_success");
                 },

--- a/src/renderer/src/hooks/use-drive-descendant-search.ts
+++ b/src/renderer/src/hooks/use-drive-descendant-search.ts
@@ -1,0 +1,106 @@
+import { isDriveSearchUnavailable } from "@renderer/lib/utils";
+import { useViewStore } from "@renderer/store/drive";
+import { toErrorMessage } from "@shared/utils";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+export function useDriveDescendantSearch(effectiveId: string) {
+    const { t } = useTranslation();
+    const searchInDirQuery = useViewStore((s) => s.searchInDirQuery);
+    const setSearchInDirQuery = useViewStore((s) => s.setSearchInDirQuery);
+    const includeSubdirs = useViewStore((s) => s.includeSubdirs);
+
+    const [debouncedQ, setDebouncedQ] = useState("");
+
+    // biome-ignore lint/correctness/useExhaustiveDependencies: <>
+    useEffect(() => {
+        if (searchInDirQuery) {
+            setSearchInDirQuery("");
+        }
+        setDebouncedQ("");
+    }, [effectiveId]);
+
+    useEffect(() => {
+        const timeout = window.setTimeout(() => {
+            setDebouncedQ(searchInDirQuery.trim());
+        }, 300);
+
+        return () => clearTimeout(timeout);
+    }, [searchInDirQuery]);
+
+    const isSubdirSearchMode = includeSubdirs && effectiveId !== "share";
+    const trimmedQuery = searchInDirQuery.trim();
+    const isSearching = isSubdirSearchMode && trimmedQuery.length >= 2;
+    const isDescendantSearch = isSearching && debouncedQ.length >= 2;
+
+    const searchQuery = useInfiniteQuery({
+        queryKey: ["drive", "search", effectiveId, debouncedQ],
+        enabled: isDescendantSearch,
+        staleTime: 30_000,
+        refetchOnWindowFocus: false,
+        retry: false,
+        initialPageParam: undefined as string | undefined,
+        queryFn: async ({ pageParam }) => {
+            try {
+                return await window.api.invoke("drive:get:search", effectiveId, {
+                    q: debouncedQ,
+                    limit: 50,
+                    ...(pageParam === undefined ? {} : { cursor: pageParam }),
+                });
+            } catch (error) {
+                if (isDriveSearchUnavailable(error)) {
+                    throw new Error("search_unavailable");
+                }
+                throw error;
+            }
+        },
+        getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    });
+
+    const searchContents = useMemo(
+        () => searchQuery.data?.pages.flatMap((page) => page.items) ?? [],
+        [searchQuery.data],
+    );
+
+    const isSearchPending =
+        isSearching &&
+        (!isDescendantSearch || (searchQuery.isFetching && searchContents.length === 0));
+    const isSearchFailed = isDescendantSearch && searchQuery.isError && !searchQuery.data;
+    const searchErrorMessage = isSearchFailed
+        ? isDriveSearchUnavailable(searchQuery.error)
+            ? t("page.drive.head_buttons.search_unavailable")
+            : toErrorMessage(searchQuery.error)
+        : null;
+    const isSearchEmpty =
+        isDescendantSearch &&
+        searchQuery.isFetched &&
+        !searchQuery.isError &&
+        searchContents.length === 0;
+
+    const loadMore = async () => {
+        try {
+            await searchQuery.fetchNextPage();
+        } catch (error) {
+            toast.error(
+                isDriveSearchUnavailable(error)
+                    ? t("page.drive.head_buttons.search_unavailable")
+                    : toErrorMessage(error),
+            );
+        }
+    };
+
+    return {
+        isSearching,
+        isDescendantSearch,
+        searchContents,
+        isSearchPending,
+        isSearchFailed,
+        searchErrorMessage,
+        isSearchEmpty,
+        hasNextPage: searchQuery.hasNextPage,
+        isFetchingNextPage: searchQuery.isFetchingNextPage,
+        loadMore,
+    };
+}

--- a/src/renderer/src/hooks/use-mod-actions.tsx
+++ b/src/renderer/src/hooks/use-mod-actions.tsx
@@ -37,6 +37,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
 import { BodyShapeDialog } from "../components/mod/body-shape-dialog";
+import { ModConflictFinderDialog } from "../components/mod/mod-conflict-finder-dialog";
 import { ModFixRunnerDialogs } from "../components/mod/mod-fix-runner-dialogs";
 import { pasteModPreview } from "../components/mod/paste-preview";
 import { TextureResizeDialog } from "../components/mod/texture-resize-dialog";
@@ -85,6 +86,7 @@ export interface ModActionApi {
   openTextureResizeDialog: (mod: ModInfo) => void;
   openBodyShapeDialog: (mod: ModInfo) => void;
   openTouchProfileDialog: (mod: ModInfo) => void;
+  openConflictFinder: (mod: ModInfo) => void;
   openWuwaFixer: (mod: ModInfo) => Promise<void>;
   markAsManualSubGroup: (mod: ModInfo) => Promise<void>;
   runPreset: (mod: ModInfo, presetId: string) => Promise<void>;
@@ -108,6 +110,7 @@ export function useModActions(selectedGroupPath?: string): ModActionApi {
   const [textureResizeMod, setTextureResizeMod] = useState<ModInfo | null>(null);
   const [bodyShapeMod, setBodyShapeMod] = useState<ModInfo | null>(null);
   const [touchProfileMod, setTouchProfileMod] = useState<ModInfo | null>(null);
+  const [conflictFinderMod, setConflictFinderMod] = useState<ModInfo | null>(null);
   const [renameDialogState, setRenameDialogState] = useState<{
     groupPath?: string;
     mod: ModInfo;
@@ -353,6 +356,13 @@ export function useModActions(selectedGroupPath?: string): ModActionApi {
         }}
       />
 
+      <ModConflictFinderDialog
+        open={conflictFinderMod !== null}
+        onOpenChange={(open) => !open && setConflictFinderMod(null)}
+        game={selectedGame}
+        mod={conflictFinderMod}
+      />
+
       <ModelViewerDialog
         open={showModelViewer}
         onOpenChange={(open) => {
@@ -385,6 +395,7 @@ export function useModActions(selectedGroupPath?: string): ModActionApi {
     openTextureResizeDialog: (mod) => setTextureResizeMod(mod),
     openBodyShapeDialog: (mod) => setBodyShapeMod(mod),
     openTouchProfileDialog: (mod) => setTouchProfileMod(mod),
+    openConflictFinder: (mod) => setConflictFinderMod(mod),
     openWuwaFixer: async (mod) => {
       await runner.handleOpenWuwaFixer(mod.path);
     },

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -153,6 +153,11 @@
       },
       "head_buttons": {
         "search_in_dir_placeholder": "Search in this folder...",
+        "search_in_subdirs_placeholder": "Search in subfolders...",
+        "search_include_subdirs": "Include subfolders",
+        "search_no_results": "No search results",
+        "search_load_more": "Load more",
+        "search_unavailable": "Search is unavailable",
         "import": "Import a shared link",
         "dropdown_menu": {
           "download": "Download",

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -405,6 +405,12 @@
           "name-placeholder": "Mod name",
           "confirm": "Rename"
         },
+        "find-conflict": {
+          "title": "Find Conflict Mode",
+          "description": "Runs a bisect with \"{{name}}\" kept enabled to find which other mod conflicts with it.",
+          "mod-disabled-warning": "This mod is currently disabled. Enable it first to reproduce the conflict.",
+          "session-active": "A bisect session is already in progress. Cancel or finish it before starting a new one."
+        },
         "texture-resize": {
           "title": "Resize mod textures",
           "description": "Scan \"{{name}}\" for DDS files and resize them in place."
@@ -607,7 +613,8 @@
         "open-folder": "Open folder",
         "open-gamebanana": "View on GameBanana",
         "mark-manual-subgroup": "Mark as subgroup",
-        "rename": "Rename"
+        "rename": "Rename",
+        "find-conflict": "Find Conflict Mode"
       },
       "toast": {
         "trash-loading": "Moving to recycle bin...",

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -387,6 +387,12 @@
           "name-placeholder": "MOD名",
           "confirm": "名前を変更"
         },
+        "find-conflict": {
+          "title": "競合モードを探す",
+          "description": "\"{{name}}\" のフォルダーを無効化対象から除外して二分探索を実行し、このモードと競合する他のモードを特定します。",
+          "mod-disabled-warning": "このモードは現在無効化されています。競合を再現するには先に有効化してください。",
+          "session-active": "二分探索はすでに実行中です。現在のセッションをキャンセルまたは完了してから再試行してください。"
+        },
         "texture-resize": {
           "title": "MOD テクスチャをリサイズ",
           "description": "\"{{name}}\" 内の DDS ファイルを検索してその場でリサイズします。"
@@ -585,7 +591,8 @@
         "open-folder": "フォルダーを開く",
         "open-gamebanana": "GameBananaで表示",
         "mark-manual-subgroup": "サブグループとして指定",
-        "rename": "名前を変更"
+        "rename": "名前を変更",
+        "find-conflict": "競合モードを探す"
       },
       "toast": {
         "trash-loading": "ゴミ箱に移動中...",

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -137,6 +137,11 @@
       },
       "head_buttons": {
         "search_in_dir_placeholder": "このフォルダー内を検索...",
+        "search_in_subdirs_placeholder": "サブフォルダ内を検索...",
+        "search_include_subdirs": "サブフォルダを含める",
+        "search_no_results": "検索結果がありません",
+        "search_load_more": "もっと見る",
+        "search_unavailable": "検索を利用できません",
         "import": "共有リンクをインポート",
         "dropdown_menu": {
           "download": "ダウンロード",

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -136,6 +136,11 @@
       },
       "head_buttons": {
         "search_in_dir_placeholder": "이 폴더에서 검색...",
+        "search_in_subdirs_placeholder": "하위 폴더에서 검색...",
+        "search_include_subdirs": "하위 폴더 포함",
+        "search_no_results": "검색 결과가 없습니다",
+        "search_load_more": "더 보기",
+        "search_unavailable": "검색을 사용할 수 없습니다",
         "import": "공유 링크 가져오기",
         "dropdown_menu": {
           "download": "다운로드",

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -389,6 +389,12 @@
           "name-placeholder": "모드 이름",
           "confirm": "이름 변경"
         },
+        "find-conflict": {
+          "title": "충돌 모드 찾기",
+          "description": "\"{{name}}\" 모드의 폴더를 비활성화에서 제외한 채 이진 탐색을 실행합니다. 이 모드와 충돌하는 다른 모드를 찾아냅니다.",
+          "mod-disabled-warning": "이 모드는 현재 비활성화되어 있습니다. 충돌을 재현하려면 먼저 활성화하세요.",
+          "session-active": "이진 탐색이 이미 진행 중입니다. 현재 세션을 취소하거나 완료한 뒤 다시 시도하세요."
+        },
         "texture-resize": {
           "title": "모드 텍스처 리사이즈",
           "description": "\"{{name}}\" 아래의 DDS 파일을 찾아 제자리에서 리사이즈합니다."
@@ -591,7 +597,8 @@
         "open-folder": "폴더 열기",
         "open-gamebanana": "GameBanana에서 보기",
         "mark-manual-subgroup": "서브그룹으로 지정",
-        "rename": "이름 변경"
+        "rename": "이름 변경",
+        "find-conflict": "충돌 모드 찾기"
       },
       "toast": {
         "trash-loading": "휴지통으로 이동 중...",

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -136,6 +136,11 @@
       },
       "head_buttons": {
         "search_in_dir_placeholder": "在此文件夹中搜索...",
+        "search_in_subdirs_placeholder": "在子文件夹中搜索...",
+        "search_include_subdirs": "包含子文件夹",
+        "search_no_results": "没有搜索结果",
+        "search_load_more": "加载更多",
+        "search_unavailable": "搜索暂不可用",
         "import": "导入共享链接",
         "dropdown_menu": {
           "download": "下载",

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -386,6 +386,12 @@
           "name-placeholder": "模组名称",
           "confirm": "重命名"
         },
+        "find-conflict": {
+          "title": "查找冲突模组",
+          "description": "运行二分查找，将 \"{{name}}\" 的文件夹排除在禁用之外，以找出与它冲突的其他模组。",
+          "mod-disabled-warning": "该模组当前已禁用。请先启用它再重现冲突。",
+          "session-active": "二分查找已在运行中。请先取消或完成当前会话，然后再试。"
+        },
         "texture-resize": {
           "title": "缩放模组纹理",
           "description": "扫描“{{name}}”中的 DDS 文件并原地缩放。"
@@ -584,7 +590,8 @@
         "open-folder": "打开文件夹",
         "open-gamebanana": "在 GameBanana 中查看",
         "mark-manual-subgroup": "指定为子分组",
-        "rename": "重命名"
+        "rename": "重命名",
+        "find-conflict": "查找冲突模组"
       },
       "toast": {
         "trash-loading": "移动到回收站中...",

--- a/src/renderer/src/lib/utils.ts
+++ b/src/renderer/src/lib/utils.ts
@@ -8,6 +8,20 @@ export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs));
 }
 
+// Drive descendant search is unavailable when the backend OpenSearch dependency is down (503)
+// or the backend itself is unreachable; DriveApiError fields may be lost through IPC
+// serialization, so both status/code and message markers are checked.
+export function isDriveSearchUnavailable(error: unknown): boolean {
+    if (typeof error !== "object" || error === null) return false;
+
+    const record = error as Record<string, unknown>;
+    if (record.status === 502 || record.status === 503 || record.status === 504) return true;
+    if (record.code === "DRIVE_BACKEND_UNAVAILABLE") return true;
+
+    const message = typeof record.message === "string" ? record.message : "";
+    return message.includes("DRIVE_BACKEND_UNAVAILABLE") || message.includes("search_unavailable");
+}
+
 export const naturalCompare = (a: string, b: string, mp: number) => {
     const collator = new Intl.Collator(undefined, {
         numeric: true,

--- a/src/renderer/src/routes/drive/drive.$id.tsx
+++ b/src/renderer/src/routes/drive/drive.$id.tsx
@@ -17,21 +17,23 @@ import { Center, ServerCrash } from "@renderer/components/common";
 import { ContextMenuProvider } from "@renderer/components/drive/context-menu";
 import { DriveImportOverlay } from "@renderer/components/drive/drive-import-overlay";
 import { AliceLoader } from "@renderer/components/loaders";
+import { Button } from "@renderer/components/ui/button";
 import { ScrollArea } from "@renderer/components/ui/scroll-area";
 import { useDrag } from "@renderer/hooks/drive";
 import { useAuth } from "@renderer/hooks/use-auth";
 import { useDriveUploadRefresh } from "@renderer/hooks/use-drive-upload-refresh";
 import { useDriveNameSortPolicy } from "@renderer/hooks/use-settings";
 import { getSearchScore } from "@renderer/lib/sejong";
-import { commonSort } from "@renderer/lib/utils";
+import { commonSort, isDriveSearchUnavailable } from "@renderer/lib/utils";
 import { useViewStore, viewStore } from "@renderer/store/drive";
+import type { Content } from "@shared/types";
 import { toErrorMessage } from "@shared/utils";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, useLocation } from "@tanstack/react-router";
 import { disassemble, getChoseong } from "es-hangul";
 import { orderBy } from "es-toolkit";
 import { FolderIcon } from "lucide-react";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -49,11 +51,17 @@ function RouteComponent() {
   const { onDragEnter, onDragLeave, onDragOver, onDrop } = useDrag();
   const searchInDirQuery = useViewStore((s) => s.searchInDirQuery);
   const setSearchInDirQuery = useViewStore((s) => s.setSearchInDirQuery);
+  const includeSubdirs = useViewStore((s) => s.includeSubdirs);
   const sortType = useViewStore((s) => s.sortType);
   const layout = useViewStore((s) => s.layout);
   const { data: nameSortPolicy = "natural_ignore_spacing" } = useDriveNameSortPolicy();
 
   useDriveUploadRefresh(effectiveId, ["drive", "drive", effectiveId]);
+
+  const [debouncedQ, setDebouncedQ] = useState("");
+  const [extraItems, setExtraItems] = useState<Content[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
 
   const query = useQuery({
     queryKey: ["drive", "drive", effectiveId],
@@ -77,7 +85,53 @@ function RouteComponent() {
     if (searchInDirQuery) {
       setSearchInDirQuery("");
     }
+    setDebouncedQ("");
   }, [effectiveId]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedQ(searchInDirQuery.trim());
+    }, 300);
+
+    return () => clearTimeout(timeout);
+  }, [searchInDirQuery]);
+
+  const isSubdirSearchMode = includeSubdirs && effectiveId !== "share";
+  const trimmedQuery = searchInDirQuery.trim();
+  const isSearching = isSubdirSearchMode && trimmedQuery.length >= 2;
+  const isDescendantSearch = isSearching && debouncedQ.length >= 2;
+
+  const searchQuery = useQuery({
+    queryKey: ["drive", "search", effectiveId, debouncedQ],
+    enabled: isDescendantSearch,
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      try {
+        return await window.api.invoke("drive:get:search", effectiveId, {
+          q: debouncedQ,
+          limit: 50,
+        });
+      } catch (error) {
+        if (isDriveSearchUnavailable(error)) {
+          toast.error(t("page.drive.head_buttons.search_unavailable"));
+          throw new Error("search_unavailable");
+        }
+        throw error;
+      }
+    },
+  });
+
+  useEffect(() => {
+    setExtraItems([]);
+    setNextCursor(null);
+    setIsLoadingMore(false);
+  }, [effectiveId, debouncedQ]);
+
+  useEffect(() => {
+    setExtraItems([]);
+    setNextCursor(searchQuery.data?.nextCursor ?? null);
+  }, [searchQuery.data]);
 
   useEffect(() => {
     if (effectiveId && location.pathname.startsWith("/drive/drive/")) {
@@ -91,9 +145,9 @@ function RouteComponent() {
     return commonSort([...query.data.children], sortType, nameSortPolicy);
   }, [query.data?.children, sortType, nameSortPolicy]);
 
-  const sortedContents = useMemo(() => {
+  const localContents = useMemo(() => {
     if (!rawContents) return [];
-    if (!searchInDirQuery) return rawContents;
+    if (isSubdirSearchMode || !searchInDirQuery) return rawContents;
 
     const query = searchInDirQuery.toLowerCase();
 
@@ -115,7 +169,48 @@ function RouteComponent() {
       [(di) => di.score],
       ["desc"],
     ).map((scoredItem) => scoredItem.item);
-  }, [rawContents, searchInDirQuery]);
+  }, [rawContents, searchInDirQuery, isSubdirSearchMode]);
+
+  const searchContents = useMemo(() => {
+    if (!searchQuery.data) return extraItems;
+    return [...searchQuery.data.items, ...extraItems];
+  }, [searchQuery.data, extraItems]);
+
+  const displayContents = isDescendantSearch ? searchContents : isSearching ? [] : localContents;
+  const isSearchPending =
+    isSearching && (!isDescendantSearch || (searchQuery.isFetching && searchContents.length === 0));
+  const isSearchFailed = isDescendantSearch && searchQuery.isError;
+  const isSearchEmpty =
+    isDescendantSearch &&
+    searchQuery.isFetched &&
+    !searchQuery.isError &&
+    searchContents.length === 0;
+
+  async function loadMore() {
+    if (!nextCursor || isLoadingMore) return;
+
+    const identity = `${effectiveId}:${debouncedQ}`;
+    setIsLoadingMore(true);
+    try {
+      const data = await window.api.invoke("drive:get:search", effectiveId, {
+        q: debouncedQ,
+        limit: 50,
+        cursor: nextCursor,
+      });
+
+      if (identity !== `${effectiveId}:${debouncedQ}`) return;
+
+      setExtraItems((prev) => [...prev, ...data.items]);
+      setNextCursor(data.nextCursor);
+    } catch {
+      if (identity !== `${effectiveId}:${debouncedQ}`) return;
+      toast.error(t("page.drive.head_buttons.search_unavailable"));
+    } finally {
+      if (identity === `${effectiveId}:${debouncedQ}`) {
+        setIsLoadingMore(false);
+      }
+    }
+  }
 
   const handleDrop = async (e: React.DragEvent<HTMLDivElement>) => {
     try {
@@ -177,28 +272,59 @@ function RouteComponent() {
             <ContextMenuProvider>
               <HandlerProvider
                 queryData={query}
-                sortedContents={sortedContents}
+                sortedContents={displayContents}
                 currentId={effectiveId}
               >
-                {sortedContents.length > 0 ? (
+                {displayContents.length > 0 ? (
                   <ScrollArea className="flex h-full flex-1 flex-col">
                     <>
                       {layout === "list" ? (
                         <ContentMenuList
-                          sortedContents={sortedContents}
+                          sortedContents={displayContents}
                           isFetching={query.isFetching}
                           itemId={effectiveId}
                         />
                       ) : layout === "grid" ? (
                         <ContentMenuGrid
-                          sortedContents={sortedContents}
+                          sortedContents={displayContents}
                           isFetching={query.isFetching}
                           itemId={effectiveId}
                         />
                       ) : null}
+
+                      {isDescendantSearch && nextCursor && (
+                        <div className="flex justify-center p-4">
+                          <Button
+                            variant="outline"
+                            disabled={isLoadingMore}
+                            onClick={() => {
+                              void loadMore();
+                            }}
+                          >
+                            {t("page.drive.head_buttons.search_load_more")}
+                          </Button>
+                        </div>
+                      )}
                     </>
                   </ScrollArea>
-                ) : query.isFetched && sortedContents.length < 1 ? (
+                ) : isSearchFailed ? (
+                  <Center className="flex-col">
+                    <p className="text-center text-lg">
+                      {t("page.drive.head_buttons.search_unavailable")}
+                    </p>
+                  </Center>
+                ) : isSearchEmpty ? (
+                  <Center className="flex-col">
+                    <div>
+                      <FolderIcon size="80" />
+                    </div>
+                    <p className="mt-4 text-center text-lg">
+                      {t("page.drive.head_buttons.search_no_results")}
+                    </p>
+                  </Center>
+                ) : isSearchPending ? (
+                  <AkashaSkeleton />
+                ) : query.isFetched && displayContents.length < 1 ? (
                   <Center className="flex-col">
                     <div>
                       <FolderIcon size="80" />
@@ -210,7 +336,7 @@ function RouteComponent() {
                       {t("page.drive.no_contents_section_message.1")}
                     </p>
                   </Center>
-                ) : query.isFetching && sortedContents.length === 0 ? (
+                ) : query.isFetching && displayContents.length === 0 ? (
                   <AkashaSkeleton />
                 ) : null}
               </HandlerProvider>
@@ -221,7 +347,7 @@ function RouteComponent() {
         <RenameDialog />
         <DeleteItemsDialog />
         <ConflictNameDialog />
-        <NewDirectoryDialog contents={sortedContents} />
+        <NewDirectoryDialog contents={rawContents} />
         {/* <PubLinkDialog /> */}
 
         <DriveImportOverlay destinationId={effectiveId} />

--- a/src/renderer/src/routes/drive/drive.$id.tsx
+++ b/src/renderer/src/routes/drive/drive.$id.tsx
@@ -21,19 +21,19 @@ import { Button } from "@renderer/components/ui/button";
 import { ScrollArea } from "@renderer/components/ui/scroll-area";
 import { useDrag } from "@renderer/hooks/drive";
 import { useAuth } from "@renderer/hooks/use-auth";
+import { useDriveDescendantSearch } from "@renderer/hooks/use-drive-descendant-search";
 import { useDriveUploadRefresh } from "@renderer/hooks/use-drive-upload-refresh";
 import { useDriveNameSortPolicy } from "@renderer/hooks/use-settings";
 import { getSearchScore } from "@renderer/lib/sejong";
-import { commonSort, isDriveSearchUnavailable } from "@renderer/lib/utils";
+import { commonSort } from "@renderer/lib/utils";
 import { useViewStore, viewStore } from "@renderer/store/drive";
-import type { Content } from "@shared/types";
 import { toErrorMessage } from "@shared/utils";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, useLocation } from "@tanstack/react-router";
 import { disassemble, getChoseong } from "es-hangul";
 import { orderBy } from "es-toolkit";
 import { FolderIcon } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -50,7 +50,6 @@ function RouteComponent() {
 
   const { onDragEnter, onDragLeave, onDragOver, onDrop } = useDrag();
   const searchInDirQuery = useViewStore((s) => s.searchInDirQuery);
-  const setSearchInDirQuery = useViewStore((s) => s.setSearchInDirQuery);
   const includeSubdirs = useViewStore((s) => s.includeSubdirs);
   const sortType = useViewStore((s) => s.sortType);
   const layout = useViewStore((s) => s.layout);
@@ -58,10 +57,18 @@ function RouteComponent() {
 
   useDriveUploadRefresh(effectiveId, ["drive", "drive", effectiveId]);
 
-  const [debouncedQ, setDebouncedQ] = useState("");
-  const [extraItems, setExtraItems] = useState<Content[]>([]);
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const {
+    isSearching,
+    isDescendantSearch,
+    searchContents,
+    isSearchPending,
+    isSearchFailed,
+    searchErrorMessage,
+    isSearchEmpty,
+    hasNextPage,
+    isFetchingNextPage,
+    loadMore,
+  } = useDriveDescendantSearch(effectiveId);
 
   const query = useQuery({
     queryKey: ["drive", "drive", effectiveId],
@@ -80,58 +87,7 @@ function RouteComponent() {
     },
   });
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <>
-  useEffect(() => {
-    if (searchInDirQuery) {
-      setSearchInDirQuery("");
-    }
-    setDebouncedQ("");
-  }, [effectiveId]);
-
-  useEffect(() => {
-    const timeout = window.setTimeout(() => {
-      setDebouncedQ(searchInDirQuery.trim());
-    }, 300);
-
-    return () => clearTimeout(timeout);
-  }, [searchInDirQuery]);
-
   const isSubdirSearchMode = includeSubdirs && effectiveId !== "share";
-  const trimmedQuery = searchInDirQuery.trim();
-  const isSearching = isSubdirSearchMode && trimmedQuery.length >= 2;
-  const isDescendantSearch = isSearching && debouncedQ.length >= 2;
-
-  const searchQuery = useQuery({
-    queryKey: ["drive", "search", effectiveId, debouncedQ],
-    enabled: isDescendantSearch,
-    staleTime: 30_000,
-    refetchOnWindowFocus: false,
-    queryFn: async () => {
-      try {
-        return await window.api.invoke("drive:get:search", effectiveId, {
-          q: debouncedQ,
-          limit: 50,
-        });
-      } catch (error) {
-        if (isDriveSearchUnavailable(error)) {
-          toast.error(t("page.drive.head_buttons.search_unavailable"));
-          throw new Error("search_unavailable");
-        }
-        throw error;
-      }
-    },
-  });
-
-  useEffect(() => {
-    setExtraItems([]);
-    setNextCursor(null);
-    setIsLoadingMore(false);
-  }, [effectiveId, debouncedQ]);
-
-  useEffect(() => {
-    setExtraItems([]);
-    setNextCursor(searchQuery.data?.nextCursor ?? null);
-  }, [searchQuery.data]);
 
   useEffect(() => {
     if (effectiveId && location.pathname.startsWith("/drive/drive/")) {
@@ -171,46 +127,7 @@ function RouteComponent() {
     ).map((scoredItem) => scoredItem.item);
   }, [rawContents, searchInDirQuery, isSubdirSearchMode]);
 
-  const searchContents = useMemo(() => {
-    if (!searchQuery.data) return extraItems;
-    return [...searchQuery.data.items, ...extraItems];
-  }, [searchQuery.data, extraItems]);
-
   const displayContents = isDescendantSearch ? searchContents : isSearching ? [] : localContents;
-  const isSearchPending =
-    isSearching && (!isDescendantSearch || (searchQuery.isFetching && searchContents.length === 0));
-  const isSearchFailed = isDescendantSearch && searchQuery.isError;
-  const isSearchEmpty =
-    isDescendantSearch &&
-    searchQuery.isFetched &&
-    !searchQuery.isError &&
-    searchContents.length === 0;
-
-  async function loadMore() {
-    if (!nextCursor || isLoadingMore) return;
-
-    const identity = `${effectiveId}:${debouncedQ}`;
-    setIsLoadingMore(true);
-    try {
-      const data = await window.api.invoke("drive:get:search", effectiveId, {
-        q: debouncedQ,
-        limit: 50,
-        cursor: nextCursor,
-      });
-
-      if (identity !== `${effectiveId}:${debouncedQ}`) return;
-
-      setExtraItems((prev) => [...prev, ...data.items]);
-      setNextCursor(data.nextCursor);
-    } catch {
-      if (identity !== `${effectiveId}:${debouncedQ}`) return;
-      toast.error(t("page.drive.head_buttons.search_unavailable"));
-    } finally {
-      if (identity === `${effectiveId}:${debouncedQ}`) {
-        setIsLoadingMore(false);
-      }
-    }
-  }
 
   const handleDrop = async (e: React.DragEvent<HTMLDivElement>) => {
     try {
@@ -292,11 +209,11 @@ function RouteComponent() {
                         />
                       ) : null}
 
-                      {isDescendantSearch && nextCursor && (
+                      {isDescendantSearch && hasNextPage && (
                         <div className="flex justify-center p-4">
                           <Button
                             variant="outline"
-                            disabled={isLoadingMore}
+                            disabled={isFetchingNextPage}
                             onClick={() => {
                               void loadMore();
                             }}
@@ -309,9 +226,7 @@ function RouteComponent() {
                   </ScrollArea>
                 ) : isSearchFailed ? (
                   <Center className="flex-col">
-                    <p className="text-center text-lg">
-                      {t("page.drive.head_buttons.search_unavailable")}
-                    </p>
+                    <p className="text-center text-lg">{searchErrorMessage}</p>
                   </Center>
                 ) : isSearchEmpty ? (
                   <Center className="flex-col">

--- a/src/renderer/src/routes/drive/share.$id.tsx
+++ b/src/renderer/src/routes/drive/share.$id.tsx
@@ -16,20 +16,22 @@ import {
 import { Center, ServerCrash } from "@renderer/components/common";
 import { ContextMenuProvider } from "@renderer/components/drive/context-menu";
 import { AliceLoader } from "@renderer/components/loaders";
+import { Button } from "@renderer/components/ui/button";
 import { ScrollArea } from "@renderer/components/ui/scroll-area";
 import { useDrag } from "@renderer/hooks/drive";
 import { useDriveUploadRefresh } from "@renderer/hooks/use-drive-upload-refresh";
 import { useDriveNameSortPolicy } from "@renderer/hooks/use-settings";
 import { getSearchScore } from "@renderer/lib/sejong";
-import { commonSort } from "@renderer/lib/utils";
+import { commonSort, isDriveSearchUnavailable } from "@renderer/lib/utils";
 import { useViewStore, viewStore } from "@renderer/store/drive";
+import type { Content } from "@shared/types";
 import { toErrorMessage } from "@shared/utils";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, useLocation } from "@tanstack/react-router";
 import { disassemble, getChoseong } from "es-hangul";
 import { orderBy } from "es-toolkit";
 import { FolderIcon, Share2Icon } from "lucide-react";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -46,11 +48,17 @@ function RouteComponent() {
   const { onDragEnter, onDragLeave, onDragOver, onDrop } = useDrag();
   const searchInDirQuery = useViewStore((s) => s.searchInDirQuery);
   const setSearchInDirQuery = useViewStore((s) => s.setSearchInDirQuery);
+  const includeSubdirs = useViewStore((s) => s.includeSubdirs);
   const sortType = useViewStore((s) => s.sortType);
   const layout = useViewStore((s) => s.layout);
   const { data: nameSortPolicy = "natural_ignore_spacing" } = useDriveNameSortPolicy();
 
   useDriveUploadRefresh(effectiveId, ["drive", "share", effectiveId]);
+
+  const [debouncedQ, setDebouncedQ] = useState("");
+  const [extraItems, setExtraItems] = useState<Content[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
 
   const query = useQuery({
     queryKey: ["drive", "share", effectiveId],
@@ -74,7 +82,53 @@ function RouteComponent() {
     if (searchInDirQuery) {
       setSearchInDirQuery("");
     }
+    setDebouncedQ("");
   }, [effectiveId]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedQ(searchInDirQuery.trim());
+    }, 300);
+
+    return () => clearTimeout(timeout);
+  }, [searchInDirQuery]);
+
+  const isSubdirSearchMode = includeSubdirs && effectiveId !== "share";
+  const trimmedQuery = searchInDirQuery.trim();
+  const isSearching = isSubdirSearchMode && trimmedQuery.length >= 2;
+  const isDescendantSearch = isSearching && debouncedQ.length >= 2;
+
+  const searchQuery = useQuery({
+    queryKey: ["drive", "search", effectiveId, debouncedQ],
+    enabled: isDescendantSearch,
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      try {
+        return await window.api.invoke("drive:get:search", effectiveId, {
+          q: debouncedQ,
+          limit: 50,
+        });
+      } catch (error) {
+        if (isDriveSearchUnavailable(error)) {
+          toast.error(t("page.drive.head_buttons.search_unavailable"));
+          throw new Error("search_unavailable");
+        }
+        throw error;
+      }
+    },
+  });
+
+  useEffect(() => {
+    setExtraItems([]);
+    setNextCursor(null);
+    setIsLoadingMore(false);
+  }, [effectiveId, debouncedQ]);
+
+  useEffect(() => {
+    setExtraItems([]);
+    setNextCursor(searchQuery.data?.nextCursor ?? null);
+  }, [searchQuery.data]);
 
   useEffect(() => {
     if (effectiveId && location.pathname.startsWith("/drive/share/")) {
@@ -88,9 +142,9 @@ function RouteComponent() {
     return commonSort([...query.data.children], sortType, nameSortPolicy);
   }, [query.data?.children, sortType, nameSortPolicy]);
 
-  const sortedContents = useMemo(() => {
+  const localContents = useMemo(() => {
     if (!rawContents) return [];
-    if (!searchInDirQuery) return rawContents;
+    if (isSubdirSearchMode || !searchInDirQuery) return rawContents;
 
     const query = searchInDirQuery.toLowerCase();
 
@@ -112,7 +166,48 @@ function RouteComponent() {
       [(di) => di.score],
       ["desc"],
     ).map((scoredItem) => scoredItem.item);
-  }, [rawContents, searchInDirQuery]);
+  }, [rawContents, searchInDirQuery, isSubdirSearchMode]);
+
+  const searchContents = useMemo(() => {
+    if (!searchQuery.data) return extraItems;
+    return [...searchQuery.data.items, ...extraItems];
+  }, [searchQuery.data, extraItems]);
+
+  const displayContents = isDescendantSearch ? searchContents : isSearching ? [] : localContents;
+  const isSearchPending =
+    isSearching && (!isDescendantSearch || (searchQuery.isFetching && searchContents.length === 0));
+  const isSearchFailed = isDescendantSearch && searchQuery.isError;
+  const isSearchEmpty =
+    isDescendantSearch &&
+    searchQuery.isFetched &&
+    !searchQuery.isError &&
+    searchContents.length === 0;
+
+  async function loadMore() {
+    if (!nextCursor || isLoadingMore) return;
+
+    const identity = `${effectiveId}:${debouncedQ}`;
+    setIsLoadingMore(true);
+    try {
+      const data = await window.api.invoke("drive:get:search", effectiveId, {
+        q: debouncedQ,
+        limit: 50,
+        cursor: nextCursor,
+      });
+
+      if (identity !== `${effectiveId}:${debouncedQ}`) return;
+
+      setExtraItems((prev) => [...prev, ...data.items]);
+      setNextCursor(data.nextCursor);
+    } catch {
+      if (identity !== `${effectiveId}:${debouncedQ}`) return;
+      toast.error(t("page.drive.head_buttons.search_unavailable"));
+    } finally {
+      if (identity === `${effectiveId}:${debouncedQ}`) {
+        setIsLoadingMore(false);
+      }
+    }
+  }
 
   const handleDrop = async (e: React.DragEvent<HTMLDivElement>) => {
     try {
@@ -161,7 +256,7 @@ function RouteComponent() {
               <div className="flex-1"></div>
             )}
 
-            <AkashaHeadButtons />
+            <AkashaHeadButtons currentId={effectiveId} />
           </div>
 
           <div
@@ -174,26 +269,59 @@ function RouteComponent() {
             <ContextMenuProvider>
               <HandlerProvider
                 queryData={query}
-                sortedContents={sortedContents}
+                sortedContents={displayContents}
                 currentId={effectiveId}
               >
-                {sortedContents.length > 0 ? (
+                {displayContents.length > 0 ? (
                   <ScrollArea className="flex h-full flex-1 flex-col">
-                    {layout === "list" ? (
-                      <ContentMenuList
-                        sortedContents={sortedContents}
-                        isFetching={query.isFetching}
-                        itemId={effectiveId}
-                      />
-                    ) : layout === "grid" ? (
-                      <ContentMenuGrid
-                        sortedContents={sortedContents}
-                        isFetching={query.isFetching}
-                        itemId={effectiveId}
-                      />
-                    ) : null}
+                    <>
+                      {layout === "list" ? (
+                        <ContentMenuList
+                          sortedContents={displayContents}
+                          isFetching={query.isFetching}
+                          itemId={effectiveId}
+                        />
+                      ) : layout === "grid" ? (
+                        <ContentMenuGrid
+                          sortedContents={displayContents}
+                          isFetching={query.isFetching}
+                          itemId={effectiveId}
+                        />
+                      ) : null}
+
+                      {isDescendantSearch && nextCursor && (
+                        <div className="flex justify-center p-4">
+                          <Button
+                            variant="outline"
+                            disabled={isLoadingMore}
+                            onClick={() => {
+                              void loadMore();
+                            }}
+                          >
+                            {t("page.drive.head_buttons.search_load_more")}
+                          </Button>
+                        </div>
+                      )}
+                    </>
                   </ScrollArea>
-                ) : query.isFetched && sortedContents.length < 1 ? (
+                ) : isSearchFailed ? (
+                  <Center className="flex-col">
+                    <p className="text-center text-lg">
+                      {t("page.drive.head_buttons.search_unavailable")}
+                    </p>
+                  </Center>
+                ) : isSearchEmpty ? (
+                  <Center className="flex-col">
+                    <div>
+                      <FolderIcon size="80" />
+                    </div>
+                    <p className="mt-4 text-center text-lg">
+                      {t("page.drive.head_buttons.search_no_results")}
+                    </p>
+                  </Center>
+                ) : isSearchPending ? (
+                  <AkashaSkeleton />
+                ) : query.isFetched && displayContents.length < 1 ? (
                   effectiveId === "share" && rawContents.length === 0 ? (
                     <Center className="flex-col">
                       <div>
@@ -216,7 +344,7 @@ function RouteComponent() {
                       </p>
                     </Center>
                   )
-                ) : query.isFetching && sortedContents.length === 0 ? (
+                ) : query.isFetching && displayContents.length === 0 ? (
                   <AkashaSkeleton />
                 ) : null}
               </HandlerProvider>
@@ -227,7 +355,7 @@ function RouteComponent() {
         <RenameDialog />
         <DeleteItemsDialog />
         <ConflictNameDialog />
-        <NewDirectoryDialog contents={sortedContents} />
+        <NewDirectoryDialog contents={rawContents} />
         {/* <PubLinkDialog /> */}
       </>
     );

--- a/src/renderer/src/routes/drive/share.$id.tsx
+++ b/src/renderer/src/routes/drive/share.$id.tsx
@@ -19,19 +19,19 @@ import { AliceLoader } from "@renderer/components/loaders";
 import { Button } from "@renderer/components/ui/button";
 import { ScrollArea } from "@renderer/components/ui/scroll-area";
 import { useDrag } from "@renderer/hooks/drive";
+import { useDriveDescendantSearch } from "@renderer/hooks/use-drive-descendant-search";
 import { useDriveUploadRefresh } from "@renderer/hooks/use-drive-upload-refresh";
 import { useDriveNameSortPolicy } from "@renderer/hooks/use-settings";
 import { getSearchScore } from "@renderer/lib/sejong";
-import { commonSort, isDriveSearchUnavailable } from "@renderer/lib/utils";
+import { commonSort } from "@renderer/lib/utils";
 import { useViewStore, viewStore } from "@renderer/store/drive";
-import type { Content } from "@shared/types";
 import { toErrorMessage } from "@shared/utils";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, useLocation } from "@tanstack/react-router";
 import { disassemble, getChoseong } from "es-hangul";
 import { orderBy } from "es-toolkit";
 import { FolderIcon, Share2Icon } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -47,7 +47,6 @@ function RouteComponent() {
 
   const { onDragEnter, onDragLeave, onDragOver, onDrop } = useDrag();
   const searchInDirQuery = useViewStore((s) => s.searchInDirQuery);
-  const setSearchInDirQuery = useViewStore((s) => s.setSearchInDirQuery);
   const includeSubdirs = useViewStore((s) => s.includeSubdirs);
   const sortType = useViewStore((s) => s.sortType);
   const layout = useViewStore((s) => s.layout);
@@ -55,10 +54,18 @@ function RouteComponent() {
 
   useDriveUploadRefresh(effectiveId, ["drive", "share", effectiveId]);
 
-  const [debouncedQ, setDebouncedQ] = useState("");
-  const [extraItems, setExtraItems] = useState<Content[]>([]);
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const {
+    isSearching,
+    isDescendantSearch,
+    searchContents,
+    isSearchPending,
+    isSearchFailed,
+    searchErrorMessage,
+    isSearchEmpty,
+    hasNextPage,
+    isFetchingNextPage,
+    loadMore,
+  } = useDriveDescendantSearch(effectiveId);
 
   const query = useQuery({
     queryKey: ["drive", "share", effectiveId],
@@ -77,58 +84,7 @@ function RouteComponent() {
     },
   });
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <>
-  useEffect(() => {
-    if (searchInDirQuery) {
-      setSearchInDirQuery("");
-    }
-    setDebouncedQ("");
-  }, [effectiveId]);
-
-  useEffect(() => {
-    const timeout = window.setTimeout(() => {
-      setDebouncedQ(searchInDirQuery.trim());
-    }, 300);
-
-    return () => clearTimeout(timeout);
-  }, [searchInDirQuery]);
-
   const isSubdirSearchMode = includeSubdirs && effectiveId !== "share";
-  const trimmedQuery = searchInDirQuery.trim();
-  const isSearching = isSubdirSearchMode && trimmedQuery.length >= 2;
-  const isDescendantSearch = isSearching && debouncedQ.length >= 2;
-
-  const searchQuery = useQuery({
-    queryKey: ["drive", "search", effectiveId, debouncedQ],
-    enabled: isDescendantSearch,
-    staleTime: 30_000,
-    refetchOnWindowFocus: false,
-    queryFn: async () => {
-      try {
-        return await window.api.invoke("drive:get:search", effectiveId, {
-          q: debouncedQ,
-          limit: 50,
-        });
-      } catch (error) {
-        if (isDriveSearchUnavailable(error)) {
-          toast.error(t("page.drive.head_buttons.search_unavailable"));
-          throw new Error("search_unavailable");
-        }
-        throw error;
-      }
-    },
-  });
-
-  useEffect(() => {
-    setExtraItems([]);
-    setNextCursor(null);
-    setIsLoadingMore(false);
-  }, [effectiveId, debouncedQ]);
-
-  useEffect(() => {
-    setExtraItems([]);
-    setNextCursor(searchQuery.data?.nextCursor ?? null);
-  }, [searchQuery.data]);
 
   useEffect(() => {
     if (effectiveId && location.pathname.startsWith("/drive/share/")) {
@@ -168,46 +124,7 @@ function RouteComponent() {
     ).map((scoredItem) => scoredItem.item);
   }, [rawContents, searchInDirQuery, isSubdirSearchMode]);
 
-  const searchContents = useMemo(() => {
-    if (!searchQuery.data) return extraItems;
-    return [...searchQuery.data.items, ...extraItems];
-  }, [searchQuery.data, extraItems]);
-
   const displayContents = isDescendantSearch ? searchContents : isSearching ? [] : localContents;
-  const isSearchPending =
-    isSearching && (!isDescendantSearch || (searchQuery.isFetching && searchContents.length === 0));
-  const isSearchFailed = isDescendantSearch && searchQuery.isError;
-  const isSearchEmpty =
-    isDescendantSearch &&
-    searchQuery.isFetched &&
-    !searchQuery.isError &&
-    searchContents.length === 0;
-
-  async function loadMore() {
-    if (!nextCursor || isLoadingMore) return;
-
-    const identity = `${effectiveId}:${debouncedQ}`;
-    setIsLoadingMore(true);
-    try {
-      const data = await window.api.invoke("drive:get:search", effectiveId, {
-        q: debouncedQ,
-        limit: 50,
-        cursor: nextCursor,
-      });
-
-      if (identity !== `${effectiveId}:${debouncedQ}`) return;
-
-      setExtraItems((prev) => [...prev, ...data.items]);
-      setNextCursor(data.nextCursor);
-    } catch {
-      if (identity !== `${effectiveId}:${debouncedQ}`) return;
-      toast.error(t("page.drive.head_buttons.search_unavailable"));
-    } finally {
-      if (identity === `${effectiveId}:${debouncedQ}`) {
-        setIsLoadingMore(false);
-      }
-    }
-  }
 
   const handleDrop = async (e: React.DragEvent<HTMLDivElement>) => {
     try {
@@ -289,11 +206,11 @@ function RouteComponent() {
                         />
                       ) : null}
 
-                      {isDescendantSearch && nextCursor && (
+                      {isDescendantSearch && hasNextPage && (
                         <div className="flex justify-center p-4">
                           <Button
                             variant="outline"
-                            disabled={isLoadingMore}
+                            disabled={isFetchingNextPage}
                             onClick={() => {
                               void loadMore();
                             }}
@@ -306,9 +223,7 @@ function RouteComponent() {
                   </ScrollArea>
                 ) : isSearchFailed ? (
                   <Center className="flex-col">
-                    <p className="text-center text-lg">
-                      {t("page.drive.head_buttons.search_unavailable")}
-                    </p>
+                    <p className="text-center text-lg">{searchErrorMessage}</p>
                   </Center>
                 ) : isSearchEmpty ? (
                   <Center className="flex-col">

--- a/src/renderer/src/store/drive.ts
+++ b/src/renderer/src/store/drive.ts
@@ -16,6 +16,8 @@ interface ViewState {
     ) => void;
     searchInDirQuery: string;
     setSearchInDirQuery: (query: string) => void;
+    includeSubdirs: boolean;
+    setIncludeSubdirs: (includeSubdirs: boolean) => void;
     isfocusSearchInput: boolean;
     setFocusSearchInputState: (state: boolean) => void;
     lastDriveId: string;
@@ -37,6 +39,8 @@ export const viewStore = createStore<ViewState>((set) => ({
     setSortType: (sortType) => set({ sortType }),
     searchInDirQuery: "",
     setSearchInDirQuery: (searchInDirQuery) => set({ searchInDirQuery }),
+    includeSubdirs: false,
+    setIncludeSubdirs: (includeSubdirs) => set({ includeSubdirs }),
     isfocusSearchInput: false,
     setFocusSearchInputState: (isfocusSearchInput) => set({ isfocusSearchInput }),
     lastDriveId: "",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Descendant search depends on external Akasha/OpenSearch availability and new IPC paths; conflict finder shares the global bisect session with the tools page, so concurrent sessions could confuse users.
> 
> **Overview**
> Bumps the desktop app to **2.59.0** and ships two user-facing capabilities plus shared UI cleanup.
> 
> **Drive search in subfolders** adds backend `drive:get:search` (Akasha content search API), an `includeSubdirs` toggle on the drive header (not on share roots), and `useDriveDescendantSearch` with debounced queries, infinite scroll, empty/error/pending states, and `isDriveSearchUnavailable` handling when search backends are down. Personal and shared drive routes switch between local folder filtering and server descendant results; clipboard move/copy now invalidates `["drive", "search"]` so results stay fresh.
> 
> **Find Conflict Mode** exposes mod bisect from mod card and context menus (card dropdown skips NTE games; context menu entry is present in the diff for all—worth noting). A new dialog starts bisect with the selected mod’s path passed as an exclude list so it stays enabled while hunting conflicting INIs, reusing shared `BisectStatusCards` extracted from the tools mod-bisect page.
> 
> Locales (en/ja/ko/zh) cover search strings and conflict-finder copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d673282c57b5a590c19f1f28dc265b1efd5feb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Search folders and shared drives, including optional subdirectories, pagination, and clear loading or unavailable states.
  - Added a mod conflict finder with guided testing.
  - Added conflict-finder actions to supported mod menus.

- **Bug Fixes**
  - Drive search results now refresh after copy, cut, and move operations.
  - Improved handling of unavailable search services and changing search states.

- **Localization**
  - Added translations for search and conflict-finder features in English, Japanese, Korean, and Simplified Chinese.

- **Release**
  - Updated the application version to 2.59.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->