### PR TITLE
fix(tools): detect VS Build Tools for 4001 fixer

### DIFF
--- a/src/main/services/mod-tools/4001-fixer.ts
+++ b/src/main/services/mod-tools/4001-fixer.ts
@@ -64,7 +64,13 @@ type D3DBuildState = {
 };
 
 export class FourThousandOneFixer {
-    private readonly VS_EDITIONS = ["Community", "Professional", "Enterprise", "Insiders"];
+    private readonly VS_EDITIONS = [
+        "Community",
+        "Professional",
+        "Enterprise",
+        "Insiders",
+        "BuildTools",
+    ];
     private readonly VS_VERSIONS = ["2025", "2022", "18", "17"];
     private readonly RELEASES_FETCH_COOLDOWN_MS = ms("1m");
 
@@ -770,21 +776,29 @@ export class FourThousandOneFixer {
     }
 
     private async findVsDevCmd(): Promise<string | null> {
-        const baseDir = "C:\\Program Files\\Microsoft Visual Studio";
+        const baseDirs = [
+            path.join(process.env.ProgramFiles ?? "C:\\Program Files", "Microsoft Visual Studio"),
+            path.join(
+                process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)",
+                "Microsoft Visual Studio",
+            ),
+        ];
 
-        for (const version of this.VS_VERSIONS) {
-            for (const edition of this.VS_EDITIONS) {
-                const candidatePath = path.join(
-                    baseDir,
-                    version,
-                    edition,
-                    "VC",
-                    "Auxiliary",
-                    "Build",
-                    "vcvars64.bat",
-                );
-                if (await fse.pathExists(candidatePath)) {
-                    return candidatePath;
+        for (const baseDir of baseDirs) {
+            for (const version of this.VS_VERSIONS) {
+                for (const edition of this.VS_EDITIONS) {
+                    const candidatePath = path.join(
+                        baseDir,
+                        version,
+                        edition,
+                        "VC",
+                        "Auxiliary",
+                        "Build",
+                        "vcvars64.bat",
+                    );
+                    if (await fse.pathExists(candidatePath)) {
+                        return candidatePath;
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow change to local VS path discovery for the mod-tools build flow; no auth, data, or shared infrastructure impact.
> 
> **Overview**
> The **4001 fixer** D3D11 DLL build path now finds Visual Studio when only **Build Tools** is installed, not just full IDE editions.
> 
> `findVsDevCmd` searches **`BuildTools`** alongside Community/Professional/Enterprise/Insiders, and scans both **`ProgramFiles`** and **`ProgramFiles(x86)`** (via env vars) instead of a single hardcoded `C:\Program Files` root—so `vcvars64.bat` discovery matches typical Build Tools layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec264101fee7c68b9a8495974839194967b00832. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Visual Studio discovery across both 64-bit and 32-bit installation locations.
  * Added support for detecting the Build Tools edition of Visual Studio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->