### PR TITLE
fix: harden Eden session handling and correct conflict-finder copy

### DIFF
--- a/src/main/client.ts
+++ b/src/main/client.ts
@@ -6,12 +6,7 @@ import { BACKEND_URL } from "@shared/const";
 import { isEmpty } from "es-toolkit/compat";
 
 import { desktop } from "./index";
-import {
-    decodeCborBody,
-    isCborContentType,
-    jsonResponseFrom,
-    readApiBody,
-} from "./lib/cbor-response";
+import { isCborContentType, jsonResponseFromBody } from "./lib/cbor-response";
 
 export const eden = treaty<App>(BACKEND_URL, {
     fetcher: (async (input: URL | RequestInfo, init: RequestInit | undefined) => {
@@ -25,10 +20,7 @@ export const eden = treaty<App>(BACKEND_URL, {
         const contentType = response.headers.get("Content-Type");
         if (isCborContentType(contentType)) {
             try {
-                return rewriteEdenBody(
-                    response,
-                    decodeCborBody(new Uint8Array(await response.arrayBuffer())),
-                );
+                return await jsonResponseFromBody(response, unminifyIfNeeded);
             } catch (error) {
                 desktop.logger.error(error, "EdenCborDecodeFailed");
                 const retryUrl = new URL(url);
@@ -42,16 +34,17 @@ export const eden = treaty<App>(BACKEND_URL, {
         }
 
         try {
-            return rewriteEdenBody(response, await readApiBody(response));
-        } catch {
-            return response;
+            return await jsonResponseFromBody(response, unminifyIfNeeded);
+        } catch (error) {
+            desktop.logger.error(error, "EdenBodyRewriteFailed");
+            throw error;
         }
     }) as typeof fetch,
     parseDate: false,
 });
 
-function rewriteEdenBody(response: Response, data: unknown) {
-    return jsonResponseFrom(response, isMinified(data) ? unminify(data) : data);
+function unminifyIfNeeded(data: unknown) {
+    return isMinified(data) ? unminify(data) : data;
 }
 
 export type Eden = typeof eden;

--- a/src/main/internal/http.test.ts
+++ b/src/main/internal/http.test.ts
@@ -47,6 +47,26 @@ describe("DesktopHttpService", () => {
         );
     });
 
+    it("does not replace an Authorization header provided as a tuple array", async () => {
+        mocks.ky.mockResolvedValue(new Response("ok"));
+        const { service, getToken } = createService();
+
+        await service.fetcher("https://api.nahida.live/api/auth/get-session", {
+            headers: [["Authorization", "Bearer pinned-token"]],
+        });
+
+        expect(getToken).not.toHaveBeenCalled();
+        expect(mocks.ky).toHaveBeenCalledWith(
+            "https://api.nahida.live/api/auth/get-session",
+            expect.objectContaining({
+                headers: {
+                    Authorization: "Bearer pinned-token",
+                    "User-Agent": "Nahida Desktop/test-version",
+                },
+            }),
+        );
+    });
+
     it("resolves Authorization from the current token when the caller does not provide one", async () => {
         mocks.ky.mockResolvedValue(new Response("ok"));
         const { service, getToken } = createService();

--- a/src/main/internal/http.test.ts
+++ b/src/main/internal/http.test.ts
@@ -1,0 +1,67 @@
+import type { NahidaDesktop } from "@main/index";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    ky: vi.fn(),
+}));
+
+vi.mock("ky", () => ({
+    default: mocks.ky,
+    isNetworkError: () => false,
+    isTimeoutError: () => false,
+}));
+
+vi.mock("electron", () => ({ app: { getVersion: () => "test-version" } }));
+
+import { DesktopHttpService } from "./http";
+
+function createService(getToken = vi.fn(async () => "stored-token")) {
+    const desktop = {
+        service: {
+            auth: { getToken, getSession: vi.fn() },
+            backendConnectivity: { setOffline: vi.fn(), setOnline: vi.fn() },
+        },
+        logger: { warn: vi.fn(), error: vi.fn() },
+    } as unknown as NahidaDesktop;
+    return { service: new DesktopHttpService(desktop), getToken };
+}
+
+describe("DesktopHttpService", () => {
+    it("does not replace an Authorization header already provided by the caller", async () => {
+        mocks.ky.mockResolvedValue(new Response("ok"));
+        const { service, getToken } = createService();
+
+        await service.fetcher("https://api.nahida.live/api/auth/get-session", {
+            headers: { Authorization: "Bearer pinned-token" },
+        });
+
+        expect(getToken).not.toHaveBeenCalled();
+        expect(mocks.ky).toHaveBeenCalledWith(
+            "https://api.nahida.live/api/auth/get-session",
+            expect.objectContaining({
+                headers: {
+                    Authorization: "Bearer pinned-token",
+                    "User-Agent": "Nahida Desktop/test-version",
+                },
+            }),
+        );
+    });
+
+    it("resolves Authorization from the current token when the caller does not provide one", async () => {
+        mocks.ky.mockResolvedValue(new Response("ok"));
+        const { service, getToken } = createService();
+
+        await service.fetcher("https://api.nahida.live/api/drive");
+
+        expect(getToken).toHaveBeenCalledOnce();
+        expect(mocks.ky).toHaveBeenCalledWith(
+            "https://api.nahida.live/api/drive",
+            expect.objectContaining({
+                headers: {
+                    Authorization: "Bearer stored-token",
+                    "User-Agent": "Nahida Desktop/test-version",
+                },
+            }),
+        );
+    });
+});

--- a/src/main/internal/http.ts
+++ b/src/main/internal/http.ts
@@ -36,7 +36,9 @@ export class DesktopHttpService {
         const optionHeaders =
             options?.headers instanceof Headers
                 ? Object.fromEntries(options.headers.entries())
-                : ((options?.headers as Record<string, string> | undefined) ?? {});
+                : Array.isArray(options?.headers)
+                  ? Object.fromEntries(options.headers)
+                  : ((options?.headers as Record<string, string> | undefined) ?? {});
         const hasAuthorization = Object.keys(optionHeaders).some(
             (key) => key.toLowerCase() === "authorization",
         );

--- a/src/main/internal/http.ts
+++ b/src/main/internal/http.ts
@@ -33,12 +33,17 @@ export class DesktopHttpService {
     public async fetcher(url: string, options?: FetcherOptions) {
         const isNHD = this.isNHD(url);
         const isSessionRequest = URL.parse(url)?.pathname === "/api/auth/get-session";
-        const headers = {
-            ...(options?.headers instanceof Headers
+        const optionHeaders =
+            options?.headers instanceof Headers
                 ? Object.fromEntries(options.headers.entries())
-                : (options?.headers as Record<string, string> | undefined)),
-            ...(await this.getHeaders(url)),
-        };
+                : ((options?.headers as Record<string, string> | undefined) ?? {});
+        const hasAuthorization = Object.keys(optionHeaders).some(
+            (key) => key.toLowerCase() === "authorization",
+        );
+        // Keep a caller-supplied Authorization instead of resolving a newer token mid-request.
+        const headers = hasAuthorization
+            ? { ...optionHeaders, "User-Agent": `Nahida Desktop/${appVersion}` }
+            : { ...optionHeaders, ...(await this.getHeaders(url)) };
 
         try {
             const resp = await ky(url, {

--- a/src/main/lib/cbor-response.test.ts
+++ b/src/main/lib/cbor-response.test.ts
@@ -1,0 +1,98 @@
+import { isMinified, minify, unminify } from "@backend/utils/jsonMinify";
+import { Encoder } from "cbor-x";
+import { describe, expect, it } from "vitest";
+
+import { jsonResponseFromBody, readApiBody } from "./cbor-response";
+
+const encoder = new Encoder({ useRecords: false, mapsAsObjects: true });
+
+function jsonResponse(body: unknown) {
+    return new Response(JSON.stringify(body), {
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+function cborResponse(body: Uint8Array) {
+    const bytes = new Uint8Array(body.byteLength);
+    bytes.set(body);
+    return new Response(bytes.buffer, {
+        headers: { "Content-Type": "application/cbor" },
+    });
+}
+
+function unminifyIfNeeded(data: unknown) {
+    return isMinified(data) ? unminify(data) : data;
+}
+
+describe("jsonResponseFromBody", () => {
+    it("returns a fresh JSON body after the original response is consumed", async () => {
+        const response = jsonResponse({ ok: true });
+        const rewritten = await jsonResponseFromBody(response);
+
+        expect(response.bodyUsed).toBe(true);
+        expect(await rewritten.json()).toEqual({ ok: true });
+        expect(rewritten.headers.get("Content-Type")).toContain("application/json");
+    });
+
+    it("unminifies mapped JSON without leaving the original body locked", async () => {
+        const payload = { role: "member", name: "member" };
+        const response = jsonResponse(minify(payload));
+        const rewritten = await jsonResponseFromBody(response, unminifyIfNeeded);
+
+        expect(response.bodyUsed).toBe(true);
+        expect(await rewritten.json()).toEqual(payload);
+    });
+
+    it("falls back to the already-read payload when mapping throws", async () => {
+        const response = jsonResponse({ ok: true });
+        const rewritten = await jsonResponseFromBody(response, () => {
+            throw new Error("unminify failed");
+        });
+
+        expect(response.bodyUsed).toBe(true);
+        expect(await rewritten.json()).toEqual({ ok: true });
+    });
+
+    it("throws a decode error instead of returning the consumed CBOR response", async () => {
+        const response = cborResponse(new Uint8Array([255, 255]));
+
+        await expect(jsonResponseFromBody(response)).rejects.toThrow();
+        expect(response.bodyUsed).toBe(true);
+        await expect(response.arrayBuffer()).rejects.toThrow();
+    });
+
+    it("rewrites a successful CBOR body into readable JSON", async () => {
+        const response = cborResponse(encoder.encode({ ok: true }));
+        const rewritten = await jsonResponseFromBody(response);
+
+        expect(response.bodyUsed).toBe(true);
+        expect(await rewritten.json()).toEqual({ ok: true });
+    });
+
+    it("falls back to the already-read payload when mapped data cannot be serialized", async () => {
+        const response = jsonResponse({ ok: true });
+        const rewritten = await jsonResponseFromBody(response, () => ({ ok: 1n }));
+
+        expect(response.bodyUsed).toBe(true);
+        expect(await rewritten.json()).toEqual({ ok: true });
+    });
+
+    it("throws when the already-read payload cannot be serialized instead of returning a locked body", async () => {
+        const response = cborResponse(encoder.encode({ ok: 2n ** 80n }));
+
+        await expect(jsonResponseFromBody(response)).rejects.toThrow();
+        expect(response.bodyUsed).toBe(true);
+        await expect(response.arrayBuffer()).rejects.toThrow();
+    });
+});
+
+describe("readApiBody", () => {
+    it("consumes the original response before returning parsed JSON", async () => {
+        const response = jsonResponse({ ok: true });
+        const data = await readApiBody(response);
+
+        expect(response.bodyUsed).toBe(true);
+        expect(data).toEqual({ ok: true });
+        await expect(response.text()).rejects.toThrow();
+    });
+});

--- a/src/main/lib/cbor-response.test.ts
+++ b/src/main/lib/cbor-response.test.ts
@@ -43,14 +43,15 @@ describe("jsonResponseFromBody", () => {
         expect(await rewritten.json()).toEqual(payload);
     });
 
-    it("falls back to the already-read payload when mapping throws", async () => {
-        const response = jsonResponse({ ok: true });
-        const rewritten = await jsonResponseFromBody(response, () => {
-            throw new Error("unminify failed");
-        });
+    it("propagates mapping errors so CBOR callers can retry as JSON", async () => {
+        const response = cborResponse(encoder.encode({ ok: true }));
 
+        await expect(
+            jsonResponseFromBody(response, () => {
+                throw new Error("unminify failed");
+            }),
+        ).rejects.toThrow("unminify failed");
         expect(response.bodyUsed).toBe(true);
-        expect(await rewritten.json()).toEqual({ ok: true });
     });
 
     it("throws a decode error instead of returning the consumed CBOR response", async () => {

--- a/src/main/lib/cbor-response.ts
+++ b/src/main/lib/cbor-response.ts
@@ -40,8 +40,9 @@ export async function jsonResponseFromBody(
     mapData?: (data: unknown) => unknown,
 ) {
     const data = await readApiBody(response);
+    const mapped = mapData ? mapData(data) : data;
     try {
-        return jsonResponseFrom(response, mapData ? mapData(data) : data);
+        return jsonResponseFrom(response, mapped);
     } catch {
         return jsonResponseFrom(response, data);
     }

--- a/src/main/lib/cbor-response.ts
+++ b/src/main/lib/cbor-response.ts
@@ -35,6 +35,18 @@ export async function readApiBody(response: Response) {
     }
 }
 
+export async function jsonResponseFromBody(
+    response: Response,
+    mapData?: (data: unknown) => unknown,
+) {
+    const data = await readApiBody(response);
+    try {
+        return jsonResponseFrom(response, mapData ? mapData(data) : data);
+    } catch {
+        return jsonResponseFrom(response, data);
+    }
+}
+
 function parseDecodedHttpResult(status: number, value: unknown) {
     if (typeof value === "string") return { status, reason: value };
     if (value && typeof value === "object") {

--- a/src/main/services/auth.test.ts
+++ b/src/main/services/auth.test.ts
@@ -147,6 +147,119 @@ describe("Auth token concurrency", () => {
         expect(broadcast).not.toHaveBeenCalled();
     });
 
+    it("does not drop a session when a token is saved after getToken but before the request finishes", async () => {
+        let storedToken: string | null = "old-token";
+        let auth!: Auth;
+        const fetchStarted = deferred();
+        const allowFetch = deferred();
+        const fetcher = vi.fn(
+            async (_url: string, options?: { headers?: Record<string, string> }) => {
+                fetchStarted.resolve();
+                await allowFetch.promise;
+                const requestToken = options?.headers?.Authorization?.replace(/^Bearer /, "");
+                return sessionResponse(requestToken ?? "missing-token");
+            },
+        );
+        const desktop = {
+            lib: {
+                crypto: {
+                    encryptString: (value: string) => value,
+                    decryptString: (value: string) => value,
+                },
+                db: {
+                    settings: {
+                        getValue: vi.fn(async () => storedToken),
+                        upsert: vi.fn(async (_key: string, value: string) => {
+                            storedToken = value;
+                        }),
+                        updateValue: vi.fn(async (_key: string, value: null) => {
+                            storedToken = value;
+                        }),
+                    },
+                },
+            },
+            httpService: { fetcher },
+            ipc: { broadcast: vi.fn() },
+            logger: { error: vi.fn() },
+        } as unknown as NahidaDesktop;
+        auth = new Auth(desktop);
+
+        const sessionPromise = auth.getSession();
+        await fetchStarted.promise;
+        await auth.saveToken("new-token");
+        allowFetch.resolve();
+
+        await expect(sessionPromise).resolves.toMatchObject({
+            session: { token: "new-token" },
+        });
+        expect(storedToken).toBe("new-token");
+        expect(desktop.lib.db.settings.updateValue).not.toHaveBeenCalled();
+        expect(fetcher).toHaveBeenCalledTimes(2);
+        expect(fetcher).toHaveBeenNthCalledWith(
+            1,
+            expect.stringContaining("/api/auth/get-session"),
+            expect.objectContaining({ headers: { Authorization: "Bearer old-token" } }),
+        );
+        expect(fetcher).toHaveBeenNthCalledWith(
+            2,
+            expect.stringContaining("/api/auth/get-session"),
+            expect.objectContaining({ headers: { Authorization: "Bearer new-token" } }),
+        );
+    });
+
+    it("does not drop a session when a token is saved while getToken is waiting", async () => {
+        let storedToken: string | null = "old-token";
+        const readStarted = deferred();
+        const allowRead = deferred();
+        let blockNextRead = true;
+        const fetcher = vi.fn(
+            async (_url: string, options?: { headers?: Record<string, string> }) => {
+                const requestToken = options?.headers?.Authorization?.replace(/^Bearer /, "");
+                return sessionResponse(requestToken ?? "missing-token");
+            },
+        );
+        const settings = {
+            getValue: vi.fn(async () => {
+                if (blockNextRead) {
+                    blockNextRead = false;
+                    readStarted.resolve();
+                    await allowRead.promise;
+                }
+                return storedToken;
+            }),
+            upsert: vi.fn(async (_key: string, value: string) => {
+                storedToken = value;
+            }),
+            updateValue: vi.fn(async (_key: string, value: null) => {
+                storedToken = value;
+            }),
+        };
+        const desktop = {
+            lib: {
+                crypto: {
+                    encryptString: (value: string) => value,
+                    decryptString: (value: string) => value,
+                },
+                db: { settings },
+            },
+            httpService: { fetcher },
+            ipc: { broadcast: vi.fn() },
+            logger: { error: vi.fn() },
+        } as unknown as NahidaDesktop;
+        const auth = new Auth(desktop);
+
+        const sessionPromise = auth.getSession();
+        await readStarted.promise;
+        await auth.saveToken("new-token");
+        allowRead.resolve();
+
+        await expect(sessionPromise).resolves.toMatchObject({
+            session: { token: "new-token" },
+        });
+        expect(storedToken).toBe("new-token");
+        expect(settings.updateValue).not.toHaveBeenCalled();
+    });
+
     it("deduplicates concurrent getSession calls started before the first fetch resolves", async () => {
         const storedToken = "session-token";
         const allowFetch = deferred();

--- a/src/main/services/auth.test.ts
+++ b/src/main/services/auth.test.ts
@@ -300,4 +300,118 @@ describe("Auth token concurrency", () => {
         expect(await firstSession).toBe(await secondSession);
         expect(fetcher).toHaveBeenCalledOnce();
     });
+
+    it("does not return null when a token is saved while 401 logout is in flight", async () => {
+        let storedToken: string | null = "old-token";
+        let tokenReads = 0;
+        const logoutReadStarted = deferred();
+        const allowLogoutRead = deferred();
+        const fetcher = vi.fn(
+            async (_url: string, options?: { headers?: Record<string, string> }) => {
+                const requestToken = options?.headers?.Authorization?.replace(/^Bearer /, "");
+                if (requestToken === "old-token") {
+                    return new Response(null, { status: 401 });
+                }
+                return sessionResponse(requestToken ?? "missing-token");
+            },
+        );
+        const settings = {
+            getValue: vi.fn(async () => {
+                tokenReads++;
+                if (tokenReads === 2) {
+                    logoutReadStarted.resolve();
+                    await allowLogoutRead.promise;
+                }
+                return storedToken;
+            }),
+            upsert: vi.fn(async (_key: string, value: string) => {
+                storedToken = value;
+            }),
+            updateValue: vi.fn(async (_key: string, value: null) => {
+                storedToken = value;
+            }),
+        };
+        const desktop = {
+            lib: {
+                crypto: {
+                    encryptString: (value: string) => value,
+                    decryptString: (value: string) => value,
+                },
+                db: { settings },
+            },
+            httpService: { fetcher },
+            ipc: { broadcast: vi.fn() },
+            logger: { error: vi.fn() },
+        } as unknown as NahidaDesktop;
+        const auth = new Auth(desktop);
+
+        const sessionPromise = auth.getSession();
+        await logoutReadStarted.promise;
+        await auth.saveToken("new-token");
+        allowLogoutRead.resolve();
+
+        await expect(sessionPromise).resolves.toMatchObject({
+            session: { token: "new-token" },
+        });
+        expect(storedToken).toBe("new-token");
+        expect(settings.updateValue).not.toHaveBeenCalled();
+        expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not return null when a token is saved while a "null" session logout is in flight', async () => {
+        let storedToken: string | null = "old-token";
+        let tokenReads = 0;
+        const logoutReadStarted = deferred();
+        const allowLogoutRead = deferred();
+        const fetcher = vi.fn(
+            async (_url: string, options?: { headers?: Record<string, string> }) => {
+                const requestToken = options?.headers?.Authorization?.replace(/^Bearer /, "");
+                if (requestToken === "old-token") {
+                    return new Response("null", { status: 200 });
+                }
+                return sessionResponse(requestToken ?? "missing-token");
+            },
+        );
+        const settings = {
+            getValue: vi.fn(async () => {
+                tokenReads++;
+                if (tokenReads === 2) {
+                    logoutReadStarted.resolve();
+                    await allowLogoutRead.promise;
+                }
+                return storedToken;
+            }),
+            upsert: vi.fn(async (_key: string, value: string) => {
+                storedToken = value;
+            }),
+            updateValue: vi.fn(async (_key: string, value: null) => {
+                storedToken = value;
+            }),
+        };
+        const desktop = {
+            lib: {
+                crypto: {
+                    encryptString: (value: string) => value,
+                    decryptString: (value: string) => value,
+                },
+                db: { settings },
+            },
+            httpService: { fetcher },
+            ipc: { broadcast: vi.fn() },
+            logger: { error: vi.fn() },
+        } as unknown as NahidaDesktop;
+        const auth = new Auth(desktop);
+
+        const sessionPromise = auth.getSession();
+        await logoutReadStarted.promise;
+        await auth.saveToken("new-token");
+        allowLogoutRead.resolve();
+
+        await expect(sessionPromise).resolves.toMatchObject({
+            session: { token: "new-token" },
+        });
+        expect(storedToken).toBe("new-token");
+        expect(settings.updateValue).not.toHaveBeenCalled();
+        expect(fetcher).toHaveBeenCalledTimes(2);
+    });
 });

--- a/src/main/services/auth.test.ts
+++ b/src/main/services/auth.test.ts
@@ -146,4 +146,45 @@ describe("Auth token concurrency", () => {
         expect(settings.updateValue).not.toHaveBeenCalled();
         expect(broadcast).not.toHaveBeenCalled();
     });
+
+    it("deduplicates concurrent getSession calls started before the first fetch resolves", async () => {
+        const storedToken = "session-token";
+        const allowFetch = deferred();
+        const fetcher = vi.fn(async () => {
+            await allowFetch.promise;
+            return sessionResponse(storedToken);
+        });
+        const desktop = {
+            lib: {
+                crypto: {
+                    encryptString: (value: string) => value,
+                    decryptString: (value: string) => value,
+                },
+                db: {
+                    settings: {
+                        getValue: vi.fn(async () => storedToken),
+                        upsert: vi.fn(),
+                        updateValue: vi.fn(),
+                    },
+                },
+            },
+            httpService: { fetcher },
+            ipc: { broadcast: vi.fn() },
+            logger: { error: vi.fn() },
+        } as unknown as NahidaDesktop;
+        const auth = new Auth(desktop);
+
+        const firstSession = auth.getSession();
+        const secondSession = auth.getSession();
+        allowFetch.resolve();
+
+        await expect(firstSession).resolves.toMatchObject({
+            session: { token: storedToken },
+        });
+        await expect(secondSession).resolves.toMatchObject({
+            session: { token: storedToken },
+        });
+        expect(await firstSession).toBe(await secondSession);
+        expect(fetcher).toHaveBeenCalledOnce();
+    });
 });

--- a/src/main/services/auth.test.ts
+++ b/src/main/services/auth.test.ts
@@ -1,0 +1,149 @@
+import type { NahidaDesktop } from "@main/index";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    ky: vi.fn(),
+    post: vi.fn(),
+}));
+
+vi.mock("ky", () => ({
+    default: Object.assign(mocks.ky, { post: mocks.post }),
+}));
+
+vi.mock("electron", () => ({ app: { getVersion: () => "test-version" } }));
+vi.mock("@main/windows/utils", () => ({ focus: vi.fn() }));
+vi.mock("./util", () => ({ openExternal: vi.fn() }));
+
+import { Auth } from "./auth";
+
+function deferred() {
+    let resolve!: () => void;
+    const promise = new Promise<void>((resolvePromise) => {
+        resolve = resolvePromise;
+    });
+    return { promise, resolve };
+}
+
+function sessionResponse(token: string) {
+    return new Response(
+        JSON.stringify({
+            session: {
+                id: "session-id",
+                userId: "user-id",
+                createdAt: "2026-01-01T00:00:00.000Z",
+                updatedAt: "2026-01-01T00:00:00.000Z",
+                expiresAt: "2027-01-01T00:00:00.000Z",
+                token,
+            },
+            user: {
+                id: "user-id",
+                name: "User",
+                email: "user@example.com",
+                role: "user",
+                image: null,
+            },
+            drive: { id: "drive-id", rootId: "root-id" },
+        }),
+    );
+}
+
+describe("Auth token concurrency", () => {
+    it("does not attribute an old-token 401 to a token being saved", async () => {
+        let storedToken: string | null = "old-token";
+        let auth!: Auth;
+        const allowSave = deferred();
+        const allowOldTokenResponse = deferred();
+        const settings = {
+            getValue: vi.fn(async () => storedToken),
+            upsert: vi.fn(async (_key: string, value: string) => {
+                await allowSave.promise;
+                storedToken = value;
+            }),
+            updateValue: vi.fn(async (_key: string, value: null) => {
+                storedToken = value;
+            }),
+        };
+        const desktop = {
+            lib: {
+                crypto: {
+                    encryptString: (value: string) => value,
+                    decryptString: (value: string) => value,
+                },
+                db: { settings },
+            },
+            httpService: {
+                fetcher: vi.fn(async () => {
+                    const requestToken = await auth.getToken();
+                    if (requestToken === "old-token") {
+                        await allowOldTokenResponse.promise;
+                        return new Response(null, { status: 401 });
+                    }
+                    return sessionResponse(requestToken ?? "missing-token");
+                }),
+            },
+            ipc: { broadcast: vi.fn() },
+            logger: { error: vi.fn() },
+        } as unknown as NahidaDesktop;
+        auth = new Auth(desktop);
+
+        const savePromise = auth.saveToken("new-token");
+        const sessionPromise = auth.getSession();
+        await Promise.resolve();
+        await Promise.resolve();
+        allowSave.resolve();
+        await savePromise;
+        allowOldTokenResponse.resolve();
+
+        await expect(sessionPromise).resolves.toMatchObject({
+            session: { token: "new-token" },
+        });
+        expect(storedToken).toBe("new-token");
+        expect(settings.updateValue).not.toHaveBeenCalled();
+    });
+
+    it("does not remove a token saved while guarded logout is reading it", async () => {
+        let storedToken: string | null = "old-token";
+        const readStarted = deferred();
+        const allowRead = deferred();
+        let blockNextRead = true;
+        const broadcast = vi.fn();
+        const settings = {
+            getValue: vi.fn(async () => {
+                if (blockNextRead) {
+                    blockNextRead = false;
+                    readStarted.resolve();
+                    await allowRead.promise;
+                }
+                return storedToken;
+            }),
+            upsert: vi.fn(async (_key: string, value: string) => {
+                storedToken = value;
+            }),
+            updateValue: vi.fn(async (_key: string, value: null) => {
+                storedToken = value;
+            }),
+        };
+        const desktop = {
+            lib: {
+                crypto: {
+                    encryptString: (value: string) => value,
+                    decryptString: (value: string) => value,
+                },
+                db: { settings },
+            },
+            ipc: { broadcast },
+            logger: { error: vi.fn() },
+        } as unknown as NahidaDesktop;
+        const auth = new Auth(desktop);
+
+        const logoutPromise = auth.startLogout(0);
+        await readStarted.promise;
+        await auth.saveToken("new-token");
+        allowRead.resolve();
+        await logoutPromise;
+
+        expect(storedToken).toBe("new-token");
+        expect(settings.updateValue).not.toHaveBeenCalled();
+        expect(broadcast).not.toHaveBeenCalled();
+    });
+});

--- a/src/main/services/auth.ts
+++ b/src/main/services/auth.ts
@@ -12,6 +12,7 @@ import { openExternal } from "./util";
 export class Auth {
     private desktop: NahidaDesktop;
     private sessionInFlight: Promise<Session | null> | null = null;
+    private tokenMutationInFlight = Promise.resolve();
     private tokenGeneration = 0;
 
     constructor(desktop: NahidaDesktop) {
@@ -27,13 +28,12 @@ export class Auth {
     }
 
     public async saveToken(key: string) {
-        this.sessionInFlight = null;
-        this.tokenGeneration++;
         const encryptedKey = this.desktop.lib.crypto.encryptString(key);
-        await this.desktop.lib.db.settings.upsert("token", encryptedKey);
+        await this.mutateToken(() => this.desktop.lib.db.settings.upsert("token", encryptedKey));
     }
 
     public async getToken() {
+        await this.tokenMutationInFlight;
         const key = await this.desktop.lib.db.settings.getValue("token");
         if (!key) {
             return null;
@@ -47,9 +47,18 @@ export class Auth {
     }
 
     public async removeToken() {
+        await this.mutateToken(() => this.desktop.lib.db.settings.updateValue("token", null));
+    }
+
+    private async mutateToken(mutation: () => Promise<unknown>) {
         this.sessionInFlight = null;
         this.tokenGeneration++;
-        await this.desktop.lib.db.settings.updateValue("token", null);
+        const queuedMutation = this.tokenMutationInFlight.then(mutation);
+        this.tokenMutationInFlight = queuedMutation.then(
+            () => undefined,
+            () => undefined,
+        );
+        await queuedMutation;
     }
 
     public async hasToken() {
@@ -73,6 +82,7 @@ export class Auth {
     private async fetchSession() {
         const capturedGeneration = this.tokenGeneration;
         const token = await this.getToken();
+        if (this.tokenGeneration !== capturedGeneration) return null;
         if (!token) return null;
 
         const url = `${BACKEND_URL}/api/auth/get-session`;
@@ -188,6 +198,9 @@ export class Auth {
         }
 
         const token = await this.getToken();
+        if (expectedGeneration !== undefined && this.tokenGeneration !== expectedGeneration) {
+            return;
+        }
         await this.removeToken();
         this.desktop.ipc.broadcast("auth:update", null);
 

--- a/src/main/services/auth.ts
+++ b/src/main/services/auth.ts
@@ -2,7 +2,7 @@ import { appVersion } from "@main/const";
 import type { NahidaDesktop } from "@main/index";
 import { focus } from "@main/windows/utils";
 import { BACKEND_URL } from "@shared/const";
-import { SessionSchema } from "@shared/schemas/auth";
+import { SessionSchema, type Session } from "@shared/schemas/auth";
 import ky from "ky";
 import { parseServerSentEvents } from "parse-sse";
 import { Nullable, validate } from "valdex";
@@ -11,6 +11,7 @@ import { openExternal } from "./util";
 
 export class Auth {
     private desktop: NahidaDesktop;
+    private sessionInFlight: Promise<Session | null> | null = null;
 
     constructor(desktop: NahidaDesktop) {
         this.desktop = desktop;
@@ -25,6 +26,7 @@ export class Auth {
     }
 
     public async saveToken(key: string) {
+        this.sessionInFlight = null;
         const encryptedKey = this.desktop.lib.crypto.encryptString(key);
         await this.desktop.lib.db.settings.upsert("token", encryptedKey);
     }
@@ -43,6 +45,7 @@ export class Auth {
     }
 
     public async removeToken() {
+        this.sessionInFlight = null;
         await this.desktop.lib.db.settings.updateValue("token", null);
     }
 
@@ -51,6 +54,20 @@ export class Auth {
     }
 
     public async getSession() {
+        if (this.sessionInFlight) return this.sessionInFlight;
+
+        const fetchPromise = this.fetchSession();
+        this.sessionInFlight = fetchPromise;
+        try {
+            return await fetchPromise;
+        } finally {
+            if (this.sessionInFlight === fetchPromise) {
+                this.sessionInFlight = null;
+            }
+        }
+    }
+
+    private async fetchSession() {
         const token = await this.getToken();
         if (!token) return null;
 

--- a/src/main/services/auth.ts
+++ b/src/main/services/auth.ts
@@ -79,19 +79,20 @@ export class Auth {
         }
     }
 
-    private async fetchSession() {
+    private async fetchSession(): Promise<Session | null> {
         const capturedGeneration = this.tokenGeneration;
         const token = await this.getToken();
-        if (this.tokenGeneration !== capturedGeneration) return null;
+        if (this.tokenGeneration !== capturedGeneration) return this.fetchSession();
         if (!token) return null;
 
         const url = `${BACKEND_URL}/api/auth/get-session`;
-        const resp = await this.desktop.httpService.fetcher(url, { throwHttpErrors: false });
+        const resp = await this.desktop.httpService.fetcher(url, {
+            throwHttpErrors: false,
+            headers: { Authorization: `Bearer ${token}` },
+        });
 
-        // Check if token was changed while request was in flight
-        if (this.tokenGeneration !== capturedGeneration) {
-            return null;
-        }
+        // A newer token landed in flight; this response no longer belongs to the current session.
+        if (this.tokenGeneration !== capturedGeneration) return this.fetchSession();
 
         if (!resp.ok) {
             if (resp.status === 401) await this.startLogout(capturedGeneration);

--- a/src/main/services/auth.ts
+++ b/src/main/services/auth.ts
@@ -96,11 +96,14 @@ export class Auth {
 
         if (!resp.ok) {
             if (resp.status === 401) await this.startLogout(capturedGeneration);
+            if (this.tokenGeneration !== capturedGeneration) return this.fetchSession();
             return null;
         }
         const data = await resp.text();
+        if (this.tokenGeneration !== capturedGeneration) return this.fetchSession();
         if (data === "null") {
             await this.startLogout(capturedGeneration);
+            if (this.tokenGeneration !== capturedGeneration) return this.fetchSession();
             return null;
         }
         return SessionSchema.parse(JSON.parse(data));

--- a/src/main/services/auth.ts
+++ b/src/main/services/auth.ts
@@ -12,6 +12,7 @@ import { openExternal } from "./util";
 export class Auth {
     private desktop: NahidaDesktop;
     private sessionInFlight: Promise<Session | null> | null = null;
+    private tokenGeneration = 0;
 
     constructor(desktop: NahidaDesktop) {
         this.desktop = desktop;
@@ -27,6 +28,7 @@ export class Auth {
 
     public async saveToken(key: string) {
         this.sessionInFlight = null;
+        this.tokenGeneration++;
         const encryptedKey = this.desktop.lib.crypto.encryptString(key);
         await this.desktop.lib.db.settings.upsert("token", encryptedKey);
     }
@@ -46,6 +48,7 @@ export class Auth {
 
     public async removeToken() {
         this.sessionInFlight = null;
+        this.tokenGeneration++;
         await this.desktop.lib.db.settings.updateValue("token", null);
     }
 
@@ -68,18 +71,25 @@ export class Auth {
     }
 
     private async fetchSession() {
+        const capturedGeneration = this.tokenGeneration;
         const token = await this.getToken();
         if (!token) return null;
 
         const url = `${BACKEND_URL}/api/auth/get-session`;
         const resp = await this.desktop.httpService.fetcher(url, { throwHttpErrors: false });
+
+        // Check if token was changed while request was in flight
+        if (this.tokenGeneration !== capturedGeneration) {
+            return null;
+        }
+
         if (!resp.ok) {
-            if (resp.status === 401) await this.startLogout();
+            if (resp.status === 401) await this.startLogout(capturedGeneration);
             return null;
         }
         const data = await resp.text();
         if (data === "null") {
-            await this.startLogout();
+            await this.startLogout(capturedGeneration);
             return null;
         }
         return SessionSchema.parse(JSON.parse(data));
@@ -171,7 +181,12 @@ export class Auth {
         }
     }
 
-    public async startLogout() {
+    public async startLogout(expectedGeneration?: number) {
+        // If a generation was provided, verify we're still on that generation
+        if (expectedGeneration !== undefined && this.tokenGeneration !== expectedGeneration) {
+            return;
+        }
+
         const token = await this.getToken();
         await this.removeToken();
         this.desktop.ipc.broadcast("auth:update", null);

--- a/src/renderer/src/hooks/use-auth.ts
+++ b/src/renderer/src/hooks/use-auth.ts
@@ -3,11 +3,6 @@ import type { Session } from "@shared/schemas/auth";
 import { useEffect } from "react";
 
 export function useInitializeAuth() {
-    const setSession = useGlobalStore((state) => state.setSession);
-    const setSessionInitialized = useGlobalStore((state) => state.setSessionInitialized);
-    const setBackendStatus = useGlobalStore((state) => state.setBackendStatus);
-    const setHasToken = useGlobalStore((state) => state.setHasToken);
-
     useEffect(() => {
         let mounted = true;
 
@@ -33,12 +28,24 @@ export function useInitializeAuth() {
                 console.error("Failed to load auth bootstrap state", error);
             }
 
+            if (!session && hasToken && backendStatus === "online") {
+                try {
+                    session = await window.api.invoke("auth:getSession");
+                } catch (error) {
+                    console.error("Failed to restore session after backend became online", error);
+                }
+            }
+
             if (!mounted) return;
 
-            setSession(session);
-            setHasToken(!!session || hasToken);
-            setBackendStatus(backendStatus);
-            setSessionInitialized(true);
+            const currentBackendStatus = globalStore.getState().backendStatus;
+            globalStore.setState({
+                session,
+                sessionInitialized: true,
+                hasToken: !!session || hasToken,
+                backendStatus:
+                    currentBackendStatus === "unknown" ? backendStatus : currentBackendStatus,
+            });
         };
 
         void loadSession();
@@ -46,7 +53,7 @@ export function useInitializeAuth() {
         return () => {
             mounted = false;
         };
-    }, [setSession, setSessionInitialized, setBackendStatus, setHasToken]);
+    }, []);
 }
 
 export function useAuth() {

--- a/src/renderer/src/hooks/use-global-events.ts
+++ b/src/renderer/src/hooks/use-global-events.ts
@@ -19,6 +19,7 @@ export function useGlobalEvents(
     const setSession = useGlobalStore((state) => state.setSession);
     const setHasToken = useGlobalStore((state) => state.setHasToken);
     const setBackendStatus = useGlobalStore((state) => state.setBackendStatus);
+    const setPendingSessionRestore = useGlobalStore((state) => state.setPendingSessionRestore);
     const [listeners, setListeners] = useState<Map<string, () => void>>(new Map());
     const { i18n } = useTranslation();
 
@@ -61,10 +62,14 @@ export function useGlobalEvents(
             setBackendStatus(status);
             if (status !== "online") return;
 
+            const isColdStartRestore = previousStatus === "unknown";
+            if (previousStatus !== "offline" && !isColdStartRestore) return;
+
+            if (isColdStartRestore) setPendingSessionRestore(true);
+
             void (async () => {
                 try {
-                    if (previousStatus !== "offline") {
-                        if (previousStatus !== "unknown") return;
+                    if (isColdStartRestore) {
                         await whenSessionInitialized();
                         const state = globalStore.getState();
                         if (state.session || !state.hasToken) return;
@@ -75,6 +80,8 @@ export function useGlobalEvents(
                     setHasToken(!!session || (await window.api.invoke("auth:hasToken")));
                 } catch (error) {
                     console.error("Failed to refresh session after backend recovery", error);
+                } finally {
+                    if (isColdStartRestore) setPendingSessionRestore(false);
                 }
             })();
         });

--- a/src/renderer/src/hooks/use-global-events.ts
+++ b/src/renderer/src/hooks/use-global-events.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
-import { useGlobalStore } from "../store/global";
+import { globalStore, useGlobalStore } from "../store/global";
 
 export function useGlobalEvents(
     onPathSelectorModeSelect?: (data: {
@@ -57,11 +57,19 @@ export function useGlobalEvents(
         setListeners(new Map(listeners.set("auth:update", removeAuthListener)));
 
         const removeBackendStatusListener = window.api.on("backend:status", (status) => {
+            const previousStatus = globalStore.getState().backendStatus;
             setBackendStatus(status);
             if (status !== "online") return;
 
             void (async () => {
                 try {
+                    if (previousStatus !== "offline") {
+                        if (previousStatus !== "unknown") return;
+                        await whenSessionInitialized();
+                        const state = globalStore.getState();
+                        if (state.session || !state.hasToken) return;
+                    }
+
                     const session = await window.api.invoke("auth:getSession");
                     setSession(session);
                     setHasToken(!!session || (await window.api.invoke("auth:hasToken")));
@@ -81,4 +89,21 @@ export function useGlobalEvents(
             removeAllListeners();
         };
     }, [onPathSelectorModeSelect, i18n]);
+}
+
+function whenSessionInitialized() {
+    if (globalStore.getState().sessionInitialized) return Promise.resolve();
+
+    return new Promise<void>((resolve) => {
+        const unsubscribe = globalStore.subscribe((state) => {
+            if (!state.sessionInitialized) return;
+            unsubscribe();
+            resolve();
+        });
+
+        if (globalStore.getState().sessionInitialized) {
+            unsubscribe();
+            resolve();
+        }
+    });
 }

--- a/src/renderer/src/hooks/use-global-events.ts
+++ b/src/renderer/src/hooks/use-global-events.ts
@@ -59,13 +59,17 @@ export function useGlobalEvents(
 
         const removeBackendStatusListener = window.api.on("backend:status", (status) => {
             const previousStatus = globalStore.getState().backendStatus;
-            setBackendStatus(status);
+            const isColdStartRestore = status === "online" && previousStatus === "unknown";
+            if (isColdStartRestore) {
+                globalStore.setState({
+                    backendStatus: status,
+                    pendingSessionRestore: true,
+                });
+            } else {
+                setBackendStatus(status);
+            }
             if (status !== "online") return;
-
-            const isColdStartRestore = previousStatus === "unknown";
             if (previousStatus !== "offline" && !isColdStartRestore) return;
-
-            if (isColdStartRestore) setPendingSessionRestore(true);
 
             void (async () => {
                 try {

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -406,7 +406,7 @@
           "confirm": "Rename"
         },
         "find-conflict": {
-          "title": "Find Conflict Mode",
+          "title": "Find Conflict Mods",
           "description": "Runs a bisect with \"{{name}}\" kept enabled to find which other mod conflicts with it.",
           "mod-disabled-warning": "This mod is currently disabled. Enable it first to reproduce the conflict.",
           "session-active": "A bisect session is already in progress. Cancel or finish it before starting a new one."
@@ -614,7 +614,7 @@
         "open-gamebanana": "View on GameBanana",
         "mark-manual-subgroup": "Mark as subgroup",
         "rename": "Rename",
-        "find-conflict": "Find Conflict Mode"
+        "find-conflict": "Find Conflict Mods"
       },
       "toast": {
         "trash-loading": "Moving to recycle bin...",

--- a/src/renderer/src/lib/start-page.test.ts
+++ b/src/renderer/src/lib/start-page.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { isStartPageSessionReady, resolveStartPage } from "./start-page";
+
+describe("isStartPageSessionReady", () => {
+    it("waits until the initial session load has finished", () => {
+        expect(
+            isStartPageSessionReady({
+                sessionInitialized: false,
+                pendingSessionRestore: false,
+                hasSession: false,
+                hasToken: true,
+                backendStatus: "unknown",
+            }),
+        ).toBe(false);
+    });
+
+    it("waits while cold-start restore is still fetching the session", () => {
+        expect(
+            isStartPageSessionReady({
+                sessionInitialized: true,
+                pendingSessionRestore: true,
+                hasSession: false,
+                hasToken: true,
+                backendStatus: "online",
+            }),
+        ).toBe(false);
+    });
+
+    it("waits when a token exists but the backend status is still unknown", () => {
+        expect(
+            isStartPageSessionReady({
+                sessionInitialized: true,
+                pendingSessionRestore: false,
+                hasSession: false,
+                hasToken: true,
+                backendStatus: "unknown",
+            }),
+        ).toBe(false);
+    });
+
+    it("resolves as logged out when restore finished without a session", () => {
+        expect(
+            isStartPageSessionReady({
+                sessionInitialized: true,
+                pendingSessionRestore: false,
+                hasSession: false,
+                hasToken: true,
+                backendStatus: "online",
+            }),
+        ).toBe(true);
+    });
+
+    it("resolves immediately when a session is already present", () => {
+        expect(
+            isStartPageSessionReady({
+                sessionInitialized: true,
+                pendingSessionRestore: false,
+                hasSession: true,
+                hasToken: true,
+                backendStatus: "online",
+            }),
+        ).toBe(true);
+    });
+
+    it("does not block local-first startup while the backend is offline", () => {
+        expect(
+            isStartPageSessionReady({
+                sessionInitialized: true,
+                pendingSessionRestore: false,
+                hasSession: false,
+                hasToken: true,
+                backendStatus: "offline",
+            }),
+        ).toBe(true);
+    });
+});
+
+describe("resolveStartPage", () => {
+    it("materializes the drive root from the restored session", () => {
+        expect(
+            resolveStartPage("/drive/drive/root", {
+                isLoggedIn: true,
+                sessionRootId: "root-123",
+            }),
+        ).toBe("/drive/drive/root-123");
+    });
+
+    it("falls back when the start page is chosen before the session exists", () => {
+        expect(
+            resolveStartPage("/drive/drive/root", {
+                isLoggedIn: false,
+            }),
+        ).toBe("/mod");
+    });
+});

--- a/src/renderer/src/lib/start-page.ts
+++ b/src/renderer/src/lib/start-page.ts
@@ -1,3 +1,5 @@
+import type { BackendStatus } from "@shared/backend";
+
 export const DRIVE_START_PAGES = ["/drive/drive/root", "/drive/share/root"] as const;
 
 export function requiresAuthForStartPage(page: string | null | undefined) {
@@ -26,6 +28,18 @@ export function materializeStartPage(
     }
 
     return page;
+}
+
+export function isStartPageSessionReady(state: {
+    sessionInitialized: boolean;
+    pendingSessionRestore: boolean;
+    hasSession: boolean;
+    hasToken: boolean;
+    backendStatus: BackendStatus;
+}) {
+    if (!state.sessionInitialized || state.pendingSessionRestore) return false;
+    if (state.hasToken && !state.hasSession && state.backendStatus === "unknown") return false;
+    return true;
 }
 
 export function resolveStartPage(

--- a/src/renderer/src/routes/index.tsx
+++ b/src/renderer/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { getSetting } from "@renderer/lib/settings";
-import { resolveStartPage } from "@renderer/lib/start-page";
-import { globalStore, useGlobalStore } from "@renderer/store/global";
+import { isStartPageSessionReady, resolveStartPage } from "@renderer/lib/start-page";
+import { useGlobalStore } from "@renderer/store/global";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 
@@ -11,14 +11,29 @@ export const Route = createFileRoute("/")({
 function RouteComponent() {
   const navi = useNavigate();
   const sessionInitialized = useGlobalStore((state) => state.sessionInitialized);
+  const pendingSessionRestore = useGlobalStore((state) => state.pendingSessionRestore);
+  const session = useGlobalStore((state) => state.session);
+  const hasToken = useGlobalStore((state) => state.hasToken);
+  const backendStatus = useGlobalStore((state) => state.backendStatus);
 
   useEffect(() => {
-    if (!sessionInitialized) return;
+    if (
+      !isStartPageSessionReady({
+        sessionInitialized,
+        pendingSessionRestore,
+        hasSession: !!session,
+        hasToken,
+        backendStatus,
+      })
+    ) {
+      return;
+    }
 
-    const session = globalStore.getState().session;
+    let cancelled = false;
 
     Promise.all([getSetting("general.defaultStartPage"), window.api.invoke("util:getAppStatus")])
       .then(([page, appStatus]) => {
+        if (cancelled) return;
         void navi({
           to: resolveStartPage(page, {
             isLoggedIn: !!session,
@@ -28,6 +43,7 @@ function RouteComponent() {
         });
       })
       .catch((error) => {
+        if (cancelled) return;
         console.error("Failed to resolve startup navigation", error);
         void navi({
           to: resolveStartPage(undefined, {
@@ -35,7 +51,11 @@ function RouteComponent() {
           }),
         });
       });
-  }, [navi, sessionInitialized]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [navi, sessionInitialized, pendingSessionRestore, session, hasToken, backendStatus]);
 
   return <div className="flex min-h-screen flex-col" />;
 }

--- a/src/renderer/src/routes/index.tsx
+++ b/src/renderer/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { getSetting } from "@renderer/lib/settings";
 import { resolveStartPage } from "@renderer/lib/start-page";
+import { globalStore, useGlobalStore } from "@renderer/store/global";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 
@@ -9,14 +10,15 @@ export const Route = createFileRoute("/")({
 
 function RouteComponent() {
   const navi = useNavigate();
+  const sessionInitialized = useGlobalStore((state) => state.sessionInitialized);
 
   useEffect(() => {
-    Promise.all([
-      getSetting("general.defaultStartPage"),
-      window.api.invoke("auth:getSession"),
-      window.api.invoke("util:getAppStatus"),
-    ])
-      .then(([page, session, appStatus]) => {
+    if (!sessionInitialized) return;
+
+    const session = globalStore.getState().session;
+
+    Promise.all([getSetting("general.defaultStartPage"), window.api.invoke("util:getAppStatus")])
+      .then(([page, appStatus]) => {
         void navi({
           to: resolveStartPage(page, {
             isLoggedIn: !!session,
@@ -33,7 +35,7 @@ function RouteComponent() {
           }),
         });
       });
-  }, [navi]);
+  }, [navi, sessionInitialized]);
 
   return <div className="flex min-h-screen flex-col" />;
 }

--- a/src/renderer/src/store/global.ts
+++ b/src/renderer/src/store/global.ts
@@ -24,8 +24,10 @@ interface GlobalStore {
     setUpdaterStatus: (status: UpdaterStatus) => void;
     session: Session | null;
     sessionInitialized: boolean;
+    pendingSessionRestore: boolean;
     setSession: (session: Session | null) => void;
     setSessionInitialized: (initialized: boolean) => void;
+    setPendingSessionRestore: (pending: boolean) => void;
     backendStatus: BackendStatus;
     setBackendStatus: (status: BackendStatus) => void;
     hasToken: boolean;
@@ -65,8 +67,10 @@ export const globalStore = createStore<GlobalStore>((set) => {
             }),
         session: null,
         sessionInitialized: false,
+        pendingSessionRestore: false,
         setSession: (session) => set({ session, sessionInitialized: true }),
         setSessionInitialized: (sessionInitialized) => set({ sessionInitialized }),
+        setPendingSessionRestore: (pendingSessionRestore) => set({ pendingSessionRestore }),
         backendStatus: "unknown",
         setBackendStatus: (backendStatus) => set({ backendStatus }),
         hasToken: false,


### PR DESCRIPTION
## Summary
- Stop returning already-consumed Eden/CBOR response bodies from the client layer.
- Deduplicate `get-session` on startup so auth does not fire twice.
- Correct the Find Conflict Mods English copy.

Independent of the Real-ESRGAN work. Merge this first so the patch lands as 2.60.2.

## Test plan
- [ ] Cold-start the app and confirm only one `get-session` request is sent
- [ ] Sign in / restore session and confirm auth still succeeds after CBOR responses
- [ ] Open a mod context menu and confirm the action reads **Find Conflict Mods**, not Find Conflict Mode
- [ ] CI validate passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication concurrency, logout guards, and session bootstrap/navigation timing—security-sensitive paths with broad startup impact; covered by extensive new tests.
> 
> **Overview**
> Hardens desktop auth and API client behavior so token rotation and concurrent session fetches do not log users out or return unusable response bodies, and delays startup routing until session restore can finish.
> 
> **Auth** (`Auth`): Queues token save/remove via `tokenGeneration`, deduplicates in-flight `getSession`, pins `Authorization` on the session request, and only runs logout when the token generation still matches—so stale 401/`null` responses and overlapping login/logout do not clear a newer token.
> 
> **HTTP** (`DesktopHttpService`): If the caller already set `Authorization` (object or tuple headers), the fetcher no longer overwrites it with a freshly resolved token.
> 
> **Eden client** (`client.ts` + `jsonResponseFromBody`): JSON/CBOR handling now reads the body once and returns a new JSON `Response` instead of handing Eden an already-consumed body; mapping failures surface for CBOR retry-as-JSON.
> 
> **Renderer**: Cold start and backend recovery coordinate session restore (`pendingSessionRestore`, `isStartPageSessionReady`) so the index route does not navigate before auth bootstrap; English copy fixes **Find Conflict Mods** labeling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 155468c7f5d4439e5fe8e6b0b6148e1236c8ed5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication recovery when the backend reconnects.
  - Prevented outdated session responses and logout actions from overriding newer changes.
  - Reduced duplicate session requests during startup and authentication checks.
  - Preserved caller-provided authorization headers.
  - Improved JSON and CBOR response handling, including consumed response bodies.
  - Improved session restoration during startup and offline recovery.

- **Navigation**
  - Startup navigation now waits for session initialization before selecting a page.

- **Localization**
  - Corrected the label to “Find Conflict Mods.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->