### PR TITLE
feat(mod): add create folder to character sidebar menu

### DIFF
--- a/src/renderer/src/components/mod/character-sidebar.tsx
+++ b/src/renderer/src/components/mod/character-sidebar.tsx
@@ -38,6 +38,7 @@ import { Input } from "@renderer/components/ui/input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@renderer/components/ui/tooltip";
 import { useConfirmTrash } from "@renderer/hooks/use-confirm-trash";
 import { useDelayedSkeleton } from "@renderer/hooks/use-delayed-skeleton";
+import { useGames } from "@renderer/hooks/use-mod-data";
 import { useSidebarLayoutSetting } from "@renderer/hooks/use-settings";
 import { setSetting } from "@renderer/lib/settings";
 import { useModStore } from "@renderer/store/mod";
@@ -49,12 +50,13 @@ import {
   ArrowDownIcon,
   ArrowUpDownIcon,
   ArrowUpIcon,
+  EllipsisIcon,
+  FolderPlus,
   FolderXIcon,
   LayoutGridIcon,
   ListIcon,
   Loader2Icon,
   Search,
-  SlidersHorizontalIcon,
 } from "lucide-react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -123,6 +125,8 @@ export const CharacterSidebar = memo(function CharacterSidebar({
   const markUserSelectedDuringDownload = useModStore((s) => s.markUserSelectedDuringDownload);
   const selectedGame = useModStore((s) => s.selectedGame);
   const selectedGroup = useModStore((s) => s.selectedGroup);
+  const { data: games = [] } = useGames();
+  const selectedGameConfig = games.find((game) => game.game === selectedGame);
   const setExpandedGroup = useModStore((s) => s.setExpandedGroup);
   const [searchTerm, setSearchTerm] = useState("");
   const sortKey = useModStore((s) => s.folderSortKey);
@@ -456,19 +460,37 @@ export const CharacterSidebar = memo(function CharacterSidebar({
                         type="button"
                         size="icon"
                         variant="ghost"
-                        aria-label={t("page.mod.character-sidebar.sort.label")}
+                        aria-label={t("page.mod.character-sidebar.more-options")}
                       />
                     }
                   />
                 }
               >
-                <SlidersHorizontalIcon />
+                <EllipsisIcon />
               </TooltipTrigger>
               <TooltipContent side="bottom">
-                {t("page.mod.character-sidebar.sort.label")}
+                {t("page.mod.character-sidebar.more-options")}
               </TooltipContent>
             </Tooltip>
             <DropdownMenuContent align="end" className="w-56" finalFocus={false}>
+              <DropdownMenuItem
+                disabled={!selectedGameConfig?.modFolderPath}
+                onClick={() => {
+                  if (!selectedGameConfig?.modFolderPath) {
+                    return;
+                  }
+
+                  handleCreateFolderOpen({
+                    name: selectedGameConfig.game,
+                    path: selectedGameConfig.modFolderPath,
+                    mods: [],
+                  });
+                }}
+              >
+                <FolderPlus />
+                {t("page.mod.character-sidebar.create-folder")}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <DropdownMenuSub>
                 <DropdownMenuSubTrigger>
                   <ArrowUpDownIcon />

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -299,6 +299,7 @@
           "ascending": "Ascending",
           "descending": "Descending"
         },
+        "more-options": "More options",
         "hide-empty-folders": "Hide empty folders",
         "toggle-layout": "Switch to {{mode}}",
         "active-mod-count": "{{enabled}} active / {{total}} total",

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -283,6 +283,7 @@
           "ascending": "昇順",
           "descending": "降順"
         },
+        "more-options": "その他",
         "hide-empty-folders": "空のフォルダーを非表示",
         "toggle-layout": "{{mode}}に切り替え",
         "active-mod-count": "有効 {{enabled}} 件 / 全 {{total}} 件",

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -282,6 +282,7 @@
           "ascending": "오름차순",
           "descending": "내림차순"
         },
+        "more-options": "더보기",
         "hide-empty-folders": "빈 폴더 숨기기",
         "toggle-layout": "{{mode, josa(pair: 으로/로)}} 전환",
         "active-mod-count": "활성 {{enabled}}개 / 전체 {{total}}개",

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -282,6 +282,7 @@
           "ascending": "升序",
           "descending": "降序"
         },
+        "more-options": "更多选项",
         "hide-empty-folders": "隐藏空文件夹",
         "toggle-layout": "切换到{{mode}}",
         "active-mod-count": "已启用 {{enabled}} 个 / 共 {{total}} 个",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Reuses the existing folder-creation dialog and `util:fs:mkdir` flow; changes are limited to UI entry point and i18n.
> 
> **Overview**
> The character sidebar toolbar **overflow menu** is relabeled from sort-only to **“More options”** (ellipsis icon instead of sliders), and a new **Create New Folder** action sits at the top of that menu.
> 
> Choosing it opens the **existing** create-folder dialog with the **selected game’s mod root** (`modFolderPath` from game config) as the parent. The action is **disabled** when that path is not configured. Sort, hide empty folders, and layout toggle remain in the same dropdown below a separator.
> 
> Locale strings for **more-options** were added in en, ja, ko, and zh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4135bc70a5262e64d328828bdf910c5ac09f9db7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more-options menu to the character sidebar.
  * Added a root-level option to create folders.
  * Folder creation is unavailable when the selected game lacks a mod folder location.
  * Existing sorting and sidebar controls remain accessible.
* **Localization**
  * Added translated labels for the more-options menu in English, Japanese, Korean, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->