### PR TITLE
feat(touch-profile): use FRAME_NUMBER guard on XXMI 1.0.2+

### DIFF
--- a/src/main/services/mod-tools/touch-profile-ini.ts
+++ b/src/main/services/mod-tools/touch-profile-ini.ts
@@ -955,11 +955,10 @@ function compareTouchIniVersions(left: string, right: string) {
 }
 
 function parseTouchIniVersionParts(version: string) {
-    const parts = version
-        .replace(/^v/i, "")
-        .split(".")
-        .map((part) => Number(part));
-    if (parts.length === 0 || parts.some((part) => !Number.isFinite(part))) return null;
+    const rawParts = version.replace(/^v/i, "").split(".");
+    if (rawParts.length === 0 || rawParts.some((part) => part.length === 0)) return null;
+    const parts = rawParts.map((part) => Number(part));
+    if (parts.some((part) => !Number.isFinite(part))) return null;
     return parts;
 }
 

--- a/src/main/services/mod-tools/touch-profile-ini.ts
+++ b/src/main/services/mod-tools/touch-profile-ini.ts
@@ -20,7 +20,16 @@ export type TouchIniCompileInput = {
     assets: TouchGeneratedAssets[];
     namespaceToken: string;
     varPrefix: string;
+    useFrameNumberGuard?: boolean;
 };
+
+const FRAME_NUMBER_GUARD_MIN_VERSION = "1.0.2";
+
+export function supportsTouchFrameNumberGuard(deployedVersion: string | null | undefined) {
+    if (!deployedVersion) return false;
+    const comparison = compareTouchIniVersions(deployedVersion, FRAME_NUMBER_GUARD_MIN_VERSION);
+    return comparison !== null && comparison >= 0;
+}
 
 type InteractiveEntry = {
     draft: TouchComponentDraft;
@@ -68,6 +77,7 @@ export async function compileTouchIni(input: TouchIniCompileInput) {
         text,
         input.varPrefix,
         interactive.map((entry) => entry.component),
+        input.useFrameNumberGuard === true,
     );
     text = appendRuntime(text, input.varPrefix, interactive, interactive[0].asset.relativeDir);
 
@@ -209,7 +219,12 @@ function patchBlendSections(text: string, varPrefix: string, components: TouchCo
     return next;
 }
 
-function patchIbSections(text: string, varPrefix: string, components: TouchComponentAnalysis[]) {
+function patchIbSections(
+    text: string,
+    varPrefix: string,
+    components: TouchComponentAnalysis[],
+    useFrameNumberGuard: boolean,
+) {
     let next = text;
     const st = sectionToken(varPrefix);
     const groups = new Map<string, TouchComponentAnalysis[]>();
@@ -233,7 +248,7 @@ function patchIbSections(text: string, varPrefix: string, components: TouchCompo
         }
 
         const inject = group
-            .map((component) => buildIbInjection(component, varPrefix, st))
+            .map((component) => buildIbInjection(component, varPrefix, st, useFrameNumberGuard))
             .join("\n");
         const ibLine = section.body.match(/^\s*ib\s*=\s*.+$/im);
         if (ibLine) {
@@ -258,17 +273,23 @@ function patchIbSections(text: string, varPrefix: string, components: TouchCompo
     return next;
 }
 
-function buildIbInjection(component: TouchComponentAnalysis, varPrefix: string, st: string) {
+function buildIbInjection(
+    component: TouchComponentAnalysis,
+    varPrefix: string,
+    st: string,
+    useFrameNumberGuard: boolean,
+) {
     const id = token(component.id);
+    const frameToken = useFrameNumberGuard ? "FRAME_NUMBER" : "time";
     const lines = `
  if $${varPrefix}_detect_allowed == 1
 	run = CustomShader${st}Bake${id}
 	run = CustomShader${st}Detect${id}
 endif
 if $${varPrefix}_mode == 1
-	if time != $${varPrefix}_last_dispatch_${id}
+	if ${frameToken} != $${varPrefix}_last_dispatch_${id}
 		run = CustomShader${st}Jiggle${id}
-		$${varPrefix}_last_dispatch_${id} = time
+		$${varPrefix}_last_dispatch_${id} = ${frameToken}
 	endif
 	vb0 = Resource${st}TempVB${id}
 endif
@@ -916,6 +937,30 @@ function packedVectorLines(slot: number, values: number[]) {
 
 function formatIniNumber(value: number) {
     return Number(value.toFixed(6)).toString();
+}
+
+function compareTouchIniVersions(left: string, right: string) {
+    const leftParts = parseTouchIniVersionParts(left);
+    const rightParts = parseTouchIniVersionParts(right);
+    if (!leftParts || !rightParts) return null;
+
+    const maxLength = Math.max(leftParts.length, rightParts.length);
+    for (let index = 0; index < maxLength; index += 1) {
+        const leftValue = leftParts[index] ?? 0;
+        const rightValue = rightParts[index] ?? 0;
+        if (leftValue > rightValue) return 1;
+        if (leftValue < rightValue) return -1;
+    }
+    return 0;
+}
+
+function parseTouchIniVersionParts(version: string) {
+    const parts = version
+        .replace(/^v/i, "")
+        .split(".")
+        .map((part) => Number(part));
+    if (parts.length === 0 || parts.some((part) => !Number.isFinite(part))) return null;
+    return parts;
 }
 
 function matchSection(text: string, header: string) {

--- a/src/main/services/mod-tools/touch-profile-regeneration.test.ts
+++ b/src/main/services/mod-tools/touch-profile-regeneration.test.ts
@@ -159,6 +159,9 @@ describe("TouchProfileService regeneration", () => {
                 },
             },
             service: {
+                xxmi: {
+                    getXXMIConfig: () => null,
+                },
                 mod: {
                     fn: {
                         enable: async (source: string) => {

--- a/src/main/services/mod-tools/touch-profile.test.ts
+++ b/src/main/services/mod-tools/touch-profile.test.ts
@@ -405,6 +405,8 @@ describe("touch frame number guard version", () => {
         assert.equal(supportsTouchFrameNumberGuard("1.0.1"), false);
         assert.equal(supportsTouchFrameNumberGuard(""), false);
         assert.equal(supportsTouchFrameNumberGuard(undefined), false);
+        assert.equal(supportsTouchFrameNumberGuard("1..2"), false);
+        assert.equal(supportsTouchFrameNumberGuard("1.0.2."), false);
     });
 });
 

--- a/src/main/services/mod-tools/touch-profile.test.ts
+++ b/src/main/services/mod-tools/touch-profile.test.ts
@@ -29,7 +29,11 @@ import {
     assertTouchProfileDetectionAllowed,
     inspectTouchProfileInput,
 } from "./touch-profile-detection";
-import { buildTouchRuntimeZoneOverrides, compileTouchIni } from "./touch-profile-ini";
+import {
+    buildTouchRuntimeZoneOverrides,
+    compileTouchIni,
+    supportsTouchFrameNumberGuard,
+} from "./touch-profile-ini";
 import {
     buildAllViewTransforms,
     buildViewTransform,
@@ -255,10 +259,16 @@ describe("touch profile INI generation", () => {
         const sourceIniPath = path.join(root, "source.ini");
         const targetIniPath = path.join(root, "Body", "target.ini");
         const resourceDir = path.join(root, "Resources", "IM");
-        const component = makeTouchComponent(3);
+        const component = {
+            ...makeTouchComponent(3),
+            ibSectionName: "BodyA",
+        };
         fs.mkdirSync(path.dirname(targetIniPath));
         fs.mkdirSync(resourceDir, { recursive: true });
-        fs.writeFileSync(sourceIniPath, "[Constants]\n\n[Present]\n");
+        fs.writeFileSync(
+            sourceIniPath,
+            "[Constants]\n\n[Present]\n\n[TextureOverrideBodyA]\nib = ResourceBodyA\n",
+        );
 
         await compileTouchIni({
             sourceIniPath,
@@ -313,7 +323,88 @@ describe("touch profile INI generation", () => {
         assert.match(ini, /filename = \.\.\/Resources\/IM\/mask0\.buf/);
         assert.match(ini, /filename = \.\.\/Resources\/IM\/object-map\.buf/);
         assert.match(ini, /filename = \.\.\/Resources\/IM\/params\.buf/);
+        assert.match(ini, /if time != \$nhd_touch_test_last_dispatch_bodyPosition/);
+        assert.doesNotMatch(ini, /FRAME_NUMBER != \$nhd_touch_test_last_dispatch_bodyPosition/);
         fs.rmSync(root, { recursive: true, force: true });
+    });
+
+    it("uses FRAME_NUMBER for the per-frame jiggle guard when requested", async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), "touch-profile-ini-frame-"));
+        const sourceIniPath = path.join(root, "source.ini");
+        const targetIniPath = path.join(root, "target.ini");
+        const resourceDir = path.join(root, "Resources", "IM");
+        const component = {
+            ...makeTouchComponent(3),
+            ibSectionName: "BodyA",
+        };
+        fs.mkdirSync(resourceDir, { recursive: true });
+        fs.writeFileSync(
+            sourceIniPath,
+            "[Constants]\n\n[Present]\n\n[TextureOverrideBodyA]\nib = ResourceBodyA\n",
+        );
+
+        await compileTouchIni({
+            sourceIniPath,
+            targetIniPath,
+            analysis: {
+                modRoot: root,
+                sourceRoot: root,
+                modRootRelativeToSource: "",
+                iniPath: sourceIniPath,
+                iniRelativePath: "source.ini",
+                sourceFilesRelativePaths: ["source.ini"],
+                supportGrade: "A",
+                supportReasons: [],
+                components: [component],
+                meshHash: "mesh",
+                iniHash: "ini",
+            },
+            drafts: [
+                {
+                    ...createSettingsDraft(0, "normal"),
+                    componentId: component.id,
+                },
+            ],
+            assets: [
+                {
+                    componentId: component.id,
+                    assetPrefix: "Body",
+                    relativeDir: "Resources/IM",
+                    maskPaths: ["mask0.buf", "mask1.buf", "mask2.buf"],
+                    objectMapPaths: [
+                        {
+                            label: "main",
+                            relativePath: "object-map.buf",
+                            absolutePath: path.join(resourceDir, "object-map.buf"),
+                        },
+                    ],
+                    paramsRelativePath: "params.buf",
+                    paramsAbsolutePath: path.join(resourceDir, "params.buf"),
+                    previewRelativePath: "preview.png",
+                    previewAbsolutePath: path.join(resourceDir, "preview.png"),
+                    masks: new Float32Array(),
+                } satisfies TouchGeneratedAssets,
+            ],
+            namespaceToken: "test",
+            varPrefix: "nhd_touch_test",
+            useFrameNumberGuard: true,
+        });
+
+        const ini = fs.readFileSync(targetIniPath, "utf8");
+        assert.match(ini, /if FRAME_NUMBER != \$nhd_touch_test_last_dispatch_bodyPosition/);
+        assert.match(ini, /\$nhd_touch_test_last_dispatch_bodyPosition = FRAME_NUMBER/);
+        assert.doesNotMatch(ini, /if time != \$nhd_touch_test_last_dispatch_bodyPosition/);
+        fs.rmSync(root, { recursive: true, force: true });
+    });
+});
+
+describe("touch frame number guard version", () => {
+    it("enables FRAME_NUMBER only for deployed XXMI 1.0.2 and newer", () => {
+        assert.equal(supportsTouchFrameNumberGuard("1.0.2"), true);
+        assert.equal(supportsTouchFrameNumberGuard("v1.0.3"), true);
+        assert.equal(supportsTouchFrameNumberGuard("1.0.1"), false);
+        assert.equal(supportsTouchFrameNumberGuard(""), false);
+        assert.equal(supportsTouchFrameNumberGuard(undefined), false);
     });
 });
 

--- a/src/main/services/mod-tools/touch-profile.ts
+++ b/src/main/services/mod-tools/touch-profile.ts
@@ -42,7 +42,7 @@ import {
     DEFAULT_BONE_WEIGHT_THRESHOLD_MAX,
 } from "./touch-profile-bone";
 import { assertTouchProfileInputAllowed } from "./touch-profile-detection";
-import { compileTouchIni } from "./touch-profile-ini";
+import { compileTouchIni, supportsTouchFrameNumberGuard } from "./touch-profile-ini";
 import { normalizeTouchZoneSettings } from "./touch-profile-settings";
 import {
     TOUCH_CONFIDENCE_AUTO_APPLY_AVG,
@@ -1098,6 +1098,9 @@ export class TouchProfileService {
             assets,
             namespaceToken,
             varPrefix,
+            useFrameNumberGuard: supportsTouchFrameNumberGuard(
+                this.desktop.service.xxmi.getXXMIConfig()?.Packages.packages.XXMI?.deployed_version,
+            ),
         });
 
         this.broadcast({


### PR DESCRIPTION
## Summary
- Use XXMI `deployed_version` to choose the touch-profile INI frame guard.
- Emit `FRAME_NUMBER` on 1.0.2+ and keep the existing `time` comparison otherwise.

## Test plan
- [ ] Generate a touch profile with XXMI `deployed_version` below 1.0.2 and confirm the INI still uses `time`.
- [ ] Generate a touch profile with XXMI `deployed_version` 1.0.2+ and confirm the INI uses `FRAME_NUMBER`.
- [ ] Confirm an unset or unreadable XXMI config still generates the legacy INI instead of failing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved touch profile generation with optional frame-number safeguards to prevent duplicate jiggle effects.
  * Automatically enables safeguards when the installed package supports them.
  * Added compatibility handling for supported and unsupported package versions.

* **Bug Fixes**
  * Improved reliability of touch profile regeneration and per-frame effect handling.

* **Tests**
  * Added coverage for version compatibility, timing-based safeguards, and frame-number safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes generated mod INI runtime semantics for jiggle dispatch; incorrect version detection could break older XXMI or reintroduce duplicate effects on newer builds.
> 
> **Overview**
> Touch profile INI generation now picks the **per-frame jiggle dispatch guard** based on the installed XXMI **`deployed_version`**: on **1.0.2+** it emits **`FRAME_NUMBER`** instead of **`time`** in the IB injection (`last_dispatch` compare and assignment), which avoids duplicate jiggle runs where the newer runtime supports frame-based guarding.
> 
> The choice is driven by optional **`useFrameNumberGuard`** on `compileTouchIni`, set from **`supportsTouchFrameNumberGuard`** (semver-style compare against `1.0.2`, with invalid/missing versions falling back to the legacy **`time`** path). Missing or unreadable XXMI config keeps the old behavior.
> 
> Tests cover default INI output, explicit FRAME_NUMBER mode, and version gating; regeneration tests stub **`getXXMIConfig`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5189f2a2b67bb9f7eb478362159e32ad28d23778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->