### PR TITLE
fix(tools): align texture resize result types

### DIFF
--- a/src/main/services/mod-tools/texture-resizer.test.ts
+++ b/src/main/services/mod-tools/texture-resizer.test.ts
@@ -14,7 +14,7 @@ vi.mock("./realesrgan-runtime", () => ({
 
 import type { NahidaDesktop } from "@main/index";
 import { resizeTextures } from "@native/mod-tools";
-import type { TextureResizeResult, TextureResizeSettings } from "@shared/types";
+import type { TextureResizeSettings } from "@shared/types";
 
 import {
     TextureResizer,
@@ -47,7 +47,7 @@ function deferred<T>() {
     return { promise, resolve, reject };
 }
 
-function resizeResult(targetPath: string): TextureResizeResult {
+function resizeResult(targetPath: string): Awaited<ReturnType<typeof resizeTextures>> {
     return {
         targetPath,
         processed: 1,
@@ -194,8 +194,8 @@ describe("texture resizer progress ownership", () => {
 
     it("keeps running state when a later resizeFile finishes first", async () => {
         const { resizer, broadcast } = createResizer();
-        const first = deferred<TextureResizeResult>();
-        const second = deferred<TextureResizeResult>();
+        const first = deferred<Awaited<ReturnType<typeof resizeTextures>>>();
+        const second = deferred<Awaited<ReturnType<typeof resizeTextures>>>();
         const firstPath = "/tmp/first.dds";
         const secondPath = "/tmp/second.dds";
 
@@ -256,8 +256,8 @@ describe("texture resizer progress ownership", () => {
 
     it("does not idle after a failed resize while another job is in flight", async () => {
         const { resizer, broadcast } = createResizer();
-        const first = deferred<TextureResizeResult>();
-        const second = deferred<TextureResizeResult>();
+        const first = deferred<Awaited<ReturnType<typeof resizeTextures>>>();
+        const second = deferred<Awaited<ReturnType<typeof resizeTextures>>>();
         const firstPath = "/tmp/first.dds";
         const secondPath = "/tmp/second.dds";
 
@@ -303,8 +303,8 @@ describe("texture resizer progress ownership", () => {
 
     it("keeps folder resize activity when a file resize finishes first", async () => {
         const { resizer } = createResizer();
-        const folder = deferred<TextureResizeResult>();
-        const file = deferred<TextureResizeResult>();
+        const folder = deferred<Awaited<ReturnType<typeof resizeTextures>>>();
+        const file = deferred<Awaited<ReturnType<typeof resizeTextures>>>();
         const folderPath = "/tmp/mod-folder";
         const filePath = "/tmp/dialog.dds";
 

--- a/src/main/services/mod-tools/texture-resizer.ts
+++ b/src/main/services/mod-tools/texture-resizer.ts
@@ -11,6 +11,7 @@ import type {
     TextureResizeListItem,
     TextureResizeOperation,
     TextureResizeProgressEvent,
+    TextureResizeResult,
     TextureResizeRunInput,
     TextureResizeSettings,
     TextureUpscaleModel,
@@ -425,7 +426,7 @@ export class TextureResizer {
         );
     }
 
-    public async resizeFile(input: TextureResizeFileRunInput) {
+    public async resizeFile(input: TextureResizeFileRunInput): Promise<TextureResizeResult> {
         const filePath = input.filePath?.trim();
         if (!filePath) {
             throw new Error("File path is required.");
@@ -446,7 +447,9 @@ export class TextureResizer {
             () =>
                 isTextureUpscaleOperation(settings.operation)
                     ? this.upscaleFile(resolvedPath, settings)
-                    : resizeTextures(buildResizeRequest(resolvedPath, settings)),
+                    : toSharedTextureResizeResult(
+                          resizeTextures(buildResizeRequest(resolvedPath, settings)),
+                      ),
             () => ({
                 ...running,
                 status: "completed",
@@ -463,7 +466,10 @@ export class TextureResizer {
         await this.desktop.lib.db.settings.upsert(key, value);
     }
 
-    private async upscaleFile(filePath: string, settings: TextureResizeSettings) {
+    private async upscaleFile(
+        filePath: string,
+        settings: TextureResizeSettings,
+    ): Promise<TextureResizeResult> {
         const buffer = await fse.readFile(filePath);
         const info = parseDDSMetadata(buffer);
         const skipReason = resolveUpscaleSkipReason(info, settings.upscaleScale);
@@ -817,6 +823,20 @@ function buildResizeRequest(targetPath: string, settings: TextureResizeSettings)
         customHeight: settings.customHeight,
         outputFormat: settings.outputFormat,
         backup: settings.backup,
+    };
+}
+
+async function toSharedTextureResizeResult(
+    result: ReturnType<typeof resizeTextures>,
+): Promise<TextureResizeResult> {
+    const nativeResult = await result;
+    return {
+        ...nativeResult,
+        files: nativeResult.files.map((file) => ({
+            ...file,
+            status: file.status as TextureResizeFileResult["status"],
+            message: file.message ?? null,
+        })),
     };
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Type-boundary normalization with no intended runtime behavior change beyond consistent result shaping for callers.
> 
> **Overview**
> **Aligns single-file texture resize return values with shared `TextureResizeResult` types** instead of leaking the native `resizeTextures` shape.
> 
> `resizeFile` and `upscaleFile` are now explicitly typed to return `TextureResizeResult`. Non-upscale file runs pass native `resizeTextures` output through **`toSharedTextureResizeResult`**, which awaits the native promise and normalizes per-file entries (status cast to the shared union, `message` as `null` when absent).
> 
> Tests drop the direct `TextureResizeResult` import and type deferred mocks with **`Awaited<ReturnType<typeof resizeTextures>>`** so they match what the mocked native layer returns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d3ee7005a61d824cfd3e91c20b357c32738eaa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved texture resizing result handling for non-upscaled files.
  * Resize results now consistently report file statuses and use clear, predictable message values.
  * Standardized results across resizing paths to improve reliability for texture-processing workflows.

* **Tests**
  * Updated automated coverage to validate the revised resize-result handling without changing existing runtime expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->