### PR TITLE
feat(xxmi): add selectable DLL version install

### DIFF
--- a/src/main/ipc/handlers/xxmi.ts
+++ b/src/main/ipc/handlers/xxmi.ts
@@ -9,4 +9,8 @@ export function registerXXMIHandlers(d: NahidaDesktop) {
     rh("xxmi:findXXMIPath", () => d.service.xxmi.findXXMIPath());
     rh("xxmi:startGame", (importer: string) => d.service.xxmi.startGame(importer));
     rh("xxmi:getEnabledImporters", () => d.service.xxmi.getEnabledImporters());
+    rh("xxmi:getLibsReleases", () => d.service.xxmi.getLibsReleases());
+    rh("xxmi:installDllVersion", (input: { version: string }) =>
+        d.service.xxmi.installDllVersion(input),
+    );
 }

--- a/src/main/ipc/handlers/xxmi.ts
+++ b/src/main/ipc/handlers/xxmi.ts
@@ -10,7 +10,10 @@ export function registerXXMIHandlers(d: NahidaDesktop) {
     rh("xxmi:startGame", (importer: string) => d.service.xxmi.startGame(importer));
     rh("xxmi:getEnabledImporters", () => d.service.xxmi.getEnabledImporters());
     rh("xxmi:getLibsReleases", () => d.service.xxmi.getLibsReleases());
-    rh("xxmi:installDllVersion", (input: { version: string }) =>
-        d.service.xxmi.installDllVersion(input),
-    );
+    rh("xxmi:installDllVersion", (input: { version: string }) => {
+        if (!input || typeof input.version !== "string" || !input.version.trim()) {
+            throw new Error("Invalid version: must be a non-empty string");
+        }
+        return d.service.xxmi.installDllVersion(input);
+    });
 }

--- a/src/main/services/mod-tools/4001-fixer.ts
+++ b/src/main/services/mod-tools/4001-fixer.ts
@@ -149,7 +149,11 @@ export class FourThousandOneFixer {
         });
     }
 
-    private async closeLauncherOrFail(): Promise<BuildD3DResult | null> {
+    private async closeLauncherOrFail(context: {
+        operation: string;
+        target?: string;
+        fileChangesStarted: boolean;
+    }): Promise<BuildD3DResult | null> {
         try {
             await this.desktop.service.xxmi.ensureLauncherClosed();
             return null;
@@ -158,6 +162,9 @@ export class FourThousandOneFixer {
             this.desktop.logger.error(
                 {
                     action: "4001Fixer:closeLauncher",
+                    operation: context.operation,
+                    target: context.target,
+                    fileChangesStarted: context.fileChangesStarted,
                     error: errorMessage,
                 },
                 "4001Fixer:closeLauncher",
@@ -191,7 +198,11 @@ export class FourThousandOneFixer {
             return { success: false };
         }
 
-        const launcherCloseError = await this.closeLauncherOrFail();
+        const launcherCloseError = await this.closeLauncherOrFail({
+            operation: "build-dll",
+            target: importerPath,
+            fileChangesStarted: false,
+        });
         if (launcherCloseError) return launcherCloseError;
 
         const finalDestination = path.join(importerPath, TARGET_DLL_NAME);
@@ -321,7 +332,11 @@ export class FourThousandOneFixer {
             return { success: false };
         }
 
-        const launcherCloseError = await this.closeLauncherOrFail();
+        const launcherCloseError = await this.closeLauncherOrFail({
+            operation: "diversify-dll",
+            target: targetDllPath,
+            fileChangesStarted: false,
+        });
         if (launcherCloseError) return launcherCloseError;
 
         const destinationCheck = await this.desktop.lib.fs.isPathWritable(targetDllPath, {
@@ -444,10 +459,14 @@ export class FourThousandOneFixer {
             return { success: false };
         }
 
-        const launcherCloseError = await this.closeLauncherOrFail();
+        const targetDllPath = path.join(importerPath, TARGET_DLL_NAME);
+        const launcherCloseError = await this.closeLauncherOrFail({
+            operation: "restore-dll",
+            target: targetDllPath,
+            fileChangesStarted: false,
+        });
         if (launcherCloseError) return launcherCloseError;
 
-        const targetDllPath = path.join(importerPath, TARGET_DLL_NAME);
         const destinationCheck = await this.desktop.lib.fs.isPathWritable(targetDllPath, {
             detailed: true,
             parentPath: importerPath,

--- a/src/main/services/mod-tools/4001-fixer.ts
+++ b/src/main/services/mod-tools/4001-fixer.ts
@@ -77,7 +77,12 @@ export class FourThousandOneFixer {
             name: "mod-tools:d3d-build",
             run: () => this.cleanupStaleBuildDirs(),
         });
-        void this.updateReleases();
+        void this.updateReleases().catch((error) => {
+            this.desktop.logger.warn(
+                `Automatic XXMI libs release prefetch failed: ${String(error)}`,
+                "4001Fixer:updateReleases",
+            );
+        });
     }
 
     public getState() {

--- a/src/main/services/mod-tools/4001-fixer.ts
+++ b/src/main/services/mod-tools/4001-fixer.ts
@@ -10,7 +10,6 @@ import { diversifyDllPadding } from "@native/pe-padding-diversifier";
 import { toErrorMessage } from "@shared/utils";
 import fse from "fs-extra";
 import ky from "ky";
-import ms from "ms";
 import { nanoid } from "nanoid";
 
 import type { NahidaDesktop } from "@/main";
@@ -21,6 +20,7 @@ import {
     removeFilesElevated,
 } from "@/main/lib/elevated-fs";
 import { drainWebStream, webStreamToNodeReadable } from "@/main/lib/web-stream-to-readable";
+import { getXxmiLibsReleases, updateXxmiLibsReleases } from "@/main/services/xxmi-libs-releases";
 
 const execAsync = promisify(exec);
 
@@ -42,12 +42,7 @@ type DiversificationState = {
     backupPath: string | null;
 };
 
-type GitHubRelease = {
-    tag_name?: unknown;
-};
-
 const TARGET_DLL_NAME = "d3d11.dll";
-const NON_RELEASE_VERSION_NAMES = new Set(["main", "master"]);
 const D3D_BUILD_STATE_KEY_PREFIX = "mod_tools:d3d_build:";
 const D3D_BUILD_TEMP_DIR_NAME = "nahida-tools-d3d-build";
 const D3D_BUILD_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
@@ -72,15 +67,10 @@ export class FourThousandOneFixer {
         "BuildTools",
     ];
     private readonly VS_VERSIONS = ["2025", "2022", "18", "17"];
-    private readonly RELEASES_FETCH_COOLDOWN_MS = ms("1m");
 
     private activeTask: FourThousandOneFixerTask | null = null;
     private currentProgress = "";
     private currentErrorMessage = "";
-
-    private releasesCache: Partial<Record<string, string[]>> = {};
-    private readonly releasesFetchedAt: Partial<Record<string, number>> = {};
-    private readonly releasesFetchInFlight: Partial<Record<string, Promise<boolean>>> = {};
 
     constructor(private readonly desktop: NahidaDesktop) {
         this.desktop.service.startupCleanup.register({
@@ -100,75 +90,11 @@ export class FourThousandOneFixer {
     }
 
     public async updateReleases() {
-        await this.fetchProviderReleases("SpectrumQT");
-    }
-
-    private async fetchProviderReleases(provider: string) {
-        const inFlight = this.releasesFetchInFlight[provider];
-        if (inFlight) {
-            return inFlight;
-        }
-
-        const now = Date.now();
-        const lastFetchedAt = this.releasesFetchedAt[provider] ?? 0;
-        if (now - lastFetchedAt < this.RELEASES_FETCH_COOLDOWN_MS) {
-            return true;
-        }
-
-        const fetchPromise = this.fetchProviderReleasesInternal(provider);
-        this.releasesFetchInFlight[provider] = fetchPromise;
-
-        try {
-            const success = await fetchPromise;
-            if (success) {
-                this.releasesFetchedAt[provider] = Date.now();
-            }
-            return success;
-        } finally {
-            delete this.releasesFetchInFlight[provider];
-        }
-    }
-
-    private async fetchProviderReleasesInternal(provider: string) {
-        try {
-            const url = `https://api.github.com/repos/${provider}/XXMI-Libs-Package/releases`;
-            const resp = await ky.get(url, {
-                headers: {
-                    "User-Agent":
-                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
-                },
-                throwHttpErrors: false,
-            });
-
-            if (!resp.ok) {
-                this.desktop.logger.warn(
-                    `Failed to fetch releases for ${provider}: ${resp.status} ${resp.statusText}`,
-                    "4001Fixer:fetchProviderReleases",
-                );
-                return false;
-            }
-
-            const releases = (await resp.json()) as GitHubRelease[];
-            this.releasesCache[provider] = releases
-                .map((release) => release.tag_name)
-                .filter(
-                    (tagName): tagName is string =>
-                        typeof tagName === "string" &&
-                        !NON_RELEASE_VERSION_NAMES.has(tagName.toLowerCase()),
-                );
-            return true;
-        } catch (error) {
-            this.desktop.logger.error(error, "4001Fixer:fetchProviderReleases");
-            return false;
-        }
+        await updateXxmiLibsReleases(this.desktop.logger, "SpectrumQT");
     }
 
     public async getProviderReleases(provider: string) {
-        if (!this.releasesCache[provider]) {
-            await this.fetchProviderReleases(provider);
-        }
-
-        return this.releasesCache[provider] ?? [];
+        return getXxmiLibsReleases(this.desktop.logger, provider);
     }
 
     public async getDiversificationState({

--- a/src/main/services/mod-tools/4001-fixer.ts
+++ b/src/main/services/mod-tools/4001-fixer.ts
@@ -149,6 +149,25 @@ export class FourThousandOneFixer {
         });
     }
 
+    private async closeLauncherOrFail(): Promise<BuildD3DResult | null> {
+        try {
+            await this.desktop.service.xxmi.ensureLauncherClosed();
+            return null;
+        } catch (error) {
+            const errorMessage = toErrorMessage(error);
+            this.desktop.logger.error(
+                {
+                    action: "4001Fixer:closeLauncher",
+                    error: errorMessage,
+                },
+                "4001Fixer:closeLauncher",
+            );
+            this.updateProgress("XXMI_ERR_LAUNCHER_CLOSE_FAILED", errorMessage);
+            this.activeTask = null;
+            return { success: false, errorMessage };
+        }
+    }
+
     public async buildD3D11Dll({
         provider,
         version,
@@ -171,6 +190,9 @@ export class FourThousandOneFixer {
             this.activeTask = null;
             return { success: false };
         }
+
+        const launcherCloseError = await this.closeLauncherOrFail();
+        if (launcherCloseError) return launcherCloseError;
 
         const finalDestination = path.join(importerPath, TARGET_DLL_NAME);
         const destinationCheck = await this.desktop.lib.fs.isPathWritable(finalDestination, {
@@ -299,6 +321,9 @@ export class FourThousandOneFixer {
             return { success: false };
         }
 
+        const launcherCloseError = await this.closeLauncherOrFail();
+        if (launcherCloseError) return launcherCloseError;
+
         const destinationCheck = await this.desktop.lib.fs.isPathWritable(targetDllPath, {
             detailed: true,
             parentPath: importerPath,
@@ -418,6 +443,9 @@ export class FourThousandOneFixer {
             this.activeTask = null;
             return { success: false };
         }
+
+        const launcherCloseError = await this.closeLauncherOrFail();
+        if (launcherCloseError) return launcherCloseError;
 
         const targetDllPath = path.join(importerPath, TARGET_DLL_NAME);
         const destinationCheck = await this.desktop.lib.fs.isPathWritable(targetDllPath, {

--- a/src/main/services/xxmi-libs-releases.ts
+++ b/src/main/services/xxmi-libs-releases.ts
@@ -1,0 +1,86 @@
+import type { Logger } from "@main/internal/logger";
+import ky from "ky";
+import ms from "ms";
+
+type GitHubRelease = {
+    tag_name?: unknown;
+};
+
+const NON_RELEASE_VERSION_NAMES = new Set(["main", "master"]);
+const RELEASES_FETCH_COOLDOWN_MS = ms("1m");
+
+const releasesCache: Partial<Record<string, string[]>> = {};
+const releasesFetchedAt: Partial<Record<string, number>> = {};
+const releasesFetchInFlight: Partial<Record<string, Promise<boolean>>> = {};
+
+export async function updateXxmiLibsReleases(logger: Logger, provider = "SpectrumQT") {
+    await fetchProviderReleases(logger, provider);
+}
+
+export async function getXxmiLibsReleases(logger: Logger, provider = "SpectrumQT") {
+    if (!releasesCache[provider]) {
+        await fetchProviderReleases(logger, provider);
+    }
+
+    return releasesCache[provider] ?? [];
+}
+
+async function fetchProviderReleases(logger: Logger, provider: string) {
+    const inFlight = releasesFetchInFlight[provider];
+    if (inFlight) {
+        return inFlight;
+    }
+
+    const now = Date.now();
+    const lastFetchedAt = releasesFetchedAt[provider] ?? 0;
+    if (now - lastFetchedAt < RELEASES_FETCH_COOLDOWN_MS) {
+        return true;
+    }
+
+    const fetchPromise = fetchProviderReleasesInternal(logger, provider);
+    releasesFetchInFlight[provider] = fetchPromise;
+
+    try {
+        const success = await fetchPromise;
+        if (success) {
+            releasesFetchedAt[provider] = Date.now();
+        }
+        return success;
+    } finally {
+        delete releasesFetchInFlight[provider];
+    }
+}
+
+async function fetchProviderReleasesInternal(logger: Logger, provider: string) {
+    try {
+        const url = `https://api.github.com/repos/${provider}/XXMI-Libs-Package/releases`;
+        const resp = await ky.get(url, {
+            headers: {
+                "User-Agent":
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
+            },
+            throwHttpErrors: false,
+        });
+
+        if (!resp.ok) {
+            logger.warn(
+                `Failed to fetch releases for ${provider}: ${resp.status} ${resp.statusText}`,
+                "XxmiLibsReleases:fetchProviderReleases",
+            );
+            return false;
+        }
+
+        const releases = (await resp.json()) as GitHubRelease[];
+        releasesCache[provider] = releases
+            .map((release) => release.tag_name)
+            .filter(
+                (tagName): tagName is string =>
+                    typeof tagName === "string" &&
+                    !NON_RELEASE_VERSION_NAMES.has(tagName.toLowerCase()),
+            );
+        return true;
+    } catch (error) {
+        logger.error(error, "XxmiLibsReleases:fetchProviderReleases");
+        return false;
+    }
+}

--- a/src/main/services/xxmi-libs-releases.ts
+++ b/src/main/services/xxmi-libs-releases.ts
@@ -9,45 +9,45 @@ type GitHubRelease = {
 const NON_RELEASE_VERSION_NAMES = new Set(["main", "master"]);
 const RELEASES_FETCH_COOLDOWN_MS = ms("1m");
 
-const releasesCache: Partial<Record<string, string[]>> = {};
-const releasesFetchedAt: Partial<Record<string, number>> = {};
-const releasesFetchInFlight: Partial<Record<string, Promise<boolean>>> = {};
+const releasesCache = new Map<string, string[]>();
+const releasesFetchedAt = new Map<string, number>();
+const releasesFetchInFlight = new Map<string, Promise<boolean>>();
 
 export async function updateXxmiLibsReleases(logger: Logger, provider = "SpectrumQT") {
     await fetchProviderReleases(logger, provider);
 }
 
 export async function getXxmiLibsReleases(logger: Logger, provider = "SpectrumQT") {
-    if (!releasesCache[provider]) {
+    if (!releasesCache.has(provider)) {
         await fetchProviderReleases(logger, provider);
     }
 
-    return releasesCache[provider] ?? [];
+    return releasesCache.get(provider) ?? [];
 }
 
 async function fetchProviderReleases(logger: Logger, provider: string) {
-    const inFlight = releasesFetchInFlight[provider];
+    const inFlight = releasesFetchInFlight.get(provider);
     if (inFlight) {
         return inFlight;
     }
 
     const now = Date.now();
-    const lastFetchedAt = releasesFetchedAt[provider] ?? 0;
+    const lastFetchedAt = releasesFetchedAt.get(provider) ?? 0;
     if (now - lastFetchedAt < RELEASES_FETCH_COOLDOWN_MS) {
         return true;
     }
 
     const fetchPromise = fetchProviderReleasesInternal(logger, provider);
-    releasesFetchInFlight[provider] = fetchPromise;
+    releasesFetchInFlight.set(provider, fetchPromise);
 
     try {
         const success = await fetchPromise;
         if (success) {
-            releasesFetchedAt[provider] = Date.now();
+            releasesFetchedAt.set(provider, Date.now());
         }
         return success;
     } finally {
-        delete releasesFetchInFlight[provider];
+        releasesFetchInFlight.delete(provider);
     }
 }
 
@@ -71,13 +71,16 @@ async function fetchProviderReleasesInternal(logger: Logger, provider: string) {
         }
 
         const releases = (await resp.json()) as GitHubRelease[];
-        releasesCache[provider] = releases
-            .map((release) => release.tag_name)
-            .filter(
-                (tagName): tagName is string =>
-                    typeof tagName === "string" &&
-                    !NON_RELEASE_VERSION_NAMES.has(tagName.toLowerCase()),
-            );
+        releasesCache.set(
+            provider,
+            releases
+                .map((release) => release.tag_name)
+                .filter(
+                    (tagName): tagName is string =>
+                        typeof tagName === "string" &&
+                        !NON_RELEASE_VERSION_NAMES.has(tagName.toLowerCase()),
+                ),
+        );
         return true;
     } catch (error) {
         logger.error(error, "XxmiLibsReleases:fetchProviderReleases");

--- a/src/main/services/xxmi-libs-releases.ts
+++ b/src/main/services/xxmi-libs-releases.ts
@@ -14,7 +14,10 @@ const releasesFetchedAt = new Map<string, number>();
 const releasesFetchInFlight = new Map<string, Promise<boolean>>();
 
 export async function updateXxmiLibsReleases(logger: Logger, provider = "SpectrumQT") {
-    await fetchProviderReleases(logger, provider);
+    const success = await fetchProviderReleases(logger, provider);
+    if (!success) {
+        throw new Error(`Failed to fetch XXMI libs releases for ${provider}`);
+    }
 }
 
 export async function getXxmiLibsReleases(logger: Logger, provider = "SpectrumQT") {

--- a/src/main/services/xxmi-libs-releases.ts
+++ b/src/main/services/xxmi-libs-releases.ts
@@ -19,7 +19,10 @@ export async function updateXxmiLibsReleases(logger: Logger, provider = "Spectru
 
 export async function getXxmiLibsReleases(logger: Logger, provider = "SpectrumQT") {
     if (!releasesCache.has(provider)) {
-        await fetchProviderReleases(logger, provider);
+        const success = await fetchProviderReleases(logger, provider);
+        if (!success) {
+            throw new Error(`Failed to fetch XXMI libs releases for ${provider}`);
+        }
     }
 
     return releasesCache.get(provider) ?? [];

--- a/src/main/services/xxmi.ts
+++ b/src/main/services/xxmi.ts
@@ -1,10 +1,21 @@
+import os from "node:os";
 import path from "node:path";
+import { pipeline } from "node:stream/promises";
+
 import { findFileAcrossDrives, spawnPrivilegedProcess, waitForProcess } from "@native/utils";
 import { WaitResult } from "@native/utils/constants";
 import { type XXMIConfig, XXMIConfigSchema } from "@shared/schemas/xxmi";
+import { toErrorMessage } from "@shared/utils";
 import { delay } from "es-toolkit";
 import fse from "fs-extra";
+import ky from "ky";
+import { nanoid } from "nanoid";
+
+import { drainWebStream, webStreamToNodeReadable } from "@/main/lib/web-stream-to-readable";
+
 import type { NahidaDesktop } from "..";
+
+import { getXxmiLibsReleases } from "./xxmi-libs-releases";
 
 export class XXMI {
     private readonly desktop: NahidaDesktop;
@@ -128,6 +139,100 @@ export class XXMI {
             return path.dirname(result);
         }
         return null;
+    }
+
+    public async getLibsReleases() {
+        return getXxmiLibsReleases(this.desktop.logger);
+    }
+
+    public async installDllVersion({ version }: { version: string }) {
+        await this.init();
+
+        const selectedVersion = version.trim();
+        if (!selectedVersion) {
+            throw new Error("No version selected");
+        }
+
+        if (!this.xxmiPath) {
+            throw new Error("XXMI is not configured");
+        }
+
+        if (this.busy) {
+            throw new Error("XXMI is busy");
+        }
+
+        this.busy = true;
+        const xxmiPath = this.xxmiPath;
+        const destDir = path.join(xxmiPath, "Resources", "Packages", "XXMI");
+        const workDir = path.join(os.tmpdir(), `nahida-xxmi-dll-${nanoid()}`);
+
+        try {
+            await fse.ensureDir(workDir);
+            const zipPath = path.join(workDir, "package.zip");
+            const resp = await ky.get(
+                `https://github.com/SpectrumQT/XXMI-Libs-Package/releases/download/${selectedVersion}/XXMI-PACKAGE-${selectedVersion}.zip`,
+                {
+                    headers: {
+                        "User-Agent":
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
+                        Referer: "https://github.com/SpectrumQT/XXMI-Libs-Package",
+                    },
+                },
+            );
+
+            if (!resp.ok) {
+                await drainWebStream(resp.body).catch(() => {});
+                throw new Error(`Failed to download XXMI package: ${resp.statusText}`);
+            }
+            if (!resp.body) {
+                throw new Error("No response body");
+            }
+
+            await pipeline(webStreamToNodeReadable(resp.body), fse.createWriteStream(zipPath));
+
+            const extractedPath = await this.desktop.service.archive.extract(
+                zipPath,
+                path.join(workDir, "extracted"),
+            );
+            const entries = await fse.readdir(extractedPath, { withFileTypes: true });
+            const onlyDir =
+                entries.length === 1 && entries[0].isDirectory() ? entries[0].name : null;
+
+            await fse.ensureDir(destDir);
+            await fse.copy(onlyDir ? path.join(extractedPath, onlyDir) : extractedPath, destDir, {
+                overwrite: true,
+            });
+
+            const configPath = path.join(xxmiPath, "XXMI Launcher Config.json");
+            const config = await fse.readJson(configPath);
+            if (!config.Launcher) {
+                throw new Error("XXMI Launcher config is missing Launcher section");
+            }
+
+            config.Launcher.auto_update = false;
+            await fse.writeJson(configPath, config, { spaces: 4 });
+            this.xxmiConfig = XXMIConfigSchema.parse(await fse.readJson(configPath));
+
+            this.desktop.logger.info(
+                `Installed XXMI DLL version ${selectedVersion} to ${destDir}`,
+                "XXMI.installDllVersion",
+            );
+        } catch (error) {
+            this.desktop.logger.error(
+                {
+                    action: "xxmi:installDllVersion",
+                    version: selectedVersion,
+                    xxmiPath,
+                    destDir,
+                    error: toErrorMessage(error),
+                },
+                "XXMI.installDllVersion",
+            );
+            throw error;
+        } finally {
+            this.busy = false;
+            await fse.remove(workDir).catch(() => {});
+        }
     }
 
     public getEnabledImporters() {

--- a/src/main/services/xxmi.ts
+++ b/src/main/services/xxmi.ts
@@ -2,7 +2,13 @@ import os from "node:os";
 import path from "node:path";
 import { pipeline } from "node:stream/promises";
 
-import { findFileAcrossDrives, spawnPrivilegedProcess, waitForProcess } from "@native/utils";
+import {
+    findFileAcrossDrives,
+    getProcess,
+    killProcess,
+    spawnPrivilegedProcess,
+    waitForProcess,
+} from "@native/utils";
 import { WaitResult } from "@native/utils/constants";
 import { type XXMIConfig, XXMIConfigSchema } from "@shared/schemas/xxmi";
 import { toErrorMessage } from "@shared/utils";
@@ -16,6 +22,8 @@ import { drainWebStream, webStreamToNodeReadable } from "@/main/lib/web-stream-t
 import type { NahidaDesktop } from "..";
 
 import { getXxmiLibsReleases } from "./xxmi-libs-releases";
+
+const XXMI_LAUNCHER_EXE = "XXMI Launcher.exe";
 
 export class XXMI {
     private readonly desktop: NahidaDesktop;
@@ -145,6 +153,21 @@ export class XXMI {
         return getXxmiLibsReleases(this.desktop.logger);
     }
 
+    public async ensureLauncherClosed() {
+        const deadline = Date.now() + 5000;
+        while (true) {
+            const running = getProcess(undefined, XXMI_LAUNCHER_EXE);
+            if (!running) return;
+            if (!killProcess(running.pid)) {
+                throw new Error("Failed to close XXMI Launcher");
+            }
+            if (Date.now() >= deadline) {
+                throw new Error("XXMI Launcher is still running");
+            }
+            await delay(100);
+        }
+    }
+
     public async installDllVersion({ version }: { version: string }) {
         await this.init();
 
@@ -167,6 +190,7 @@ export class XXMI {
         const workDir = path.join(os.tmpdir(), `nahida-xxmi-dll-${nanoid()}`);
 
         try {
+            await this.ensureLauncherClosed();
             await fse.ensureDir(workDir);
             const zipPath = path.join(workDir, "package.zip");
             const resp = await ky.get(

--- a/src/main/services/xxmi.ts
+++ b/src/main/services/xxmi.ts
@@ -235,10 +235,8 @@ export class XXMI {
             const onlyDir =
                 entries.length === 1 && entries[0].isDirectory() ? entries[0].name : null;
 
-            await fse.ensureDir(destDir);
-            await fse.copy(onlyDir ? path.join(extractedPath, onlyDir) : extractedPath, destDir, {
-                overwrite: true,
-            });
+            const stagingDir = path.join(workDir, "staging");
+            await fse.copy(onlyDir ? path.join(extractedPath, onlyDir) : extractedPath, stagingDir);
 
             const manifestResp = await ky.get(
                 `https://github.com/SpectrumQT/XXMI-Libs-Package/releases/download/${selectedVersion}/Manifest.json`,
@@ -248,10 +246,17 @@ export class XXMI {
                 await drainWebStream(manifestResp.body).catch(() => {});
                 throw new Error(`Failed to download XXMI manifest: ${manifestResp.statusText}`);
             }
-            await fse.writeFile(
-                path.join(destDir, "Manifest.json"),
-                Buffer.from(await manifestResp.arrayBuffer()),
-            );
+            const manifestBuffer = Buffer.from(await manifestResp.arrayBuffer());
+            await fse.writeFile(path.join(stagingDir, "Manifest.json"), manifestBuffer);
+
+            const manifestJson = JSON.parse(manifestBuffer.toString("utf8"));
+            const manifestVersion =
+                typeof manifestJson?.version === "string" ? manifestJson.version : null;
+            if (manifestVersion !== selectedVersion) {
+                throw new Error(
+                    `Manifest version mismatch: expected ${selectedVersion}, got ${manifestVersion ?? "null"}`,
+                );
+            }
 
             const configPath = path.join(xxmiPath, "XXMI Launcher Config.json");
             const config = await fse.readJson(configPath);
@@ -260,6 +265,9 @@ export class XXMI {
             }
 
             config.Launcher.auto_update = false;
+
+            await fse.ensureDir(destDir);
+            await fse.copy(stagingDir, destDir, { overwrite: true });
             await fse.writeJson(configPath, config, { spaces: 4 });
             this.xxmiConfig = XXMIConfigSchema.parse(await fse.readJson(configPath));
 

--- a/src/main/services/xxmi.ts
+++ b/src/main/services/xxmi.ts
@@ -103,9 +103,23 @@ export class XXMI {
         await this.init();
         return {
             xxmiPath: this.xxmiPath,
+            dllVersion: await this.getDllVersion(),
             enabledImporters: this.getEnabledImporters(),
             xxmiConfig: this.xxmiConfig,
         };
+    }
+
+    private async getDllVersion() {
+        if (!this.xxmiPath) return null;
+
+        try {
+            const manifest = await fse.readJson(
+                path.join(this.xxmiPath, "Resources", "Packages", "XXMI", "Manifest.json"),
+            );
+            return typeof manifest?.version === "string" ? manifest.version : null;
+        } catch {
+            return null;
+        }
     }
 
     public async getXXMIPath() {

--- a/src/main/services/xxmi.ts
+++ b/src/main/services/xxmi.ts
@@ -193,15 +193,14 @@ export class XXMI {
             await this.ensureLauncherClosed();
             await fse.ensureDir(workDir);
             const zipPath = path.join(workDir, "package.zip");
+            const githubHeaders = {
+                "User-Agent":
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
+                Referer: "https://github.com/SpectrumQT/XXMI-Libs-Package",
+            };
             const resp = await ky.get(
                 `https://github.com/SpectrumQT/XXMI-Libs-Package/releases/download/${selectedVersion}/XXMI-PACKAGE-${selectedVersion}.zip`,
-                {
-                    headers: {
-                        "User-Agent":
-                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
-                        Referer: "https://github.com/SpectrumQT/XXMI-Libs-Package",
-                    },
-                },
+                { headers: githubHeaders },
             );
 
             if (!resp.ok) {
@@ -226,6 +225,19 @@ export class XXMI {
             await fse.copy(onlyDir ? path.join(extractedPath, onlyDir) : extractedPath, destDir, {
                 overwrite: true,
             });
+
+            const manifestResp = await ky.get(
+                `https://github.com/SpectrumQT/XXMI-Libs-Package/releases/download/${selectedVersion}/Manifest.json`,
+                { headers: githubHeaders },
+            );
+            if (!manifestResp.ok) {
+                await drainWebStream(manifestResp.body).catch(() => {});
+                throw new Error(`Failed to download XXMI manifest: ${manifestResp.statusText}`);
+            }
+            await fse.writeFile(
+                path.join(destDir, "Manifest.json"),
+                Buffer.from(await manifestResp.arrayBuffer()),
+            );
 
             const configPath = path.join(xxmiPath, "XXMI Launcher Config.json");
             const config = await fse.readJson(configPath);

--- a/src/main/services/xxmi.ts
+++ b/src/main/services/xxmi.ts
@@ -265,11 +265,11 @@ export class XXMI {
             }
 
             config.Launcher.auto_update = false;
+            await fse.writeJson(configPath, config, { spaces: 4 });
+            this.xxmiConfig = XXMIConfigSchema.parse(await fse.readJson(configPath));
 
             await fse.ensureDir(destDir);
             await fse.copy(stagingDir, destDir, { overwrite: true });
-            await fse.writeJson(configPath, config, { spaces: 4 });
-            this.xxmiConfig = XXMIConfigSchema.parse(await fse.readJson(configPath));
 
             this.desktop.logger.info(
                 `Installed XXMI DLL version ${selectedVersion} to ${destDir}`,

--- a/src/main/services/xxmi.ts
+++ b/src/main/services/xxmi.ts
@@ -252,7 +252,10 @@ export class XXMI {
             const manifestJson = JSON.parse(manifestBuffer.toString("utf8"));
             const manifestVersion =
                 typeof manifestJson?.version === "string" ? manifestJson.version : null;
-            if (manifestVersion !== selectedVersion) {
+            if (
+                !manifestVersion ||
+                manifestVersion.trim().replace(/^v/i, "") !== selectedVersion.replace(/^v/i, "")
+            ) {
                 throw new Error(
                     `Manifest version mismatch: expected ${selectedVersion}, got ${manifestVersion ?? "null"}`,
                 );

--- a/src/renderer/src/components/setting/xxmi/xxmi-dll-version.tsx
+++ b/src/renderer/src/components/setting/xxmi/xxmi-dll-version.tsx
@@ -1,13 +1,5 @@
 import { Button } from "@renderer/components/ui/button";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@renderer/components/ui/card";
-import {
   Select,
   SelectContent,
   SelectGroup,
@@ -67,12 +59,14 @@ export function XXMIDllVersion({ xxmiData }: { xxmiData?: XXMIData }) {
   };
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{t("page.setting.xxmi.dllVersion")}</CardTitle>
-        <CardDescription>{t("page.setting.xxmi.dllVersionDescription")}</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-3">
+    <div className="flex items-center justify-between gap-6">
+      <div className="space-y-0.5">
+        <span className="text-sm font-medium">{t("page.setting.xxmi.dllVersion")}</span>
+        <p className="text-xs text-muted-foreground">
+          {t("page.setting.xxmi.dllVersionDescription")}
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
         {xxmiData && !hasPath ? (
           <p className="text-sm text-muted-foreground">
             {t("page.setting.xxmi.persistNotFoundXXMI")}
@@ -87,37 +81,37 @@ export function XXMIDllVersion({ xxmiData }: { xxmiData?: XXMIData }) {
         ) : versions.length === 0 ? (
           <p className="text-sm text-muted-foreground">{t("page.setting.xxmi.dllVersionEmpty")}</p>
         ) : (
-          <Select
-            items={versions.map((item) => ({ label: item, value: item }))}
-            value={version}
-            onValueChange={(value) => {
-              if (value === null) return;
-              setVersion(value);
-            }}
-          >
-            <SelectTrigger className="w-full max-w-36">
-              <SelectValue placeholder={t("page.setting.xxmi.dllVersion")} />
-            </SelectTrigger>
-            <SelectContent className="h-64">
-              <SelectGroup>
-                {versions.map((item) => (
-                  <SelectItem key={item} value={item}>
-                    {item}
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-            </SelectContent>
-          </Select>
+          <>
+            <Select
+              items={versions.map((item) => ({ label: item, value: item }))}
+              value={version}
+              onValueChange={(value) => {
+                if (value === null) return;
+                setVersion(value);
+              }}
+            >
+              <SelectTrigger className="w-36">
+                <SelectValue placeholder={t("page.setting.xxmi.dllVersion")} />
+              </SelectTrigger>
+              <SelectContent className="h-64">
+                <SelectGroup>
+                  {versions.map((item) => (
+                    <SelectItem key={item} value={item}>
+                      {item}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+            <Button
+              onClickPromise={applyVersion}
+              disabled={!hasPath || !version || fetchError || versions === null}
+            >
+              {t("g.confirm")}
+            </Button>
+          </>
         )}
-      </CardContent>
-      <CardFooter className="flex justify-end">
-        <Button
-          onClickPromise={applyVersion}
-          disabled={!hasPath || !version || fetchError || versions === null}
-        >
-          {t("g.confirm")}
-        </Button>
-      </CardFooter>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/src/renderer/src/components/setting/xxmi/xxmi-dll-version.tsx
+++ b/src/renderer/src/components/setting/xxmi/xxmi-dll-version.tsx
@@ -16,6 +16,7 @@ import {
   SelectValue,
 } from "@renderer/components/ui/select";
 import type { XXMIData } from "@renderer/routes/setting/xxmi";
+import { toErrorMessage } from "@shared/utils";
 import { Loader2Icon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -56,8 +57,12 @@ export function XXMIDllVersion({ xxmiData }: { xxmiData?: XXMIData }) {
     try {
       await window.api.invoke("xxmi:installDllVersion", { version });
       toast.success(t("page.setting.xxmi.fn.installDllVersion.success", { version }));
-    } catch {
-      toast.error(t("page.setting.xxmi.fn.installDllVersion.failed"));
+    } catch (error) {
+      toast.error(
+        toErrorMessage(error).includes("XXMI Launcher")
+          ? t("page.setting.xxmi.fn.installDllVersion.launcherCloseFailed")
+          : t("page.setting.xxmi.fn.installDllVersion.failed"),
+      );
     }
   };
 

--- a/src/renderer/src/components/setting/xxmi/xxmi-dll-version.tsx
+++ b/src/renderer/src/components/setting/xxmi/xxmi-dll-version.tsx
@@ -31,28 +31,39 @@ export function XXMIDllVersion({
   const currentVersionLabel =
     versions?.find((item) => isCurrentVersion(item)) ?? xxmiData?.dllVersion;
 
-  useEffect(() => {
-    let cancelled = false;
+  const fetchReleases = (cancelled: { current: boolean }) => {
+    setVersions(null);
+    setFetchError(false);
 
     void window.api
       .invoke("xxmi:getLibsReleases")
       .then((releases) => {
-        if (cancelled) return;
+        if (cancelled.current) return;
         setVersions(releases);
         setVersion(releases[0] ?? "");
         setFetchError(false);
       })
       .catch(() => {
-        if (cancelled) return;
+        if (cancelled.current) return;
         setVersions([]);
         setVersion("");
         setFetchError(true);
       });
+  };
+
+  useEffect(() => {
+    const cancelled = { current: false };
+    fetchReleases(cancelled);
 
     return () => {
-      cancelled = true;
+      cancelled.current = true;
     };
   }, []);
+
+  const handleRetry = () => {
+    const cancelled = { current: false };
+    fetchReleases(cancelled);
+  };
 
   const applyVersion = async () => {
     try {
@@ -89,7 +100,12 @@ export function XXMIDllVersion({
             {t("page.setting.xxmi.persistNotFoundXXMI")}
           </p>
         ) : fetchError ? (
-          <p className="text-sm text-destructive">{t("page.setting.xxmi.dllVersionLoadFailed")}</p>
+          <>
+            <p className="text-sm text-destructive">{t("page.setting.xxmi.dllVersionLoadFailed")}</p>
+            <Button variant="outline" size="sm" onClick={handleRetry}>
+              {t("page.setting.xxmi.dllVersionRetry")}
+            </Button>
+          </>
         ) : versions === null ? (
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <Loader2Icon className="size-3.5 animate-spin" />

--- a/src/renderer/src/components/setting/xxmi/xxmi-dll-version.tsx
+++ b/src/renderer/src/components/setting/xxmi/xxmi-dll-version.tsx
@@ -1,0 +1,118 @@
+import { Button } from "@renderer/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@renderer/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@renderer/components/ui/select";
+import type { XXMIData } from "@renderer/routes/setting/xxmi";
+import { Loader2Icon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+export function XXMIDllVersion({ xxmiData }: { xxmiData?: XXMIData }) {
+  const { t } = useTranslation();
+  const [versions, setVersions] = useState<string[] | null>(null);
+  const [version, setVersion] = useState("");
+  const [fetchError, setFetchError] = useState(false);
+
+  const hasPath = !!xxmiData?.xxmiPath;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void window.api
+      .invoke("xxmi:getLibsReleases")
+      .then((releases) => {
+        if (cancelled) return;
+        setVersions(releases);
+        setVersion(releases[0] ?? "");
+        setFetchError(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setVersions([]);
+        setVersion("");
+        setFetchError(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const applyVersion = async () => {
+    try {
+      await window.api.invoke("xxmi:installDllVersion", { version });
+      toast.success(t("page.setting.xxmi.fn.installDllVersion.success", { version }));
+    } catch {
+      toast.error(t("page.setting.xxmi.fn.installDllVersion.failed"));
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("page.setting.xxmi.dllVersion")}</CardTitle>
+        <CardDescription>{t("page.setting.xxmi.dllVersionDescription")}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {xxmiData && !hasPath ? (
+          <p className="text-sm text-muted-foreground">
+            {t("page.setting.xxmi.persistNotFoundXXMI")}
+          </p>
+        ) : fetchError ? (
+          <p className="text-sm text-destructive">{t("page.setting.xxmi.dllVersionLoadFailed")}</p>
+        ) : versions === null ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2Icon className="size-3.5 animate-spin" />
+            {t("page.setting.xxmi.dllVersionLoading")}
+          </div>
+        ) : versions.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t("page.setting.xxmi.dllVersionEmpty")}</p>
+        ) : (
+          <Select
+            items={versions.map((item) => ({ label: item, value: item }))}
+            value={version}
+            onValueChange={(value) => {
+              if (value === null) return;
+              setVersion(value);
+            }}
+          >
+            <SelectTrigger className="w-full max-w-36">
+              <SelectValue placeholder={t("page.setting.xxmi.dllVersion")} />
+            </SelectTrigger>
+            <SelectContent className="h-64">
+              <SelectGroup>
+                {versions.map((item) => (
+                  <SelectItem key={item} value={item}>
+                    {item}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        )}
+      </CardContent>
+      <CardFooter className="flex justify-end">
+        <Button
+          onClickPromise={applyVersion}
+          disabled={!hasPath || !version || fetchError || versions === null}
+        >
+          {t("g.confirm")}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/renderer/src/components/setting/xxmi/xxmi-dll-version.tsx
+++ b/src/renderer/src/components/setting/xxmi/xxmi-dll-version.tsx
@@ -14,13 +14,22 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
-export function XXMIDllVersion({ xxmiData }: { xxmiData?: XXMIData }) {
+export function XXMIDllVersion({
+  xxmiData,
+  refetch,
+}: {
+  xxmiData?: XXMIData;
+  refetch: () => void;
+}) {
   const { t } = useTranslation();
   const [versions, setVersions] = useState<string[] | null>(null);
   const [version, setVersion] = useState("");
   const [fetchError, setFetchError] = useState(false);
 
   const hasPath = !!xxmiData?.xxmiPath;
+  const isCurrentVersion = (value: string) => isSameDllVersion(value, xxmiData?.dllVersion);
+  const currentVersionLabel =
+    versions?.find((item) => isCurrentVersion(item)) ?? xxmiData?.dllVersion;
 
   useEffect(() => {
     let cancelled = false;
@@ -49,6 +58,7 @@ export function XXMIDllVersion({ xxmiData }: { xxmiData?: XXMIData }) {
     try {
       await window.api.invoke("xxmi:installDllVersion", { version });
       toast.success(t("page.setting.xxmi.fn.installDllVersion.success", { version }));
+      refetch();
     } catch (error) {
       toast.error(
         toErrorMessage(error).includes("XXMI Launcher")
@@ -65,6 +75,13 @@ export function XXMIDllVersion({ xxmiData }: { xxmiData?: XXMIData }) {
         <p className="text-xs text-muted-foreground">
           {t("page.setting.xxmi.dllVersionDescription")}
         </p>
+        {hasPath && (
+          <p className="text-xs text-muted-foreground">
+            {t("page.setting.xxmi.dllVersionCurrent", {
+              version: currentVersionLabel ?? t("page.setting.xxmi.dllVersionUnknown"),
+            })}
+          </p>
+        )}
       </div>
       <div className="flex shrink-0 items-center gap-2">
         {xxmiData && !hasPath ? (
@@ -96,7 +113,7 @@ export function XXMIDllVersion({ xxmiData }: { xxmiData?: XXMIData }) {
               <SelectContent className="h-64">
                 <SelectGroup>
                   {versions.map((item) => (
-                    <SelectItem key={item} value={item}>
+                    <SelectItem key={item} value={item} disabled={isCurrentVersion(item)}>
                       {item}
                     </SelectItem>
                   ))}
@@ -105,7 +122,9 @@ export function XXMIDllVersion({ xxmiData }: { xxmiData?: XXMIData }) {
             </Select>
             <Button
               onClickPromise={applyVersion}
-              disabled={!hasPath || !version || fetchError || versions === null}
+              disabled={
+                !hasPath || !version || fetchError || versions === null || isCurrentVersion(version)
+              }
             >
               {t("g.confirm")}
             </Button>
@@ -114,4 +133,13 @@ export function XXMIDllVersion({ xxmiData }: { xxmiData?: XXMIData }) {
       </div>
     </div>
   );
+}
+
+function isSameDllVersion(selected?: string | null, installed?: string | null) {
+  if (!selected || !installed) return false;
+  return normalizeDllVersion(selected) === normalizeDllVersion(installed);
+}
+
+function normalizeDllVersion(value: string) {
+  return value.trim().replace(/^v/i, "");
 }

--- a/src/renderer/src/components/setting/xxmi/xxmi-importers.tsx
+++ b/src/renderer/src/components/setting/xxmi/xxmi-importers.tsx
@@ -1,5 +1,4 @@
 import { GameIcon } from "@renderer/components/game-icon";
-import { Card, CardContent, CardHeader, CardTitle } from "@renderer/components/ui/card";
 import { cn } from "@renderer/lib/utils";
 import type { XXMIData } from "@renderer/routes/setting/xxmi";
 import { Loader2Icon } from "lucide-react";
@@ -31,42 +30,38 @@ export function XXMIImporters({ xxmiData }: { xxmiData?: XXMIData }) {
   const isAnyProcessing = processingKey !== null;
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{t("page.setting.xxmi.activeImporter")}</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="flex flex-row space-x-2 justify-evenly">
-          {xxmiData.enabledImporters.map((importer) => {
-            const isThisProcessing = processingKey === importer.key;
+    <div>
+      <span className="text-sm font-medium">{t("page.setting.xxmi.activeImporter")}</span>
+      <div className="flex flex-row justify-evenly space-x-2 pt-2">
+        {xxmiData.enabledImporters.map((importer) => {
+          const isThisProcessing = processingKey === importer.key;
 
-            return (
-              <button
-                key={importer.key}
-                className={cn(
-                  "flex flex-col space-y-1 relative group",
-                  isAnyProcessing && !isThisProcessing && "opacity-50 cursor-not-allowed",
+          return (
+            <button
+              key={importer.key}
+              className={cn(
+                "group relative flex flex-col space-y-1",
+                isAnyProcessing && !isThisProcessing && "cursor-not-allowed opacity-50",
+              )}
+              onClick={() => handleStartGame(importer.key)}
+              disabled={isAnyProcessing}
+            >
+              <div className="relative inline-block">
+                <GameIcon gameName={importer.key} className="size-16" />
+
+                {isThisProcessing && (
+                  <div className="absolute inset-0 flex items-center justify-center rounded-md bg-black/60 transition-opacity">
+                    <Loader2Icon className="size-8 animate-spin text-white" />
+                  </div>
                 )}
-                onClick={() => handleStartGame(importer.key)}
-                disabled={isAnyProcessing}
-              >
-                <div className="relative inline-block">
-                  <GameIcon gameName={importer.key} className="size-16" />
+              </div>
 
-                  {isThisProcessing && (
-                    <div className="absolute inset-0 bg-black/60 flex items-center justify-center rounded-md transition-opacity">
-                      <Loader2Icon className="size-8 animate-spin text-white" />
-                    </div>
-                  )}
-                </div>
-
-                <span className="text-center text-xs">{importer.key}</span>
-                <span className="text-center text-xs">{importer.packageInfo.latest_version}</span>
-              </button>
-            );
-          })}
-        </div>
-      </CardContent>
-    </Card>
+              <span className="text-center text-xs">{importer.key}</span>
+              <span className="text-center text-xs">{importer.packageInfo.latest_version}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/src/renderer/src/components/setting/xxmi/xxmi-path.tsx
+++ b/src/renderer/src/components/setting/xxmi/xxmi-path.tsx
@@ -1,6 +1,5 @@
 import { Alert, AlertDescription, AlertTitle } from "@renderer/components/ui/alert";
 import { Button } from "@renderer/components/ui/button";
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@renderer/components/ui/card";
 import { Input } from "@renderer/components/ui/input";
 import type { XXMIData } from "@renderer/routes/setting/xxmi";
 import { InfoIcon } from "lucide-react";
@@ -33,51 +32,47 @@ export function XXMIPath({ xxmiData, refetch }: { xxmiData?: XXMIData; refetch: 
   };
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{t("page.setting.xxmi.xxmiPath")}</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3 w-full" aria-describedby={undefined}>
-        <div className="flex flex-row w-full space-x-2">
-          <Input
-            value={xxmiPath}
-            onChange={(e) => {
-              setXXMIPath(e.target.value);
-            }}
-          />
-          <Button
-            variant="outline"
-            onClickPromise={async () => {
-              setShowAutoSearchAlert(false);
-              const path = await window.api.invoke("xxmi:findXXMIPath");
+    <div className="space-y-3">
+      <div className="space-y-0.5">
+        <span className="text-sm font-medium">{t("page.setting.xxmi.xxmiPath")}</span>
+      </div>
+      <div className="flex w-full flex-row space-x-2">
+        <Input
+          value={xxmiPath}
+          onChange={(e) => {
+            setXXMIPath(e.target.value);
+          }}
+        />
+        <Button
+          variant="outline"
+          onClickPromise={async () => {
+            setShowAutoSearchAlert(false);
+            const path = await window.api.invoke("xxmi:findXXMIPath");
 
-              if (!path) {
-                toast.error(t("page.setting.xxmi.fn.findXXMIPath.xxmiNotFound"));
-                return;
-              }
+            if (!path) {
+              toast.error(t("page.setting.xxmi.fn.findXXMIPath.xxmiNotFound"));
+              return;
+            }
 
-              setXXMIPath(path);
-              setShowAutoSearchAlert(true);
-            }}
-          >
-            {t("page.setting.xxmi.autoScan")}
-          </Button>
-        </div>
-        {showAutoSearchAlert && (
-          <Alert>
-            <InfoIcon />
-            <AlertTitle>{t("page.setting.xxmi.fn.findXXMIPath.alert.title")}</AlertTitle>
-            <AlertDescription className="text-wrap">
-              {t("page.setting.xxmi.fn.findXXMIPath.alert.description")}
-            </AlertDescription>
-          </Alert>
-        )}
-      </CardContent>
-      <CardFooter className="flex justify-end">
+            setXXMIPath(path);
+            setShowAutoSearchAlert(true);
+          }}
+        >
+          {t("page.setting.xxmi.autoScan")}
+        </Button>
         <Button onClickPromise={saveXXMIPath} disabled={!xxmiPath}>
           {t("g.save")}
         </Button>
-      </CardFooter>
-    </Card>
+      </div>
+      {showAutoSearchAlert && (
+        <Alert>
+          <InfoIcon />
+          <AlertTitle>{t("page.setting.xxmi.fn.findXXMIPath.alert.title")}</AlertTitle>
+          <AlertDescription className="text-wrap">
+            {t("page.setting.xxmi.fn.findXXMIPath.alert.description")}
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
   );
 }

--- a/src/renderer/src/components/setting/xxmi/xxmi-path.tsx
+++ b/src/renderer/src/components/setting/xxmi/xxmi-path.tsx
@@ -60,7 +60,10 @@ export function XXMIPath({ xxmiData, refetch }: { xxmiData?: XXMIData; refetch: 
         >
           {t("page.setting.xxmi.autoScan")}
         </Button>
-        <Button onClickPromise={saveXXMIPath} disabled={!xxmiPath}>
+        <Button
+          onClickPromise={saveXXMIPath}
+          disabled={!xxmiPath || xxmiPath === (xxmiData?.xxmiPath ?? "")}
+        >
           {t("g.save")}
         </Button>
       </div>

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -1627,6 +1627,7 @@
         "dllVersionDescription": "Changing the version disables XXMI Launcher auto-update.",
         "dllVersionLoading": "Loading versions...",
         "dllVersionLoadFailed": "Failed to load versions.",
+        "dllVersionRetry": "Retry",
         "dllVersionEmpty": "No versions available.",
         "dllVersionCurrent": "Current: {{version}}",
         "dllVersionUnknown": "Unknown",

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -1622,6 +1622,11 @@
         "persistToggles": "Persist Toggles",
         "persistTogglesDescription": "Permanently saves toggle states by modifying the mod INI during reload",
         "persistNotFoundXXMI": "Please set the XXMI Launcher path first.",
+        "dllVersion": "XXMI DLL Version",
+        "dllVersionDescription": "Install a specific XXMI package version. Launcher auto update will be turned off.",
+        "dllVersionLoading": "Loading versions...",
+        "dllVersionLoadFailed": "Failed to load versions.",
+        "dllVersionEmpty": "No versions available.",
         "fn": {
           "findXXMIPath": {
             "xxmiNotFound": "XXMI not found",
@@ -1633,6 +1638,10 @@
           "saveXXMIPath": {
             "success": "XXMI path has been saved",
             "configNotFound": "Cannot find XXMI Launcher Config.json file in the specified path"
+          },
+          "installDllVersion": {
+            "success": "XXMI DLL version {{version}} has been applied",
+            "failed": "Failed to apply the selected XXMI DLL version"
           }
         }
       },

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -813,6 +813,7 @@
           "XXMI_ERR_DLL_NOT_FOUND": "Could not find the built d3d11.dll file.",
           "XXMI_ERR_DLL_NOT_WRITABLE": "Cannot write d3d11.dll to the target Importer. Check the folder permissions or approve the administrator prompt.",
           "XXMI_ERR_DLL_IN_USE": "Cannot replace d3d11.dll. Close the game first, then try again.",
+          "XXMI_ERR_LAUNCHER_CLOSE_FAILED": "Could not close XXMI Launcher. Close it and try again.",
           "XXMI_ERR_ELEVATION_FAILED": "Administrator permission was denied or the elevated write failed. Approve the UAC prompt and try again.",
           "XXMI_BUILD_SUCCESS": "d3d11.dll was applied successfully.",
           "XXMI_OBFUSCATE_SUCCESS": "d3d11.dll padding was diversified successfully.",
@@ -1641,7 +1642,8 @@
           },
           "installDllVersion": {
             "success": "XXMI DLL version {{version}} has been applied",
-            "failed": "Failed to apply the selected XXMI DLL version"
+            "failed": "Failed to apply the selected XXMI DLL version",
+            "launcherCloseFailed": "Could not close XXMI Launcher. Close it and try again."
           }
         }
       },

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -1624,10 +1624,12 @@
         "persistTogglesDescription": "Permanently saves toggle states by modifying the mod INI during reload",
         "persistNotFoundXXMI": "Please set the XXMI Launcher path first.",
         "dllVersion": "XXMI DLL Version",
-        "dllVersionDescription": "Install a specific XXMI package version. Launcher auto update will be turned off.",
+        "dllVersionDescription": "Changing the version disables XXMI Launcher auto-update.",
         "dllVersionLoading": "Loading versions...",
         "dllVersionLoadFailed": "Failed to load versions.",
         "dllVersionEmpty": "No versions available.",
+        "dllVersionCurrent": "Current: {{version}}",
+        "dllVersionUnknown": "Unknown",
         "fn": {
           "findXXMIPath": {
             "xxmiNotFound": "XXMI not found",

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -1539,10 +1539,12 @@
         "persistTogglesDescription": "リロード時にMODのINIを変更して、トグル状態を永続的に保存します",
         "persistNotFoundXXMI": "先にXXMI Launcherのパスを設定してください。",
         "dllVersion": "XXMI DLLバージョン",
-        "dllVersionDescription": "指定したXXMIパッケージバージョンをインストールします。ランチャーの自動更新はオフになります。",
+        "dllVersionDescription": "バージョンを変更すると、XXMI Launcherの自動更新が無効になります。",
         "dllVersionLoading": "バージョンを読み込み中...",
         "dllVersionLoadFailed": "バージョンの読み込みに失敗しました。",
         "dllVersionEmpty": "利用可能なバージョンがありません。",
+        "dllVersionCurrent": "現在: {{version}}",
+        "dllVersionUnknown": "不明",
         "fn": {
           "findXXMIPath": {
             "xxmiNotFound": "XXMIが見つかりません",

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -1537,6 +1537,11 @@
         "persistToggles": "トグルの永続保存",
         "persistTogglesDescription": "リロード時にMODのINIを変更して、トグル状態を永続的に保存します",
         "persistNotFoundXXMI": "先にXXMI Launcherのパスを設定してください。",
+        "dllVersion": "XXMI DLLバージョン",
+        "dllVersionDescription": "指定したXXMIパッケージバージョンをインストールします。ランチャーの自動更新はオフになります。",
+        "dllVersionLoading": "バージョンを読み込み中...",
+        "dllVersionLoadFailed": "バージョンの読み込みに失敗しました。",
+        "dllVersionEmpty": "利用可能なバージョンがありません。",
         "fn": {
           "findXXMIPath": {
             "xxmiNotFound": "XXMIが見つかりません",
@@ -1548,6 +1553,10 @@
           "saveXXMIPath": {
             "success": "XXMIパスが保存されました",
             "configNotFound": "指定されたパスでXXMI Launcher Config.jsonファイルが見つかりません"
+          },
+          "installDllVersion": {
+            "success": "XXMI DLLバージョン {{version}} を適用しました",
+            "failed": "選択したXXMI DLLバージョンの適用に失敗しました"
           }
         }
       },

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -1542,6 +1542,7 @@
         "dllVersionDescription": "バージョンを変更すると、XXMI Launcherの自動更新が無効になります。",
         "dllVersionLoading": "バージョンを読み込み中...",
         "dllVersionLoadFailed": "バージョンの読み込みに失敗しました。",
+        "dllVersionRetry": "再試行",
         "dllVersionEmpty": "利用可能なバージョンがありません。",
         "dllVersionCurrent": "現在: {{version}}",
         "dllVersionUnknown": "不明",

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -778,6 +778,7 @@
           "XXMI_ERR_DLL_NOT_FOUND": "ビルドされた d3d11.dll ファイルが見つかりません。",
           "XXMI_ERR_DLL_NOT_WRITABLE": "対象 Importer に d3d11.dll を書き込めません。フォルダーの権限を確認するか、管理者権限の要求を許可してください。",
           "XXMI_ERR_DLL_IN_USE": "d3d11.dll を置き換えられません。先にゲームを終了してからもう一度お試しください。",
+          "XXMI_ERR_LAUNCHER_CLOSE_FAILED": "XXMI Launcher を終了できませんでした。手動で終了してからもう一度お試しください。",
           "XXMI_ERR_ELEVATION_FAILED": "管理者権限が拒否されたか、昇格後の書き込みに失敗しました。UAC を許可してから再試行してください。",
           "XXMI_BUILD_SUCCESS": "d3d11.dll が正常に適用されました。",
           "XXMI_OBFUSCATE_SUCCESS": "d3d11.dll のパディング多様化が完了しました。",
@@ -1556,7 +1557,8 @@
           },
           "installDllVersion": {
             "success": "XXMI DLLバージョン {{version}} を適用しました",
-            "failed": "選択したXXMI DLLバージョンの適用に失敗しました"
+            "failed": "選択したXXMI DLLバージョンの適用に失敗しました",
+            "launcherCloseFailed": "XXMI Launcher を終了できませんでした。手動で終了してからもう一度お試しください。"
           }
         }
       },

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -1561,6 +1561,7 @@
         "dllVersionDescription": "버전 변경 시 XXMI Launcher 자동 업데이트가 비활성화됩니다.",
         "dllVersionLoading": "버전을 불러오는 중...",
         "dllVersionLoadFailed": "버전을 불러오지 못했습니다.",
+        "dllVersionRetry": "다시 시도",
         "dllVersionEmpty": "사용 가능한 버전이 없습니다.",
         "dllVersionCurrent": "현재: {{version}}",
         "dllVersionUnknown": "알 수 없음",

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -1556,6 +1556,11 @@
         "persistToggles": "토글 영구 저장",
         "persistTogglesDescription": "리로드할 때 모드 ini를 수정해 토글 상태를 영구 저장합니다",
         "persistNotFoundXXMI": "XXMI Launcher 경로를 먼저 설정해 주세요.",
+        "dllVersion": "XXMI DLL 버전",
+        "dllVersionDescription": "원하는 XXMI 패키지 버전을 설치합니다. 런처 자동 업데이트는 꺼집니다.",
+        "dllVersionLoading": "버전을 불러오는 중...",
+        "dllVersionLoadFailed": "버전을 불러오지 못했습니다.",
+        "dllVersionEmpty": "사용 가능한 버전이 없습니다.",
         "fn": {
           "findXXMIPath": {
             "xxmiNotFound": "XXMI 를 찾을 수 없습니다",
@@ -1567,6 +1572,10 @@
           "saveXXMIPath": {
             "success": "XXMI 경로가 저장되었습니다",
             "configNotFound": "해당 경로에서 XXMI Launcher Config.json 파일을 찾을 수 없습니다"
+          },
+          "installDllVersion": {
+            "success": "XXMI DLL 버전 {{version}} 을 적용했습니다",
+            "failed": "선택한 XXMI DLL 버전을 적용하지 못했습니다"
           }
         }
       },

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -1558,10 +1558,12 @@
         "persistTogglesDescription": "리로드할 때 모드 ini를 수정해 토글 상태를 영구 저장합니다",
         "persistNotFoundXXMI": "XXMI Launcher 경로를 먼저 설정해 주세요.",
         "dllVersion": "XXMI DLL 버전",
-        "dllVersionDescription": "원하는 XXMI 패키지 버전을 설치합니다. 런처 자동 업데이트는 꺼집니다.",
+        "dllVersionDescription": "버전 변경 시 XXMI Launcher 자동 업데이트가 비활성화됩니다.",
         "dllVersionLoading": "버전을 불러오는 중...",
         "dllVersionLoadFailed": "버전을 불러오지 못했습니다.",
         "dllVersionEmpty": "사용 가능한 버전이 없습니다.",
+        "dllVersionCurrent": "현재: {{version}}",
+        "dllVersionUnknown": "알 수 없음",
         "fn": {
           "findXXMIPath": {
             "xxmiNotFound": "XXMI 를 찾을 수 없습니다",

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -797,6 +797,7 @@
           "XXMI_ERR_DLL_NOT_FOUND": "빌드된 d3d11.dll 파일을 찾을 수 없습니다.",
           "XXMI_ERR_DLL_NOT_WRITABLE": "대상 Importer에 d3d11.dll을 쓸 수 없습니다. 폴더 권한을 확인하거나 관리자 권한 요청을 허용하세요.",
           "XXMI_ERR_DLL_IN_USE": "d3d11.dll을 교체할 수 없습니다. 게임을 먼저 종료한 뒤 다시 시도하세요.",
+          "XXMI_ERR_LAUNCHER_CLOSE_FAILED": "XXMI Launcher를 종료하지 못했습니다. 직접 종료한 뒤 다시 시도하세요.",
           "XXMI_ERR_ELEVATION_FAILED": "관리자 권한이 거부되었거나 권한 상승 후 쓰기에 실패했습니다. UAC 확인을 허용한 뒤 다시 시도하세요.",
           "XXMI_BUILD_SUCCESS": "d3d11.dll이 성공적으로 적용되었습니다.",
           "XXMI_OBFUSCATE_SUCCESS": "d3d11.dll 패딩 다양화가 완료되었습니다.",
@@ -1575,7 +1576,8 @@
           },
           "installDllVersion": {
             "success": "XXMI DLL 버전 {{version}} 을 적용했습니다",
-            "failed": "선택한 XXMI DLL 버전을 적용하지 못했습니다"
+            "failed": "선택한 XXMI DLL 버전을 적용하지 못했습니다",
+            "launcherCloseFailed": "XXMI Launcher를 종료하지 못했습니다. 직접 종료한 뒤 다시 시도하세요."
           }
         }
       },

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -777,6 +777,7 @@
           "XXMI_ERR_DLL_NOT_FOUND": "未找到已构建的 d3d11.dll 文件。",
           "XXMI_ERR_DLL_NOT_WRITABLE": "无法将 d3d11.dll 写入目标 Importer。请检查文件夹权限，或允许管理员权限请求。",
           "XXMI_ERR_DLL_IN_USE": "无法替换 d3d11.dll。请先关闭游戏，然后重试。",
+          "XXMI_ERR_LAUNCHER_CLOSE_FAILED": "无法关闭 XXMI Launcher。请手动关闭后重试。",
           "XXMI_ERR_ELEVATION_FAILED": "管理员权限被拒绝，或提升权限后写入失败。请批准 UAC 提示后重试。",
           "XXMI_BUILD_SUCCESS": "d3d11.dll 已成功应用。",
           "XXMI_OBFUSCATE_SUCCESS": "d3d11.dll 填充已成功多样化。",
@@ -1555,7 +1556,8 @@
           },
           "installDllVersion": {
             "success": "已应用 XXMI DLL 版本 {{version}}",
-            "failed": "应用所选 XXMI DLL 版本失败"
+            "failed": "应用所选 XXMI DLL 版本失败",
+            "launcherCloseFailed": "无法关闭 XXMI Launcher。请手动关闭后重试。"
           }
         }
       },

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -1536,6 +1536,11 @@
         "persistToggles": "持久保存切换状态",
         "persistTogglesDescription": "在重载时修改模组 INI，以持久保存切换状态",
         "persistNotFoundXXMI": "请先设置 XXMI Launcher 路径。",
+        "dllVersion": "XXMI DLL 版本",
+        "dllVersionDescription": "安装指定的 XXMI 软件包版本。启动器自动更新将被关闭。",
+        "dllVersionLoading": "正在加载版本...",
+        "dllVersionLoadFailed": "无法加载版本。",
+        "dllVersionEmpty": "没有可用版本。",
         "fn": {
           "findXXMIPath": {
             "xxmiNotFound": "未找到XXMI",
@@ -1547,6 +1552,10 @@
           "saveXXMIPath": {
             "success": "XXMI路径已保存",
             "configNotFound": "在指定路径中找不到XXMI Launcher Config.json文件"
+          },
+          "installDllVersion": {
+            "success": "已应用 XXMI DLL 版本 {{version}}",
+            "failed": "应用所选 XXMI DLL 版本失败"
           }
         }
       },

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -1541,6 +1541,7 @@
         "dllVersionDescription": "更改版本时将禁用 XXMI Launcher 自动更新。",
         "dllVersionLoading": "正在加载版本...",
         "dllVersionLoadFailed": "无法加载版本。",
+        "dllVersionRetry": "重试",
         "dllVersionEmpty": "没有可用版本。",
         "dllVersionCurrent": "当前：{{version}}",
         "dllVersionUnknown": "未知",

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -1538,10 +1538,12 @@
         "persistTogglesDescription": "在重载时修改模组 INI，以持久保存切换状态",
         "persistNotFoundXXMI": "请先设置 XXMI Launcher 路径。",
         "dllVersion": "XXMI DLL 版本",
-        "dllVersionDescription": "安装指定的 XXMI 软件包版本。启动器自动更新将被关闭。",
+        "dllVersionDescription": "更改版本时将禁用 XXMI Launcher 自动更新。",
         "dllVersionLoading": "正在加载版本...",
         "dllVersionLoadFailed": "无法加载版本。",
         "dllVersionEmpty": "没有可用版本。",
+        "dllVersionCurrent": "当前：{{version}}",
+        "dllVersionUnknown": "未知",
         "fn": {
           "findXXMIPath": {
             "xxmiNotFound": "未找到XXMI",

--- a/src/renderer/src/routes/setting/xxmi.tsx
+++ b/src/renderer/src/routes/setting/xxmi.tsx
@@ -27,7 +27,7 @@ function XXMIRouteContent() {
     <main className="mx-auto flex w-full flex-1 flex-col space-y-6 p-4 select-none">
       <XXMIPath xxmiData={xxmiData} refetch={refetch} />
       <Separator />
-      <XXMIDllVersion xxmiData={xxmiData} />
+      <XXMIDllVersion xxmiData={xxmiData} refetch={refetch} />
       {xxmiData?.xxmiConfig && (
         <>
           <Separator />

--- a/src/renderer/src/routes/setting/xxmi.tsx
+++ b/src/renderer/src/routes/setting/xxmi.tsx
@@ -1,3 +1,4 @@
+import { XXMIDllVersion } from "@renderer/components/setting/xxmi/xxmi-dll-version";
 import { XXMIImporters } from "@renderer/components/setting/xxmi/xxmi-importers";
 import { XXMIPath } from "@renderer/components/setting/xxmi/xxmi-path";
 import { useQuery } from "@tanstack/react-query";
@@ -22,8 +23,9 @@ function XXMIRouteContent() {
   });
 
   return (
-    <main className="flex-1 flex flex-col mx-auto p-4 space-y-6 w-full select-none">
+    <main className="mx-auto flex w-full flex-1 flex-col space-y-6 p-4 select-none">
       <XXMIPath xxmiData={xxmiData} refetch={refetch} />
+      <XXMIDllVersion xxmiData={xxmiData} />
       <XXMIImporters xxmiData={xxmiData} />
     </main>
   );

--- a/src/renderer/src/routes/setting/xxmi.tsx
+++ b/src/renderer/src/routes/setting/xxmi.tsx
@@ -1,6 +1,7 @@
 import { XXMIDllVersion } from "@renderer/components/setting/xxmi/xxmi-dll-version";
 import { XXMIImporters } from "@renderer/components/setting/xxmi/xxmi-importers";
 import { XXMIPath } from "@renderer/components/setting/xxmi/xxmi-path";
+import { Separator } from "@renderer/components/ui/separator";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 
@@ -25,8 +26,14 @@ function XXMIRouteContent() {
   return (
     <main className="mx-auto flex w-full flex-1 flex-col space-y-6 p-4 select-none">
       <XXMIPath xxmiData={xxmiData} refetch={refetch} />
+      <Separator />
       <XXMIDllVersion xxmiData={xxmiData} />
-      <XXMIImporters xxmiData={xxmiData} />
+      {xxmiData?.xxmiConfig && (
+        <>
+          <Separator />
+          <XXMIImporters xxmiData={xxmiData} />
+        </>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Add a selectable XXMI DLL version installer on the settings page, including GitHub release listing and package download.
- Close XXMI Launcher before replacing DLL files, and install the matching `Manifest.json` so the current version can be shown.
- Align the XXMI settings layout with other settings pages, and disable path/DLL actions when nothing would change.

## Test plan
- [ ] Open Settings → XXMI with no path set and confirm the DLL version control stays disabled.
- [ ] Set a valid XXMI path, confirm the current DLL version appears, and that Confirm is disabled while the selected version matches it.
- [ ] Install a different DLL version while XXMI Launcher is running and confirm the launcher is closed first.
- [ ] After install, confirm `Resources/Packages/XXMI/Manifest.json` is present and the settings page shows the new version.
- [ ] Confirm importer settings still appear when XXMI config is available, and that changing the path to the same value does not enable save.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Writes into the user's XXMI install (package files and launcher config) and forcibly closes XXMI Launcher; failures could leave a partial install or confuse users if the launcher won't close, but operations are scoped and validated (manifest version, busy flag).
> 
> **Overview**
> Adds **XXMI DLL version management** on Settings → XXMI: users can pick a release from GitHub, install it into `Resources/Packages/XXMI`, and see the installed version from `Manifest.json`. Applying a version turns off **XXMI Launcher auto-update** in launcher config.
> 
> **Backend:** New shared `xxmi-libs-releases` module (cached GitHub release listing) replaces duplicate logic in the 4001 fixer. `installDllVersion` downloads the release zip and manifest, validates version, and copies files after closing the launcher. `ensureLauncherClosed` kills `XXMI Launcher.exe` with a 5s timeout—used for DLL install and before 4001 fixer build/diversify/restore so files aren’t locked.
> 
> **UI:** New `XXMIDllVersion` control; path/importer sections drop card wrappers and align with other settings. Save path is disabled when unchanged; Confirm is disabled when the selected version matches the current one. New i18n strings (en/ja/ko/zh) including launcher-close failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 983f3d433de334866d60419ad5b94baf77ef308b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added XXMI DLL version management in Settings.
  * View available releases, select a version, and install it with success or failure notifications.
  * The installed DLL version is now displayed.
  * XXMI Launcher closes automatically before related operations.
* **Bug Fixes**
  * Improved release retrieval with caching and duplicate-request prevention.
  * Added clearer handling when the launcher cannot be closed.
* **Style**
  * Simplified XXMI path and importer layouts.
* **Localization**
  * Added English, Japanese, Korean, and Chinese translations for new messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->