### PR TITLE
feat(tools): add texture resizer titlebar activity

### DIFF
--- a/src/main/ipc/handlers/tools.ts
+++ b/src/main/ipc/handlers/tools.ts
@@ -43,6 +43,7 @@ export function registerToolsHandlers(d: NahidaDesktop) {
     rh("tools:resizeTextureMod", (modPath: string, input) =>
         d.service.modTools.textureResizer.resizeMod(modPath, input),
     );
+    rh("tools:getTextureResizeState", () => d.service.modTools.textureResizer.getState());
     rh(
         "tools:4001FixerBuildDll",
         ({

--- a/src/main/services/mod-tools/texture-resizer.test.ts
+++ b/src/main/services/mod-tools/texture-resizer.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import path from "node:path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@native/mod-tools", () => ({
     decodeDdsToRgba8: vi.fn(),
@@ -10,11 +12,68 @@ vi.mock("./realesrgan-runtime", () => ({
     RealesrganRuntime: class {},
 }));
 
+import type { NahidaDesktop } from "@main/index";
+import { resizeTextures } from "@native/mod-tools";
+import type { TextureResizeResult, TextureResizeSettings } from "@shared/types";
+
 import {
+    TextureResizer,
     mergeTextureResizeSettings,
     resolveUpscaleOutputFormat,
     resolveUpscaleSkipReason,
 } from "./texture-resizer";
+
+const resizeTexturesMock = vi.mocked(resizeTextures);
+
+const DEFAULT_RUN_SETTINGS: TextureResizeSettings = {
+    mode: "custom",
+    operation: "resize",
+    percent: 50,
+    customWidth: 2048,
+    customHeight: 2048,
+    outputFormat: "",
+    backup: true,
+    upscaleScale: 2,
+    upscaleModel: "realesr-animevideov3",
+};
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+}
+
+function resizeResult(targetPath: string): TextureResizeResult {
+    return {
+        targetPath,
+        processed: 1,
+        updated: 1,
+        skipped: 0,
+        failed: 0,
+        files: [],
+    };
+}
+
+function createResizer() {
+    const broadcast = vi.fn();
+    const resizer = new TextureResizer({
+        lib: {
+            db: {
+                settings: {
+                    getValue: vi.fn(async () => null),
+                    upsert: vi.fn(async () => {}),
+                },
+            },
+        },
+        ipc: { broadcast },
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    } as unknown as NahidaDesktop);
+    return { resizer, broadcast };
+}
 
 describe("texture resizer settings", () => {
     it("merges upscale settings and clamps x4plus models to 4x", () => {
@@ -125,5 +184,163 @@ describe("texture resizer settings", () => {
                 "srgb",
             ),
         ).toBeNull();
+    });
+});
+
+describe("texture resizer progress ownership", () => {
+    beforeEach(() => {
+        resizeTexturesMock.mockReset();
+    });
+
+    it("keeps running state when a later resizeFile finishes first", async () => {
+        const { resizer, broadcast } = createResizer();
+        const first = deferred<TextureResizeResult>();
+        const second = deferred<TextureResizeResult>();
+        const firstPath = "/tmp/first.dds";
+        const secondPath = "/tmp/second.dds";
+
+        resizeTexturesMock.mockImplementation(async (request) => {
+            if (request.targetPath === path.resolve(firstPath)) {
+                return await first.promise;
+            }
+            return await second.promise;
+        });
+
+        const firstJob = resizer.resizeFile({
+            filePath: firstPath,
+            settings: DEFAULT_RUN_SETTINGS,
+        });
+        await vi.waitFor(() => {
+            expect(resizer.getState()).toMatchObject({
+                status: "running",
+                fileName: "first.dds",
+            });
+        });
+
+        const secondJob = resizer.resizeFile({
+            filePath: secondPath,
+            settings: DEFAULT_RUN_SETTINGS,
+        });
+        await vi.waitFor(() => {
+            expect(resizer.getState()).toMatchObject({
+                status: "running",
+                fileName: "second.dds",
+            });
+        });
+
+        second.resolve(resizeResult(path.resolve(secondPath)));
+        await secondJob;
+
+        expect(resizer.getState()).toMatchObject({
+            status: "running",
+            fileName: "first.dds",
+        });
+        expect(broadcast).not.toHaveBeenCalledWith(
+            "tools:textureResizeProgress",
+            expect.objectContaining({ status: "completed", fileName: "second.dds" }),
+        );
+        expect(broadcast).not.toHaveBeenCalledWith(
+            "tools:textureResizeProgress",
+            expect.objectContaining({ status: "idle" }),
+        );
+
+        first.resolve(resizeResult(path.resolve(firstPath)));
+        await firstJob;
+
+        expect(broadcast).toHaveBeenCalledWith(
+            "tools:textureResizeProgress",
+            expect.objectContaining({ status: "completed", fileName: "first.dds" }),
+        );
+        expect(resizer.getState()).toEqual({ status: "idle" });
+    });
+
+    it("does not idle after a failed resize while another job is in flight", async () => {
+        const { resizer, broadcast } = createResizer();
+        const first = deferred<TextureResizeResult>();
+        const second = deferred<TextureResizeResult>();
+        const firstPath = "/tmp/first.dds";
+        const secondPath = "/tmp/second.dds";
+
+        resizeTexturesMock.mockImplementation(async (request) => {
+            if (request.targetPath === path.resolve(firstPath)) {
+                return await first.promise;
+            }
+            return await second.promise;
+        });
+
+        const firstJob = resizer.resizeFile({
+            filePath: firstPath,
+            settings: DEFAULT_RUN_SETTINGS,
+        });
+        await vi.waitFor(() => {
+            expect(resizer.getState()).toMatchObject({ status: "running", fileName: "first.dds" });
+        });
+
+        const secondJob = resizer.resizeFile({
+            filePath: secondPath,
+            settings: DEFAULT_RUN_SETTINGS,
+        });
+        await vi.waitFor(() => {
+            expect(resizer.getState()).toMatchObject({ status: "running", fileName: "second.dds" });
+        });
+
+        second.reject(new Error("boom"));
+        await expect(secondJob).rejects.toThrow("boom");
+
+        expect(resizer.getState()).toMatchObject({
+            status: "running",
+            fileName: "first.dds",
+        });
+        expect(broadcast).not.toHaveBeenCalledWith(
+            "tools:textureResizeProgress",
+            expect.objectContaining({ status: "failed" }),
+        );
+
+        first.resolve(resizeResult(path.resolve(firstPath)));
+        await firstJob;
+        expect(resizer.getState()).toEqual({ status: "idle" });
+    });
+
+    it("keeps folder resize activity when a file resize finishes first", async () => {
+        const { resizer } = createResizer();
+        const folder = deferred<TextureResizeResult>();
+        const file = deferred<TextureResizeResult>();
+        const folderPath = "/tmp/mod-folder";
+        const filePath = "/tmp/dialog.dds";
+
+        resizeTexturesMock.mockImplementation(async (request) => {
+            if (request.targetPath === path.resolve(folderPath)) {
+                return await folder.promise;
+            }
+            return await file.promise;
+        });
+
+        const folderJob = resizer.resizeFolder({
+            targetPath: folderPath,
+            settings: DEFAULT_RUN_SETTINGS,
+        });
+        await vi.waitFor(() => {
+            expect(resizer.getState()).toMatchObject({
+                status: "running",
+                fileName: "mod-folder",
+            });
+        });
+
+        const fileJob = resizer.resizeFile({ filePath, settings: DEFAULT_RUN_SETTINGS });
+        await vi.waitFor(() => {
+            expect(resizer.getState()).toMatchObject({ status: "running", fileName: "dialog.dds" });
+        });
+
+        file.resolve(resizeResult(path.resolve(filePath)));
+        await fileJob;
+
+        expect(resizer.getState()).toMatchObject({
+            status: "running",
+            fileName: "mod-folder",
+        });
+
+        folder.resolve(resizeResult(path.resolve(folderPath)));
+        await folderJob;
+        expect(resizer.getState()).toEqual({ status: "idle" });
     });
 });

--- a/src/main/services/mod-tools/texture-resizer.ts
+++ b/src/main/services/mod-tools/texture-resizer.ts
@@ -259,6 +259,7 @@ export class TextureResizer {
                     channel: "tools:textureResizeProgress",
                     operation: running.operation,
                     filePath: running.filePath,
+                    jobId,
                     stage: "runResizeJob",
                 },
                 "TextureResizer:runResizeJob",

--- a/src/main/services/mod-tools/texture-resizer.ts
+++ b/src/main/services/mod-tools/texture-resizer.ts
@@ -219,6 +219,8 @@ const DEFAULT_SETTINGS: TextureResizeSettings = {
 
 export class TextureResizer {
     private activeState: TextureResizeProgressEvent = { status: "idle" };
+    private nextJobId = 0;
+    private readonly inFlightJobs = new Map<number, TextureResizeProgressEvent>();
     private readonly realesrganRuntime: RealesrganRuntime;
 
     constructor(private readonly desktop: NahidaDesktop) {
@@ -232,6 +234,48 @@ export class TextureResizer {
     private updateProgress(event: TextureResizeProgressEvent) {
         this.activeState = event;
         this.desktop.ipc.broadcast("tools:textureResizeProgress", event);
+    }
+
+    // Concurrent resizeFile/resizeFolder/resizeMod share this service. A finished
+    // job must not broadcast completed/failed or reset idle while another job is
+    // still running, or titlebar activity would clear.
+    private async runResizeJob<T>(
+        running: TextureResizeProgressEvent,
+        work: () => Promise<T>,
+        toCompleted: (result: T) => TextureResizeProgressEvent,
+    ) {
+        const jobId = ++this.nextJobId;
+        this.inFlightJobs.set(jobId, running);
+        this.updateProgress(running);
+        try {
+            const result = await work();
+            this.settleJob(jobId, toCompleted(result));
+            return result;
+        } catch (error) {
+            this.settleJob(jobId, {
+                ...running,
+                status: "failed",
+                error: toErrorMessage(error),
+            });
+            throw error;
+        } finally {
+            this.inFlightJobs.delete(jobId);
+            if (this.inFlightJobs.size === 0) {
+                this.activeState = { status: "idle" };
+            }
+        }
+    }
+
+    private settleJob(jobId: number, event: TextureResizeProgressEvent) {
+        const remaining = [...this.inFlightJobs].filter(([id]) => id !== jobId).at(-1)?.[1];
+        if (remaining) {
+            if (this.activeState !== remaining) {
+                this.updateProgress(remaining);
+            }
+            return;
+        }
+
+        this.updateProgress(event);
     }
 
     public async getSettings() {
@@ -326,36 +370,22 @@ export class TextureResizer {
         }
 
         const resolvedPath = path.resolve(targetPath);
-        this.updateProgress({
+        const running: TextureResizeProgressEvent = {
             status: "running",
             operation: settings.operation,
             filePath: resolvedPath,
             fileName: path.basename(resolvedPath),
-        });
-
-        try {
-            const result = await resizeTextures(buildResizeRequest(resolvedPath, settings));
-            this.updateProgress({
+        };
+        return await this.runResizeJob(
+            running,
+            () => resizeTextures(buildResizeRequest(resolvedPath, settings)),
+            (result) => ({
+                ...running,
                 status: "completed",
-                operation: settings.operation,
-                filePath: resolvedPath,
-                fileName: path.basename(resolvedPath),
                 totalFiles: result.processed,
                 processedFiles: result.processed,
-            });
-            return result;
-        } catch (error) {
-            this.updateProgress({
-                status: "failed",
-                operation: settings.operation,
-                filePath: resolvedPath,
-                fileName: path.basename(resolvedPath),
-                error: toErrorMessage(error),
-            });
-            throw error;
-        } finally {
-            this.activeState = { status: "idle" };
-        }
+            }),
+        );
     }
 
     public async resizeMod(modPath: string, input: Omit<TextureResizeRunInput, "targetPath">) {
@@ -365,36 +395,22 @@ export class TextureResizer {
         }
 
         const resolvedPath = path.resolve(modPath);
-        this.updateProgress({
+        const running: TextureResizeProgressEvent = {
             status: "running",
             operation: settings.operation,
             filePath: resolvedPath,
             fileName: path.basename(resolvedPath),
-        });
-
-        try {
-            const result = await resizeTextures(buildResizeRequest(resolvedPath, settings));
-            this.updateProgress({
+        };
+        return await this.runResizeJob(
+            running,
+            () => resizeTextures(buildResizeRequest(resolvedPath, settings)),
+            (result) => ({
+                ...running,
                 status: "completed",
-                operation: settings.operation,
-                filePath: resolvedPath,
-                fileName: path.basename(resolvedPath),
                 totalFiles: result.processed,
                 processedFiles: result.processed,
-            });
-            return result;
-        } catch (error) {
-            this.updateProgress({
-                status: "failed",
-                operation: settings.operation,
-                filePath: resolvedPath,
-                fileName: path.basename(resolvedPath),
-                error: toErrorMessage(error),
-            });
-            throw error;
-        } finally {
-            this.activeState = { status: "idle" };
-        }
+            }),
+        );
     }
 
     public async resizeFile(input: TextureResizeFileRunInput) {
@@ -405,40 +421,26 @@ export class TextureResizer {
 
         const settings = await this.saveSettings(input.settings);
         const resolvedPath = path.resolve(filePath);
-        this.updateProgress({
+        const running: TextureResizeProgressEvent = {
             status: "running",
             operation: settings.operation,
             filePath: resolvedPath,
             fileName: path.basename(resolvedPath),
             totalFiles: 1,
             processedFiles: 0,
-        });
-
-        try {
-            const result = isTextureUpscaleOperation(settings.operation)
-                ? await this.upscaleFile(resolvedPath, settings)
-                : await resizeTextures(buildResizeRequest(resolvedPath, settings));
-            this.updateProgress({
+        };
+        return await this.runResizeJob(
+            running,
+            () =>
+                isTextureUpscaleOperation(settings.operation)
+                    ? this.upscaleFile(resolvedPath, settings)
+                    : resizeTextures(buildResizeRequest(resolvedPath, settings)),
+            () => ({
+                ...running,
                 status: "completed",
-                operation: settings.operation,
-                filePath: resolvedPath,
-                fileName: path.basename(resolvedPath),
-                totalFiles: 1,
                 processedFiles: 1,
-            });
-            return result;
-        } catch (error) {
-            this.updateProgress({
-                status: "failed",
-                operation: settings.operation,
-                filePath: resolvedPath,
-                fileName: path.basename(resolvedPath),
-                error: toErrorMessage(error),
-            });
-            throw error;
-        } finally {
-            this.activeState = { status: "idle" };
-        }
+            }),
+        );
     }
 
     private async getSettingValue(key: string) {

--- a/src/main/services/mod-tools/texture-resizer.ts
+++ b/src/main/services/mod-tools/texture-resizer.ts
@@ -10,6 +10,7 @@ import type {
     TextureResizeFileRunInput,
     TextureResizeListItem,
     TextureResizeOperation,
+    TextureResizeProgressEvent,
     TextureResizeRunInput,
     TextureResizeSettings,
     TextureUpscaleModel,
@@ -217,10 +218,20 @@ const DEFAULT_SETTINGS: TextureResizeSettings = {
 };
 
 export class TextureResizer {
+    private activeState: TextureResizeProgressEvent = { status: "idle" };
     private readonly realesrganRuntime: RealesrganRuntime;
 
     constructor(private readonly desktop: NahidaDesktop) {
         this.realesrganRuntime = new RealesrganRuntime(desktop);
+    }
+
+    public getState(): TextureResizeProgressEvent {
+        return this.activeState;
+    }
+
+    private updateProgress(event: TextureResizeProgressEvent) {
+        this.activeState = event;
+        this.desktop.ipc.broadcast("tools:textureResizeProgress", event);
     }
 
     public async getSettings() {
@@ -313,7 +324,38 @@ export class TextureResizer {
         if (isTextureUpscaleOperation(settings.operation)) {
             throw new Error("Folder upscale is not supported.");
         }
-        return await resizeTextures(buildResizeRequest(path.resolve(targetPath), settings));
+
+        const resolvedPath = path.resolve(targetPath);
+        this.updateProgress({
+            status: "running",
+            operation: settings.operation,
+            filePath: resolvedPath,
+            fileName: path.basename(resolvedPath),
+        });
+
+        try {
+            const result = await resizeTextures(buildResizeRequest(resolvedPath, settings));
+            this.updateProgress({
+                status: "completed",
+                operation: settings.operation,
+                filePath: resolvedPath,
+                fileName: path.basename(resolvedPath),
+                totalFiles: result.processed,
+                processedFiles: result.processed,
+            });
+            return result;
+        } catch (error) {
+            this.updateProgress({
+                status: "failed",
+                operation: settings.operation,
+                filePath: resolvedPath,
+                fileName: path.basename(resolvedPath),
+                error: toErrorMessage(error),
+            });
+            throw error;
+        } finally {
+            this.activeState = { status: "idle" };
+        }
     }
 
     public async resizeMod(modPath: string, input: Omit<TextureResizeRunInput, "targetPath">) {
@@ -321,7 +363,38 @@ export class TextureResizer {
         if (isTextureUpscaleOperation(settings.operation)) {
             throw new Error("Folder upscale is not supported.");
         }
-        return await resizeTextures(buildResizeRequest(path.resolve(modPath), settings));
+
+        const resolvedPath = path.resolve(modPath);
+        this.updateProgress({
+            status: "running",
+            operation: settings.operation,
+            filePath: resolvedPath,
+            fileName: path.basename(resolvedPath),
+        });
+
+        try {
+            const result = await resizeTextures(buildResizeRequest(resolvedPath, settings));
+            this.updateProgress({
+                status: "completed",
+                operation: settings.operation,
+                filePath: resolvedPath,
+                fileName: path.basename(resolvedPath),
+                totalFiles: result.processed,
+                processedFiles: result.processed,
+            });
+            return result;
+        } catch (error) {
+            this.updateProgress({
+                status: "failed",
+                operation: settings.operation,
+                filePath: resolvedPath,
+                fileName: path.basename(resolvedPath),
+                error: toErrorMessage(error),
+            });
+            throw error;
+        } finally {
+            this.activeState = { status: "idle" };
+        }
     }
 
     public async resizeFile(input: TextureResizeFileRunInput) {
@@ -332,11 +405,40 @@ export class TextureResizer {
 
         const settings = await this.saveSettings(input.settings);
         const resolvedPath = path.resolve(filePath);
-        if (isTextureUpscaleOperation(settings.operation)) {
-            return await this.upscaleFile(resolvedPath, settings);
-        }
+        this.updateProgress({
+            status: "running",
+            operation: settings.operation,
+            filePath: resolvedPath,
+            fileName: path.basename(resolvedPath),
+            totalFiles: 1,
+            processedFiles: 0,
+        });
 
-        return await resizeTextures(buildResizeRequest(resolvedPath, settings));
+        try {
+            const result = isTextureUpscaleOperation(settings.operation)
+                ? await this.upscaleFile(resolvedPath, settings)
+                : await resizeTextures(buildResizeRequest(resolvedPath, settings));
+            this.updateProgress({
+                status: "completed",
+                operation: settings.operation,
+                filePath: resolvedPath,
+                fileName: path.basename(resolvedPath),
+                totalFiles: 1,
+                processedFiles: 1,
+            });
+            return result;
+        } catch (error) {
+            this.updateProgress({
+                status: "failed",
+                operation: settings.operation,
+                filePath: resolvedPath,
+                fileName: path.basename(resolvedPath),
+                error: toErrorMessage(error),
+            });
+            throw error;
+        } finally {
+            this.activeState = { status: "idle" };
+        }
     }
 
     private async getSettingValue(key: string) {

--- a/src/main/services/mod-tools/texture-resizer.ts
+++ b/src/main/services/mod-tools/texture-resizer.ts
@@ -252,6 +252,17 @@ export class TextureResizer {
             this.settleJob(jobId, toCompleted(result));
             return result;
         } catch (error) {
+            this.desktop.logger.error(
+                {
+                    error,
+                    stack: error instanceof Error ? error.stack : undefined,
+                    channel: "tools:textureResizeProgress",
+                    operation: running.operation,
+                    filePath: running.filePath,
+                    stage: "runResizeJob",
+                },
+                "TextureResizer:runResizeJob",
+            );
             this.settleJob(jobId, {
                 ...running,
                 status: "failed",
@@ -641,7 +652,18 @@ export class TextureResizer {
                 filePath,
                 message: toErrorMessage(error),
             });
-            this.desktop.logger.error(error, `tools:resizeTextureFile:upscale:${filePath}`);
+            this.desktop.logger.error(
+                {
+                    error,
+                    stack: error instanceof Error ? error.stack : undefined,
+                    channel: "tools:textureUpscaleProgress",
+                    operation: settings.operation,
+                    filePath,
+                    stage: "upscaleFile",
+                    cleanup: "pending",
+                },
+                `TextureResizer:upscaleFile:${filePath}`,
+            );
             throw error;
         } finally {
             await fse.remove(workDir).catch(() => {});

--- a/src/renderer/src/components/titlebar/titlebar-activity.ts
+++ b/src/renderer/src/components/titlebar/titlebar-activity.ts
@@ -4,6 +4,7 @@ import { getAggregateTransferProgress, isOpenTransferQueueStatus } from "@shared
 import type {
     BisectSnapshot,
     FourThousandOneFixerProgressEvent,
+    TextureResizeProgressEvent,
     TransferWithoutData,
 } from "@shared/types";
 import { formatSize } from "@shared/utils";
@@ -108,6 +109,40 @@ export function buildModBisectTitlebarActivity(
         label: t("titlebar.activity.modBisect.running"),
         status: "running",
         order: 20,
+        href: "/tools",
+    };
+}
+
+function getTextureResizerLabelKey(operation?: TextureResizeProgressEvent["operation"]) {
+    switch (operation) {
+        case "upscale":
+            return "titlebar.activity.textureResizer.upscaling";
+        case "upscale_and_convert":
+            return "titlebar.activity.textureResizer.upscaling_and_converting";
+        case "convert":
+            return "titlebar.activity.textureResizer.converting";
+        case "resize_and_convert":
+            return "titlebar.activity.textureResizer.resizing_and_converting";
+        case "resize":
+        default:
+            return "titlebar.activity.textureResizer.resizing";
+    }
+}
+
+export function buildTextureResizerTitlebarActivity(
+    event: TextureResizeProgressEvent | null,
+    t: Translate,
+): TitlebarActivity | null {
+    if (!event || event.status !== "running") return null;
+
+    const detail = event.fileName;
+
+    return {
+        id: "tools:texture-resizer",
+        label: t(getTextureResizerLabelKey(event.operation)),
+        status: "running",
+        detail: detail || undefined,
+        order: 30,
         href: "/tools",
     };
 }

--- a/src/renderer/src/components/titlebar/use-texture-resizer-titlebar-activity.ts
+++ b/src/renderer/src/components/titlebar/use-texture-resizer-titlebar-activity.ts
@@ -1,0 +1,45 @@
+import { buildTextureResizerTitlebarActivity } from "@renderer/components/titlebar/titlebar-activity";
+import { titlebarActivityStore } from "@renderer/store/titlebar-activity";
+import type { TextureResizeProgressEvent } from "@shared/types";
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+
+const TEXTURE_RESIZER_ACTIVITY_ID = "tools:texture-resizer";
+
+export function useTextureResizerTitlebarActivity() {
+    const { t } = useTranslation();
+
+    useEffect(() => {
+        let disposed = false;
+        let hasLiveEvent = false;
+
+        const sync = (event: TextureResizeProgressEvent | null) => {
+            const activity = buildTextureResizerTitlebarActivity(event, t);
+            if (activity) {
+                titlebarActivityStore.getState().upsertActivity(activity);
+                return;
+            }
+            titlebarActivityStore.getState().removeActivity(TEXTURE_RESIZER_ACTIVITY_ID);
+        };
+
+        void window.api
+            .invoke("tools:getTextureResizeState")
+            .then((state) => {
+                if (disposed || hasLiveEvent) return;
+                sync(state);
+            })
+            .catch((error) => {
+                console.error("tools:getTextureResizeState failed for titlebar activity", error);
+            });
+
+        const removeListener = window.api.on("tools:textureResizeProgress", (event) => {
+            hasLiveEvent = true;
+            sync(event);
+        });
+
+        return () => {
+            disposed = true;
+            removeListener();
+        };
+    }, [t]);
+}

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -1703,7 +1703,14 @@
         "restoring": "Restoring DLL"
       },
       "modBisect": {
-        "running": "Bisecting"
+        "running": "Running bisect"
+      },
+      "textureResizer": {
+        "resizing": "Resizing texture",
+        "upscaling": "Upscaling texture",
+        "converting": "Converting texture format",
+        "resizing_and_converting": "Resizing & converting texture",
+        "upscaling_and_converting": "Upscaling & converting texture"
       }
     }
   },

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -1671,6 +1671,13 @@
       },
       "modBisect": {
         "running": "バイセクト中"
+      },
+      "textureResizer": {
+        "resizing": "テクスチャリサイズ中",
+        "upscaling": "テクスチャアップスケール中",
+        "converting": "テクスチャフォーマット変換中",
+        "resizing_and_converting": "テクスチャリサイズおよび変換中",
+        "upscaling_and_converting": "テクスチャアップスケールおよび変換中"
       }
     }
   },

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -1690,6 +1690,13 @@
       },
       "modBisect": {
         "running": "이진 탐색 중"
+      },
+      "textureResizer": {
+        "resizing": "텍스처 리사이즈 중",
+        "upscaling": "텍스처 업스케일 중",
+        "converting": "텍스처 포맷 변환 중",
+        "resizing_and_converting": "텍스처 리사이즈 및 변환 중",
+        "upscaling_and_converting": "텍스처 업스케일 및 변환 중"
       }
     }
   },

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -1670,6 +1670,13 @@
       },
       "modBisect": {
         "running": "二分排查中"
+      },
+      "textureResizer": {
+        "resizing": "正在调整纹理大小",
+        "upscaling": "正在放大纹理",
+        "converting": "正在转换纹理格式",
+        "resizing_and_converting": "正在调整纹理大小并转换",
+        "upscaling_and_converting": "正在放大纹理并转换"
       }
     }
   },

--- a/src/renderer/src/routes/__root.tsx
+++ b/src/renderer/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { Sidebar } from "@renderer/components/sidebar";
 import { TitlebarActivityBadges } from "@renderer/components/titlebar/titlebar-activity-badges";
 import { use4001FixerTitlebarActivity } from "@renderer/components/titlebar/use-4001-fixer-titlebar-activity";
 import { useModBisectTitlebarActivity } from "@renderer/components/titlebar/use-mod-bisect-titlebar-activity";
+import { useTextureResizerTitlebarActivity } from "@renderer/components/titlebar/use-texture-resizer-titlebar-activity";
 import { useTransferTitlebarActivity } from "@renderer/components/titlebar/use-transfer-titlebar-activity";
 import { Alert, AlertDescription, AlertTitle } from "@renderer/components/ui/alert";
 import { Button } from "@renderer/components/ui/button";
@@ -48,6 +49,7 @@ function RootComponent() {
   useTransferTitlebarActivity();
   use4001FixerTitlebarActivity();
   useModBisectTitlebarActivity();
+  useTextureResizerTitlebarActivity();
 
   useDownloadArchiveExtractPromptHandler();
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -204,6 +204,16 @@ export interface TextureResizeResult {
     files: TextureResizeFileResult[];
 }
 
+export type TextureResizeProgressEvent = {
+    status: "idle" | "running" | "completed" | "failed";
+    operation?: TextureResizeOperation;
+    filePath?: string;
+    fileName?: string;
+    totalFiles?: number;
+    processedFiles?: number;
+    error?: string;
+};
+
 export interface ToggleKey {
     sectionName: string;
     iniFileName: string;
@@ -386,6 +396,7 @@ export type IpcEvents = {
     "setting:xxmi:persistLogs": (logs: string[]) => void;
     "setting:xxmi:toggleViewerLogs": (logs: string[]) => void;
     "tools:4001FixerProgress": (event: FourThousandOneFixerProgressEvent) => void;
+    "tools:textureResizeProgress": (event: TextureResizeProgressEvent) => void;
     "tools:textureUpscaleProgress": (event: TextureUpscaleProgressEvent) => void;
     "tools:touchProfileProgress": (event: TouchProfileProgressEvent) => void;
     "tools:bisectState": (snapshot: BisectSnapshot) => void;


### PR DESCRIPTION
## Summary
- Add titlebar activity badge and real-time state synchronization for texture resizing, upscaling, and format conversion.
- Broadcast tools:textureResizeProgress from TextureResizer service in main process.
- Add useTextureResizerTitlebarActivity hook at root level with multi-language (ko, en, ja, zh) support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Overlapping job state must stay correct for titlebar UX; texture work still modifies files on disk as before, with added concurrency logic in the resizer service.
> 
> **Overview**
> Adds **titlebar activity** while texture tools run (resize, upscale, convert, and combined operations), with the current filename shown as detail and a link to **Tools**.
> 
> The main-process `TextureResizer` now emits **`tools:textureResizeProgress`** and exposes **`tools:getTextureResizeState`** so the UI can sync on load. File, folder, and mod resize paths are wrapped in shared job tracking: when several jobs overlap, finishing or failing one job does **not** broadcast completed/failed or return to idle until **all** in-flight work ends—so the titlebar badge does not drop early.
> 
> The renderer uses `useTextureResizerTitlebarActivity` (root layout) plus new locale strings (en, ja, ko, zh). Bisect titlebar text is tweaked to **“Running bisect”** (en).
> 
> Tests cover concurrent job progress ownership (finish order, failure while another runs, folder vs file overlap).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90d2e16c1304d8adf1aa65714456155d893cd522. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live texture-processing progress in the title bar.
  * Displays the current operation, filename, and progress for resizing, upscaling, format conversion, and combined operations.
  * Shows completion and failure states while preserving existing error handling.
  * Added localized status messages in English, Japanese, Korean, and Simplified Chinese.

* **Improvements**
  * Progress remains accurate while multiple texture-processing tasks run concurrently.
  * Updated the bisecting status label to “Running bisect.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->