### PR TITLE
feat(download): fall back to presigned urls after a second slow abort

### DIFF
--- a/src/main/lib/download.test.ts
+++ b/src/main/lib/download.test.ts
@@ -8,20 +8,55 @@ import type { NahidaDesktop } from "..";
 import type { DownloadMetadata } from "./download";
 
 import { BandwidthLimiter } from "./bandwidth-limiter";
-import { DownloadLib } from "./download";
+import { DownloadHttpError, DownloadLib } from "./download";
 import { SlowChunkMonitor } from "./slow-chunk-monitor";
 
 const mocks = vi.hoisted(() => ({
     request: vi.fn(),
+    fetchPresignedUrl: vi.fn(),
 }));
 
 vi.mock("@main/client", () => ({
-    eden: {},
+    eden: {
+        akasha: {
+            file: {
+                download: {
+                    get: mocks.fetchPresignedUrl,
+                },
+            },
+        },
+    },
 }));
 
 vi.mock("ky", () => ({
     default: mocks.request,
 }));
+
+vi.mock("./slow-chunk-monitor", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("./slow-chunk-monitor")>();
+    return {
+        ...actual,
+        slowReconnectDelayMs: () => 0,
+    };
+});
+
+function waitForSlowAbort(signal: AbortSignal) {
+    return new Promise<never>((_resolve, reject) => {
+        if (signal.aborted) {
+            reject(signal.reason ?? new DOMException("The operation was aborted.", "AbortError"));
+            return;
+        }
+        signal.addEventListener(
+            "abort",
+            () => {
+                reject(
+                    signal.reason ?? new DOMException("The operation was aborted.", "AbortError"),
+                );
+            },
+            { once: true },
+        );
+    });
+}
 
 type DownloadTask = {
     performDownload: (
@@ -31,12 +66,16 @@ type DownloadTask = {
         options?: {
             onResumeReset?: () => void;
             resumeFrom?: number;
+            attachLinkToken?: boolean;
+            onProgress?: (bytes: number) => void;
+            link?: { linkId: string; token: string };
         },
     ) => Promise<void>;
     executeWithSlowRetry: (input: {
         file: DownloadMetadata["files"][number];
         filePath: string;
         signal: AbortSignal;
+        link?: { linkId: string; token: string };
         onComplete: () => void;
         onProgress?: (bytes: number) => void;
     }) => Promise<void>;
@@ -90,6 +129,7 @@ describe("FileDownloadTask range handling", () => {
 
     beforeEach(async () => {
         mocks.request.mockReset();
+        mocks.fetchPresignedUrl.mockReset();
         tempDir = await mkdtemp(path.join(os.tmpdir(), "nahida-download-test-"));
     });
 
@@ -212,6 +252,25 @@ describe("FileDownloadTask range handling", () => {
         expect(mocks.request).toHaveBeenCalledTimes(1);
     });
 
+    it("omits the link token when attachLinkToken is false", async () => {
+        const targetPath = path.join(tempDir, "file.bin.ntmp");
+        mocks.request.mockResolvedValue(new Response("complete", { status: 200 }));
+        const desktop = createDesktop();
+        const task = (new DownloadLib(desktop) as unknown as { task: DownloadTask }).task;
+
+        await task.performDownload(file, targetPath, new AbortController().signal, {
+            link: { linkId: "link-1", token: "link-token" },
+            attachLinkToken: false,
+        });
+
+        expect(mocks.request).toHaveBeenCalledWith(
+            file.url,
+            expect.objectContaining({
+                headers: { Authorization: "Bearer token" },
+            }),
+        );
+    });
+
     it("deletes the temp file and returns zero for compressed files", async () => {
         const targetPath = path.join(tempDir, "file.bin.ntmp");
         await writeFile(targetPath, "stale-gzip");
@@ -231,6 +290,11 @@ describe("FileDownloadTask executeWithSlowRetry progress correction", () => {
 
     beforeEach(async () => {
         mocks.request.mockReset();
+        mocks.fetchPresignedUrl.mockReset();
+        mocks.fetchPresignedUrl.mockResolvedValue({
+            data: { url: "https://r2.test/signed" },
+            error: null,
+        });
         tempDir = await mkdtemp(path.join(os.tmpdir(), "nahida-download-test-"));
     });
 
@@ -351,6 +415,175 @@ describe("FileDownloadTask executeWithSlowRetry progress correction", () => {
 
         expect(recordSample).toHaveBeenCalledWith(expect.any(String), 100);
         recordSample.mockRestore();
+    });
+
+    it("keeps the original url through the first slow reconnect then switches to a presigned url", async () => {
+        const filePath = path.join(tempDir, "file.bin");
+        const targetPath = `${filePath}.ntmp`;
+        await writeFile(targetPath, "hello");
+        const slowFile = {
+            ...file,
+            size: 11,
+            url: "https://n1.nahida.live/fil/file.bin",
+        };
+        const desktop = createDesktop();
+        const task = (new DownloadLib(desktop) as unknown as { task: DownloadTask }).task;
+        const registered: Array<{ abortSlow: () => void }> = [];
+        const register = vi.spyOn(slowChunkMonitor, "register").mockImplementation((input) => {
+            const transfer = {
+                key: `transfer-${registered.length}`,
+                abortReason: null as "slow-chunk" | null,
+                detect: null as "stall" | null,
+                chunkSpeedBps: 0,
+                peerMedianBps: 0,
+            };
+            registered.push({
+                abortSlow: () => {
+                    transfer.abortReason = "slow-chunk";
+                    transfer.detect = "stall";
+                    input.attemptController.abort();
+                },
+            });
+            return transfer as never;
+        });
+        const performDownload = vi.spyOn(task, "performDownload");
+        performDownload
+            .mockImplementationOnce(async (_file, _target, signal, options) => {
+                options?.onProgress?.(3);
+                await waitForSlowAbort(signal);
+            })
+            .mockImplementationOnce(async (_file, _target, signal, options) => {
+                options?.onProgress?.(3);
+                await waitForSlowAbort(signal);
+            })
+            .mockImplementationOnce(async (currentFile, currentTarget, _signal, options) => {
+                expect(currentFile.url).toBe("https://r2.test/signed");
+                expect(currentFile.urlOrigin).toBe("presign");
+                expect(currentTarget).toBe(targetPath);
+                expect(options?.resumeFrom).toBe(5);
+                expect(options?.attachLinkToken).toBe(false);
+                await writeFile(currentTarget, "hello world");
+            });
+
+        const run = task.executeWithSlowRetry({
+            file: slowFile,
+            filePath,
+            signal: new AbortController().signal,
+            link: { linkId: "link-1", token: "link-token" },
+            onComplete: vi.fn(),
+        });
+
+        await vi.waitFor(() => expect(performDownload).toHaveBeenCalledTimes(1));
+        registered[0]?.abortSlow();
+        await vi.waitFor(() => expect(performDownload).toHaveBeenCalledTimes(2));
+        expect(slowFile.url).toBe("https://n1.nahida.live/fil/file.bin");
+        expect(slowFile.urlOrigin).toBeUndefined();
+        expect(mocks.fetchPresignedUrl).not.toHaveBeenCalled();
+        expect(register).toHaveBeenNthCalledWith(2, expect.objectContaining({ slowReconnects: 1 }));
+
+        registered[1]?.abortSlow();
+        await vi.waitFor(() => expect(performDownload).toHaveBeenCalledTimes(3));
+        await run;
+
+        expect(slowFile.url).toBe("https://r2.test/signed");
+        expect(slowFile.urlOrigin).toBe("presign");
+        expect(mocks.fetchPresignedUrl).toHaveBeenCalledWith({
+            query: {
+                uuid: "file-id",
+                presign: true,
+                linkId: "link-1",
+            },
+            headers: { "nhd-link-token": "link-token" },
+            fetch: { signal: expect.any(AbortSignal) },
+        });
+        expect(performDownload).toHaveBeenNthCalledWith(
+            3,
+            slowFile,
+            targetPath,
+            expect.any(AbortSignal),
+            expect.objectContaining({
+                attachLinkToken: false,
+                resumeFrom: 5,
+            }),
+        );
+
+        register.mockRestore();
+        performDownload.mockRestore();
+    });
+
+    it("refreshes an expired presigned url once after a 403", async () => {
+        const filePath = path.join(tempDir, "file.bin");
+        const targetPath = `${filePath}.ntmp`;
+        await writeFile(targetPath, "hello");
+        const slowFile = {
+            ...file,
+            size: 11,
+            url: "https://n1.nahida.live/fil/file.bin",
+        };
+        mocks.fetchPresignedUrl
+            .mockResolvedValueOnce({
+                data: { url: "https://r2.test/signed-1" },
+                error: null,
+            })
+            .mockResolvedValueOnce({
+                data: { url: "https://r2.test/signed-2" },
+                error: null,
+            });
+        const desktop = createDesktop();
+        const task = (new DownloadLib(desktop) as unknown as { task: DownloadTask }).task;
+        const registered: Array<{ abortSlow: () => void }> = [];
+        const register = vi.spyOn(slowChunkMonitor, "register").mockImplementation((input) => {
+            const transfer = {
+                key: `transfer-${registered.length}`,
+                abortReason: null as "slow-chunk" | null,
+                detect: null,
+                chunkSpeedBps: 0,
+                peerMedianBps: 0,
+            };
+            registered.push({
+                abortSlow: () => {
+                    transfer.abortReason = "slow-chunk";
+                    input.attemptController.abort();
+                },
+            });
+            return transfer as never;
+        });
+        const performDownload = vi.spyOn(task, "performDownload");
+        performDownload
+            .mockImplementationOnce(async (_file, _target, signal) => {
+                await waitForSlowAbort(signal);
+            })
+            .mockImplementationOnce(async (_file, _target, signal) => {
+                await waitForSlowAbort(signal);
+            })
+            .mockRejectedValueOnce(new DownloadHttpError(403, "Forbidden"))
+            .mockImplementationOnce(async (currentFile, currentTarget, _signal, options) => {
+                expect(currentFile.url).toBe("https://r2.test/signed-2");
+                expect(currentFile.urlOrigin).toBe("presign");
+                expect(options?.resumeFrom).toBe(5);
+                await writeFile(currentTarget, "hello world");
+            });
+
+        const run = task.executeWithSlowRetry({
+            file: slowFile,
+            filePath,
+            signal: new AbortController().signal,
+            onComplete: vi.fn(),
+        });
+
+        for (const expectedCalls of [1, 2]) {
+            await vi.waitFor(() => expect(performDownload).toHaveBeenCalledTimes(expectedCalls));
+            registered[expectedCalls - 1]?.abortSlow();
+        }
+
+        await vi.waitFor(() => expect(performDownload).toHaveBeenCalledTimes(4));
+        await run;
+
+        expect(slowFile.url).toBe("https://r2.test/signed-2");
+        expect(slowFile.urlOrigin).toBe("presign");
+        expect(mocks.fetchPresignedUrl).toHaveBeenCalledTimes(2);
+        register.mockRestore();
+        performDownload.mockRestore();
     });
 });
 

--- a/src/main/lib/download.test.ts
+++ b/src/main/lib/download.test.ts
@@ -37,6 +37,11 @@ vi.mock("./slow-chunk-monitor", async (importOriginal) => {
     return {
         ...actual,
         slowReconnectDelayMs: () => 0,
+        sleepWithAbort: async (_ms: number, signal: AbortSignal) => {
+            if (signal.aborted) {
+                throw new DOMException("The operation was aborted.", "AbortError");
+            }
+        },
     };
 });
 
@@ -583,6 +588,48 @@ describe("FileDownloadTask executeWithSlowRetry progress correction", () => {
         expect(slowFile.urlOrigin).toBe("presign");
         expect(mocks.fetchPresignedUrl).toHaveBeenCalledTimes(2);
         register.mockRestore();
+        performDownload.mockRestore();
+    });
+
+    it("retries expired presign refresh after a transient fetch failure", async () => {
+        const filePath = path.join(tempDir, "file.bin");
+        const targetPath = `${filePath}.ntmp`;
+        await writeFile(targetPath, "hello");
+        const expiredFile = {
+            ...file,
+            size: 11,
+            url: "https://r2.test/expired",
+            urlOrigin: "presign" as const,
+        };
+        mocks.fetchPresignedUrl
+            .mockRejectedValueOnce(new Error("temporary network error"))
+            .mockResolvedValueOnce({
+                data: { url: "https://r2.test/signed-fresh" },
+                error: null,
+            });
+        const desktop = createDesktop();
+        const task = (new DownloadLib(desktop) as unknown as { task: DownloadTask }).task;
+        const performDownload = vi.spyOn(task, "performDownload");
+        performDownload
+            .mockRejectedValueOnce(new DownloadHttpError(403, "Forbidden"))
+            .mockRejectedValueOnce(new DownloadHttpError(403, "Forbidden"))
+            .mockImplementationOnce(async (currentFile, currentTarget, _signal, options) => {
+                expect(currentFile.url).toBe("https://r2.test/signed-fresh");
+                expect(currentFile.urlOrigin).toBe("presign");
+                expect(options?.resumeFrom).toBe(5);
+                await writeFile(currentTarget, "hello world");
+            });
+
+        await task.executeWithSlowRetry({
+            file: expiredFile,
+            filePath,
+            signal: new AbortController().signal,
+            onComplete: vi.fn(),
+        });
+
+        expect(expiredFile.url).toBe("https://r2.test/signed-fresh");
+        expect(mocks.fetchPresignedUrl).toHaveBeenCalledTimes(2);
+        expect(performDownload).toHaveBeenCalledTimes(3);
         performDownload.mockRestore();
     });
 });

--- a/src/main/lib/download.test.ts
+++ b/src/main/lib/download.test.ts
@@ -305,6 +305,7 @@ describe("FileDownloadTask executeWithSlowRetry progress correction", () => {
 
     afterEach(async () => {
         await rm(tempDir, { recursive: true, force: true });
+        vi.restoreAllMocks();
     });
 
     it("reports resume delta across multiple failed attempts", async () => {
@@ -451,22 +452,41 @@ describe("FileDownloadTask executeWithSlowRetry progress correction", () => {
             });
             return transfer as never;
         });
+        const captured: Array<{
+            url: string;
+            urlOrigin?: "cdn" | "presign";
+            resumeFrom?: number;
+            attachLinkToken?: boolean;
+        }> = [];
         const performDownload = vi.spyOn(task, "performDownload");
         performDownload
-            .mockImplementationOnce(async (_file, _target, signal, options) => {
+            .mockImplementationOnce(async (currentFile, _target, signal, options) => {
+                captured.push({
+                    url: currentFile.url,
+                    urlOrigin: currentFile.urlOrigin,
+                    resumeFrom: options?.resumeFrom,
+                    attachLinkToken: options?.attachLinkToken,
+                });
                 options?.onProgress?.(3);
                 await waitForSlowAbort(signal);
             })
-            .mockImplementationOnce(async (_file, _target, signal, options) => {
+            .mockImplementationOnce(async (currentFile, _target, signal, options) => {
+                captured.push({
+                    url: currentFile.url,
+                    urlOrigin: currentFile.urlOrigin,
+                    resumeFrom: options?.resumeFrom,
+                    attachLinkToken: options?.attachLinkToken,
+                });
                 options?.onProgress?.(3);
                 await waitForSlowAbort(signal);
             })
             .mockImplementationOnce(async (currentFile, currentTarget, _signal, options) => {
-                expect(currentFile.url).toBe("https://r2.test/signed");
-                expect(currentFile.urlOrigin).toBe("presign");
-                expect(currentTarget).toBe(targetPath);
-                expect(options?.resumeFrom).toBe(5);
-                expect(options?.attachLinkToken).toBe(false);
+                captured.push({
+                    url: currentFile.url,
+                    urlOrigin: currentFile.urlOrigin,
+                    resumeFrom: options?.resumeFrom,
+                    attachLinkToken: options?.attachLinkToken,
+                });
                 await writeFile(currentTarget, "hello world");
             });
 
@@ -501,19 +521,26 @@ describe("FileDownloadTask executeWithSlowRetry progress correction", () => {
             headers: { "nhd-link-token": "link-token" },
             fetch: { signal: expect.any(AbortSignal) },
         });
-        expect(performDownload).toHaveBeenNthCalledWith(
-            3,
-            slowFile,
-            targetPath,
-            expect.any(AbortSignal),
-            expect.objectContaining({
-                attachLinkToken: false,
+        expect(captured).toEqual([
+            {
+                url: "https://n1.nahida.live/fil/file.bin",
+                urlOrigin: undefined,
                 resumeFrom: 5,
-            }),
-        );
-
-        register.mockRestore();
-        performDownload.mockRestore();
+                attachLinkToken: true,
+            },
+            {
+                url: "https://n1.nahida.live/fil/file.bin",
+                urlOrigin: undefined,
+                resumeFrom: 5,
+                attachLinkToken: true,
+            },
+            {
+                url: "https://r2.test/signed",
+                urlOrigin: "presign",
+                resumeFrom: 5,
+                attachLinkToken: false,
+            },
+        ]);
     });
 
     it("refreshes an expired presigned url once after a 403", async () => {
@@ -537,7 +564,7 @@ describe("FileDownloadTask executeWithSlowRetry progress correction", () => {
         const desktop = createDesktop();
         const task = (new DownloadLib(desktop) as unknown as { task: DownloadTask }).task;
         const registered: Array<{ abortSlow: () => void }> = [];
-        const register = vi.spyOn(slowChunkMonitor, "register").mockImplementation((input) => {
+        vi.spyOn(slowChunkMonitor, "register").mockImplementation((input) => {
             const transfer = {
                 key: `transfer-${registered.length}`,
                 abortReason: null as "slow-chunk" | null,
@@ -553,19 +580,36 @@ describe("FileDownloadTask executeWithSlowRetry progress correction", () => {
             });
             return transfer as never;
         });
+        const captured: Array<{
+            url: string;
+            urlOrigin?: "cdn" | "presign";
+            resumeFrom?: number;
+        }> = [];
         const performDownload = vi.spyOn(task, "performDownload");
         performDownload
-            .mockImplementationOnce(async (_file, _target, signal) => {
+            .mockImplementationOnce(async (currentFile, _target, signal, options) => {
+                captured.push({
+                    url: currentFile.url,
+                    urlOrigin: currentFile.urlOrigin,
+                    resumeFrom: options?.resumeFrom,
+                });
                 await waitForSlowAbort(signal);
             })
-            .mockImplementationOnce(async (_file, _target, signal) => {
+            .mockImplementationOnce(async (currentFile, _target, signal, options) => {
+                captured.push({
+                    url: currentFile.url,
+                    urlOrigin: currentFile.urlOrigin,
+                    resumeFrom: options?.resumeFrom,
+                });
                 await waitForSlowAbort(signal);
             })
             .mockRejectedValueOnce(new DownloadHttpError(403, "Forbidden"))
             .mockImplementationOnce(async (currentFile, currentTarget, _signal, options) => {
-                expect(currentFile.url).toBe("https://r2.test/signed-2");
-                expect(currentFile.urlOrigin).toBe("presign");
-                expect(options?.resumeFrom).toBe(5);
+                captured.push({
+                    url: currentFile.url,
+                    urlOrigin: currentFile.urlOrigin,
+                    resumeFrom: options?.resumeFrom,
+                });
                 await writeFile(currentTarget, "hello world");
             });
 
@@ -587,8 +631,23 @@ describe("FileDownloadTask executeWithSlowRetry progress correction", () => {
         expect(slowFile.url).toBe("https://r2.test/signed-2");
         expect(slowFile.urlOrigin).toBe("presign");
         expect(mocks.fetchPresignedUrl).toHaveBeenCalledTimes(2);
-        register.mockRestore();
-        performDownload.mockRestore();
+        expect(captured).toEqual([
+            {
+                url: "https://n1.nahida.live/fil/file.bin",
+                urlOrigin: undefined,
+                resumeFrom: 5,
+            },
+            {
+                url: "https://n1.nahida.live/fil/file.bin",
+                urlOrigin: undefined,
+                resumeFrom: 5,
+            },
+            {
+                url: "https://r2.test/signed-2",
+                urlOrigin: "presign",
+                resumeFrom: 5,
+            },
+        ]);
     });
 
     it("retries expired presign refresh after a transient fetch failure", async () => {

--- a/src/main/lib/download.ts
+++ b/src/main/lib/download.ts
@@ -804,7 +804,6 @@ class FileDownloadTask {
                         urlOrigin === "presign" &&
                         !refreshedExpiredPresign
                     ) {
-                        refreshedExpiredPresign = true;
                         const nextUrl = await this.fetchPresignedDownloadUrl({
                             fileId: file.id,
                             link,
@@ -814,6 +813,7 @@ class FileDownloadTask {
                             return null;
                         });
                         if (nextUrl) {
+                            refreshedExpiredPresign = true;
                             file.url = nextUrl;
                             file.urlOrigin = "presign";
                             this.desktop.logger.warn(

--- a/src/main/lib/download.ts
+++ b/src/main/lib/download.ts
@@ -53,6 +53,7 @@ export type DownloadMetadata = {
         size: number;
         compAlg: "gzip" | "zstd" | null;
         url: string;
+        urlOrigin?: "cdn" | "presign";
     }>;
     dirs: Array<{
         id: string;
@@ -64,6 +65,21 @@ export type DownloadMetadata = {
 export const BATCH_ROOT_ID = "batch-root";
 const FILE_ID_BATCH_LIMIT = 100;
 const PARALLEL_DOWNLOAD_THRESHOLD = 20 * 1024 * 1024;
+
+export class DownloadHttpError extends Error {
+    readonly status: number;
+
+    constructor(status: number, statusText: string) {
+        super(`Download failed: ${statusText}`);
+        this.name = "DownloadHttpError";
+        this.status = status;
+    }
+}
+
+function isDownloadHttpError(error: unknown, status?: number) {
+    if (!(error instanceof DownloadHttpError)) return false;
+    return status === undefined || error.status === status;
+}
 
 function isExpectedContentRange(value: string | null, resumeFrom: number, fileSize: number) {
     const match = /^bytes\s+(\d+)-(\d+)\/(\d+)$/i.exec(value ?? "");
@@ -491,15 +507,17 @@ class FileDownloadTask {
                 phase: Extract<SlowChunkTransferPhase, "network" | "bandwidth-wait">,
             ) => void;
             link?: LinkData;
+            attachLinkToken?: boolean;
             networkContext?: ReturnType<typeof createDownloadNetworkContext>;
             onResumeReset?: () => void;
             resumeFrom?: number;
         },
     ): Promise<void> {
         const baseHeaders = await this.desktop.httpService.getHeaders(file.url);
-        const linkHeaders: Record<string, string> = options?.link
-            ? { "nhd-link-token": options.link.token }
-            : {};
+        const linkHeaders: Record<string, string> =
+            options?.link && options.attachLinkToken !== false
+                ? { "nhd-link-token": options.link.token }
+                : {};
         const headers = { ...baseHeaders, ...linkHeaders } as Record<string, string>;
         const resumeFrom = options?.resumeFrom ?? 0;
 
@@ -531,7 +549,7 @@ class FileDownloadTask {
 
             if (!response.ok) {
                 await drainWebStream(response.body, signal);
-                throw new Error(`Download failed: ${response.statusText}`);
+                throw new DownloadHttpError(response.status, response.statusText);
             }
 
             if (append && response.status !== 206) {
@@ -556,7 +574,7 @@ class FileDownloadTask {
 
                 if (!response.ok) {
                     await drainWebStream(response.body, signal);
-                    throw new Error(`Download failed: ${response.statusText}`);
+                    throw new DownloadHttpError(response.status, response.statusText);
                 }
             }
 
@@ -646,10 +664,27 @@ class FileDownloadTask {
 
         let slowReconnects = 0;
         let errorRetries = 0;
+        let urlOrigin: "cdn" | "presign" = file.urlOrigin ?? "cdn";
+        let refreshedExpiredPresign = false;
         let reportedResumeBytes = await this.getResumeOffset(file, targetPath);
         const networkContext = createDownloadNetworkContext();
 
         if (reportedResumeBytes > 0) onProgress?.(reportedResumeBytes);
+
+        const resetAndWait = async (reconnect: number) => {
+            await networkContext.resetConnections().catch((error) => {
+                this.desktop.logger.warn(
+                    {
+                        fileId: file.id,
+                        fileName: file.name,
+                        reconnect,
+                        error: toErrorMessage(error),
+                    },
+                    "FileDownloadTask:resetConnectionsFailed",
+                );
+            });
+            await sleepWithAbort(slowReconnectDelayMs(), signal);
+        };
 
         try {
             while (true) {
@@ -676,6 +711,7 @@ class FileDownloadTask {
 
                     await this.performDownload(file, targetPath, combinedSignal, {
                         link,
+                        attachLinkToken: urlOrigin === "cdn",
                         networkContext,
                         resumeFrom,
                         onProgress: (bytes) => {
@@ -698,7 +734,8 @@ class FileDownloadTask {
                     await this.desktop.lib.fs.rename(targetPath, filePath);
                     onComplete();
                     return;
-                } catch (err) {
+                } catch (caught) {
+                    let err = caught;
                     const persistedBytes = await this.getResumeOffset(file, targetPath);
                     const progressCorrection = persistedBytes - reportedResumeBytes;
                     if (progressCorrection !== 0) onProgress?.(progressCorrection);
@@ -708,38 +745,89 @@ class FileDownloadTask {
                         throw err;
                     }
 
-                    if (
-                        transfer.abortReason === "slow-chunk" &&
-                        slowReconnects < SLOW_CHUNK_MAX_RECONNECTS
-                    ) {
-                        slowReconnects += 1;
-                        this.desktop.logger.warn(
-                            {
+                    if (transfer.abortReason === "slow-chunk") {
+                        if (urlOrigin === "cdn" && slowReconnects > 0) {
+                            const nextUrl = await this.fetchPresignedDownloadUrl({
                                 fileId: file.id,
-                                fileName: file.name,
-                                detect: transfer.detect,
-                                speedBps: transfer.chunkSpeedBps,
-                                peerMedianBps: transfer.peerMedianBps,
-                                remainingBytes: Math.max(0, file.size - reportedResumeBytes),
-                                resumeFrom: reportedResumeBytes,
-                                reconnect: slowReconnects,
-                                url: getSafeUrlResource(file.url),
-                            },
-                            "FileDownloadTask:slowChunk",
-                        );
-                        await networkContext.resetConnections().catch((error) => {
+                                link,
+                                signal,
+                            }).catch((presignErr: unknown) => {
+                                err = presignErr;
+                                return null;
+                            });
+                            if (nextUrl) {
+                                file.url = nextUrl;
+                                file.urlOrigin = "presign";
+                                urlOrigin = "presign";
+                                slowReconnects = 0;
+                                this.desktop.logger.warn(
+                                    {
+                                        fileId: file.id,
+                                        fileName: file.name,
+                                        remainingBytes: Math.max(
+                                            0,
+                                            file.size - reportedResumeBytes,
+                                        ),
+                                        resumeFrom: reportedResumeBytes,
+                                        url: getSafeUrlResource(file.url),
+                                    },
+                                    "FileDownloadTask:presignFallback",
+                                );
+                                await resetAndWait(0);
+                                continue;
+                            }
+                        }
+
+                        if (slowReconnects < SLOW_CHUNK_MAX_RECONNECTS) {
+                            slowReconnects += 1;
                             this.desktop.logger.warn(
                                 {
                                     fileId: file.id,
                                     fileName: file.name,
+                                    detect: transfer.detect,
+                                    speedBps: transfer.chunkSpeedBps,
+                                    peerMedianBps: transfer.peerMedianBps,
+                                    remainingBytes: Math.max(0, file.size - reportedResumeBytes),
+                                    resumeFrom: reportedResumeBytes,
                                     reconnect: slowReconnects,
-                                    error: toErrorMessage(error),
+                                    url: getSafeUrlResource(file.url),
                                 },
-                                "FileDownloadTask:resetConnectionsFailed",
+                                "FileDownloadTask:slowChunk",
                             );
+                            await resetAndWait(slowReconnects);
+                            continue;
+                        }
+                    }
+
+                    if (
+                        isDownloadHttpError(err, 403) &&
+                        urlOrigin === "presign" &&
+                        !refreshedExpiredPresign
+                    ) {
+                        refreshedExpiredPresign = true;
+                        const nextUrl = await this.fetchPresignedDownloadUrl({
+                            fileId: file.id,
+                            link,
+                            signal,
+                        }).catch((presignErr: unknown) => {
+                            err = presignErr;
+                            return null;
                         });
-                        await sleepWithAbort(slowReconnectDelayMs(), signal);
-                        continue;
+                        if (nextUrl) {
+                            file.url = nextUrl;
+                            file.urlOrigin = "presign";
+                            this.desktop.logger.warn(
+                                {
+                                    fileId: file.id,
+                                    fileName: file.name,
+                                    resumeFrom: reportedResumeBytes,
+                                    url: getSafeUrlResource(file.url),
+                                },
+                                "FileDownloadTask:presignRefresh",
+                            );
+                            await resetAndWait(slowReconnects);
+                            continue;
+                        }
                     }
 
                     if (!isAbortError(err) && errorRetries < MAX_ERROR_RETRIES) {
@@ -761,6 +849,33 @@ class FileDownloadTask {
         } finally {
             networkContext.release();
         }
+    }
+
+    private async fetchPresignedDownloadUrl({
+        fileId,
+        link,
+        signal,
+    }: {
+        fileId: string;
+        link?: LinkData;
+        signal: AbortSignal;
+    }) {
+        const { data, error } = await eden.akasha.file.download.get({
+            query: {
+                uuid: fileId,
+                presign: true,
+                ...(link && { linkId: link.linkId }),
+            },
+            ...(link && {
+                headers: { "nhd-link-token": link.token },
+            }),
+            fetch: { signal },
+        });
+        if (error) throw error;
+        if (!data || typeof data !== "object" || !("url" in data) || typeof data.url !== "string") {
+            throw new Error("Presigned download URL not received.");
+        }
+        return data.url;
     }
 }
 

--- a/src/main/lib/download.ts
+++ b/src/main/lib/download.ts
@@ -70,7 +70,7 @@ export class DownloadHttpError extends Error {
     readonly status: number;
 
     constructor(status: number, statusText: string) {
-        super(`Download failed: ${statusText}`);
+        super(`Download failed: ${status}${statusText ? ` ${statusText}` : ""}`);
         this.name = "DownloadHttpError";
         this.status = status;
     }
@@ -747,7 +747,7 @@ class FileDownloadTask {
 
                     if (transfer.abortReason === "slow-chunk") {
                         if (urlOrigin === "cdn" && slowReconnects > 0) {
-                            const nextUrl = await this.fetchPresignedDownloadUrl({
+                            const freshUrl = await this.fetchPresignedDownloadUrl({
                                 fileId: file.id,
                                 link,
                                 signal,
@@ -755,8 +755,8 @@ class FileDownloadTask {
                                 err = presignErr;
                                 return null;
                             });
-                            if (nextUrl) {
-                                file.url = nextUrl;
+                            if (freshUrl) {
+                                file.url = freshUrl;
                                 file.urlOrigin = "presign";
                                 urlOrigin = "presign";
                                 slowReconnects = 0;
@@ -769,7 +769,7 @@ class FileDownloadTask {
                                             file.size - reportedResumeBytes,
                                         ),
                                         resumeFrom: reportedResumeBytes,
-                                        url: getSafeUrlResource(file.url),
+                                        url: getSafeUrlResource(freshUrl),
                                     },
                                     "FileDownloadTask:presignFallback",
                                 );
@@ -804,7 +804,7 @@ class FileDownloadTask {
                         urlOrigin === "presign" &&
                         !refreshedExpiredPresign
                     ) {
-                        const nextUrl = await this.fetchPresignedDownloadUrl({
+                        const freshUrl = await this.fetchPresignedDownloadUrl({
                             fileId: file.id,
                             link,
                             signal,
@@ -812,16 +812,16 @@ class FileDownloadTask {
                             err = presignErr;
                             return null;
                         });
-                        if (nextUrl) {
+                        if (freshUrl) {
                             refreshedExpiredPresign = true;
-                            file.url = nextUrl;
+                            file.url = freshUrl;
                             file.urlOrigin = "presign";
                             this.desktop.logger.warn(
                                 {
                                     fileId: file.id,
                                     fileName: file.name,
                                     resumeFrom: reportedResumeBytes,
-                                    url: getSafeUrlResource(file.url),
+                                    url: getSafeUrlResource(freshUrl),
                                 },
                                 "FileDownloadTask:presignRefresh",
                             );
@@ -871,7 +871,15 @@ class FileDownloadTask {
             }),
             fetch: { signal },
         });
-        if (error) throw error;
+        if (error) {
+            if (typeof error === "object" && error !== null && "value" in error) {
+                const innerError = (error as { value?: unknown }).value;
+                if (isAbortError(innerError)) {
+                    throw innerError;
+                }
+            }
+            throw error;
+        }
         if (!data || typeof data !== "object" || !("url" in data) || typeof data.url !== "string") {
             throw new Error("Presigned download URL not received.");
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core download retry and URL/auth header behavior for transfers; scope is localized to download.ts with substantial test coverage but failures could still affect user file delivery.
> 
> **Overview**
> Improves **slow-download recovery** in `FileDownloadTask.executeWithSlowRetry` by tracking whether each file is fetched from the **CDN** or a **presigned** URL (`urlOrigin`), and switching strategies when transfers keep stalling or links expire.
> 
> After a **second slow-chunk abort** on the CDN, the task requests a presigned URL via `eden.akasha.file.download.get` (with link token on that API call only), updates `file.url`, and resumes without attaching `nhd-link-token` on the actual download. **403** responses on presigned URLs trigger a **one-time** presign refresh, with retries if the refresh request fails transiently.
> 
> HTTP failures now raise **`DownloadHttpError`** with status codes instead of generic errors, and **`performDownload`** honors **`attachLinkToken: false`** so presigned fetches do not send link headers. Tests cover CDN→presign fallback, 403 refresh, transient presign errors, and omitted link tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ce6e4cb1b6806beb2212c1d9e45bb8ac8198e9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download reliability by switching to alternate secure URLs when CDN transfers repeatedly stall.
  * Automatically refreshes expired download links after authorization errors.
  * Preserves download error status information for clearer failure handling.
  * Refined retry and connection-reset behavior for slow or interrupted downloads.
* **Tests**
  * Added coverage for secure URL fallback, expired-link refreshes, omitted link tokens, and transient retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->