### PR TITLE
feat(akasha): pack small unique files during upload

### DIFF
--- a/src/main/lib/upload-pack.test.ts
+++ b/src/main/lib/upload-pack.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    creditedLogicalBytesForMember,
+    DIRECT_UPLOAD_THRESHOLD,
+    logicalBytesForPackProgress,
+    PACK_MEMBER_MAX,
+    packUploadUrl,
+    partitionPackedUploads,
+} from "./upload-pack";
+
+describe("partitionPackedUploads", () => {
+    it("packs adjacent small files and keeps oversized files single", () => {
+        const groups = partitionPackedUploads([
+            { id: "a", payloadBytes: 10 },
+            { id: "b", payloadBytes: 20 },
+            { id: "c", payloadBytes: PACK_MEMBER_MAX + 1 },
+            { id: "d", payloadBytes: 30 },
+            { id: "e", payloadBytes: 40 },
+        ]);
+
+        expect(groups).toEqual([
+            {
+                kind: "pack",
+                members: [
+                    { id: "a", payloadBytes: 10 },
+                    { id: "b", payloadBytes: 20 },
+                ],
+            },
+            { kind: "single", member: { id: "c", payloadBytes: PACK_MEMBER_MAX + 1 } },
+            {
+                kind: "pack",
+                members: [
+                    { id: "d", payloadBytes: 30 },
+                    { id: "e", payloadBytes: 40 },
+                ],
+            },
+        ]);
+    });
+
+    it("flushes a pack when the payload budget is reached", () => {
+        const members = Array.from({ length: 23 }, (_, index) => ({
+            id: String(index),
+            payloadBytes: PACK_MEMBER_MAX,
+        }));
+        const groups = partitionPackedUploads(members);
+
+        expect(groups[0]).toEqual({
+            kind: "pack",
+            members: members.slice(0, 22),
+        });
+        expect(groups[1]).toEqual({ kind: "single", member: members[22] });
+    });
+});
+
+describe("packUploadUrl", () => {
+    it("rewrites an intent upload URL to the pack endpoint", () => {
+        expect(packUploadUrl("https://api.nahida.live/akasha/v2/uploads/intent-1")).toBe(
+            "https://api.nahida.live/akasha/v2/uploads:pack",
+        );
+    });
+});
+
+describe("logicalBytesForPackProgress", () => {
+    const members = [
+        { logicalSize: 10, payloadBytes: 5 },
+        { logicalSize: 20, payloadBytes: 10 },
+    ];
+
+    it("credits whole members as their payloads complete", () => {
+        expect(logicalBytesForPackProgress(members, 5)).toBe(10);
+        expect(logicalBytesForPackProgress(members, 15)).toBe(30);
+    });
+
+    it("credits a partial member by payload ratio", () => {
+        expect(logicalBytesForPackProgress(members, 10)).toBe(20);
+        expect(creditedLogicalBytesForMember(members, 1, 10)).toBe(10);
+    });
+});
+
+describe("DIRECT_UPLOAD_THRESHOLD", () => {
+    it("stays below the 100MiB request body limit", () => {
+        expect(DIRECT_UPLOAD_THRESHOLD).toBe(80 * 1024 * 1024);
+    });
+});

--- a/src/main/lib/upload-pack.test.ts
+++ b/src/main/lib/upload-pack.test.ts
@@ -59,6 +59,18 @@ describe("packUploadUrl", () => {
             "https://api.nahida.live/akasha/v2/uploads:pack",
         );
     });
+
+    it("preserves a query string and fragment", () => {
+        expect(
+            packUploadUrl("https://api.nahida.live/akasha/v2/uploads/intent-1?sig=abc#frag"),
+        ).toBe("https://api.nahida.live/akasha/v2/uploads:pack?sig=abc#frag");
+    });
+
+    it("throws when the URL has no intent upload segment", () => {
+        expect(() => packUploadUrl("https://api.nahida.live/akasha/v2/other/intent-1?x=1")).toThrow(
+            "pack_url_unresolved",
+        );
+    });
 });
 
 describe("logicalBytesForPackProgress", () => {

--- a/src/main/lib/upload-pack.ts
+++ b/src/main/lib/upload-pack.ts
@@ -45,7 +45,9 @@ export function partitionPackedUploads<T extends { payloadBytes: number }>(
 }
 
 export function packUploadUrl(intentUrl: string) {
-    return intentUrl.replace(/\/uploads\/[^/?#]+$/, "/uploads:pack");
+    const packed = intentUrl.replace(/\/uploads\/[^/?#]+(?=[?#]|$)/, "/uploads:pack");
+    if (packed === intentUrl) throw new Error("pack_url_unresolved");
+    return packed;
 }
 
 export function logicalBytesForPackProgress(

--- a/src/main/lib/upload-pack.ts
+++ b/src/main/lib/upload-pack.ts
@@ -1,0 +1,84 @@
+export const MAX_UPLOAD_BODY_BYTES = 100 * 1024 * 1024;
+export const PACK_PAYLOAD_BUDGET = 90 * 1024 * 1024;
+export const PACK_MEMBER_MAX = 4 * 1024 * 1024;
+export const PACK_MAX_FILES = 100;
+export const DIRECT_UPLOAD_THRESHOLD = 80 * 1024 * 1024;
+
+export type PackedUploadGroup<T extends { payloadBytes: number }> =
+    | { kind: "pack"; members: T[] }
+    | { kind: "single"; member: T };
+
+export function partitionPackedUploads<T extends { payloadBytes: number }>(
+    members: T[],
+): PackedUploadGroup<T>[] {
+    const groups: T[][] = [];
+    let current: T[] = [];
+    let bytes = 0;
+    for (const member of members) {
+        if (member.payloadBytes > PACK_MEMBER_MAX) {
+            if (current.length > 0) {
+                groups.push(current);
+                current = [];
+                bytes = 0;
+            }
+            groups.push([member]);
+            continue;
+        }
+        if (
+            current.length > 0 &&
+            (current.length >= PACK_MAX_FILES || bytes + member.payloadBytes > PACK_PAYLOAD_BUDGET)
+        ) {
+            groups.push(current);
+            current = [];
+            bytes = 0;
+        }
+        current.push(member);
+        bytes += member.payloadBytes;
+    }
+    if (current.length > 0) groups.push(current);
+
+    return groups.map((group) =>
+        group.length === 1
+            ? { kind: "single" as const, member: group[0] }
+            : { kind: "pack" as const, members: group },
+    );
+}
+
+export function packUploadUrl(intentUrl: string) {
+    return intentUrl.replace(/\/uploads\/[^/?#]+$/, "/uploads:pack");
+}
+
+export function logicalBytesForPackProgress(
+    members: Array<{ logicalSize: number; payloadBytes: number }>,
+    uploadedPayload: number,
+) {
+    let credited = 0;
+    let cursor = 0;
+    for (const member of members) {
+        const start = cursor;
+        const end = cursor + member.payloadBytes;
+        cursor = end;
+        if (uploadedPayload >= end) credited += member.logicalSize;
+        else if (uploadedPayload > start && member.payloadBytes > 0) {
+            credited += Math.floor(
+                (member.logicalSize * (uploadedPayload - start)) / member.payloadBytes,
+            );
+        }
+    }
+    return credited;
+}
+
+export function creditedLogicalBytesForMember(
+    members: Array<{ logicalSize: number; payloadBytes: number }>,
+    memberIndex: number,
+    uploadedPayload: number,
+) {
+    const member = members[memberIndex];
+    if (!member) return 0;
+    const start = members.slice(0, memberIndex).reduce((sum, item) => sum + item.payloadBytes, 0);
+    if (uploadedPayload <= start) return 0;
+    if (member.payloadBytes <= 0 || uploadedPayload >= start + member.payloadBytes) {
+        return member.logicalSize;
+    }
+    return Math.floor((member.logicalSize * (uploadedPayload - start)) / member.payloadBytes);
+}

--- a/src/main/lib/upload-v2.test.ts
+++ b/src/main/lib/upload-v2.test.ts
@@ -394,6 +394,7 @@ describe("uploadDriveFilesV2", () => {
             ),
         );
 
+        const progress: UploadProgress[] = [];
         await expect(
             uploadDriveFilesV2({
                 desktop,
@@ -405,8 +406,71 @@ describe("uploadDriveFilesV2", () => {
                 ],
                 queue: new PQueue({ concurrency: 1 }),
                 prepareDirectFile: async () => ({ data: Buffer.from("payload") }),
+                onProgress: (event) => progress.push(event),
             }),
         ).rejects.toThrow("second.txt: sha256_mismatch");
+        expect(progress.map((event) => event.fileId).filter(Boolean)).toEqual(["first"]);
+        expect(progress.reduce((sum, event) => sum + event.bytes, 0)).toBe(10);
+    });
+
+    it("attributes reversed pack results by intentId", async () => {
+        mocks.networkFetch.mockResolvedValue(
+            sseResponse([
+                {
+                    event: "complete",
+                    data: {
+                        requestId: "request-id",
+                        items: [
+                            { clientId: "first", status: "pending", intentId: "intent-a" },
+                            { clientId: "second", status: "pending", intentId: "intent-b" },
+                        ],
+                        uploads: [
+                            {
+                                intentId: "intent-a",
+                                url: "https://api.nahida.live/akasha/v2/uploads/intent-a",
+                                method: "POST",
+                                form: { token: "token-a", sha256: "a".repeat(64) },
+                            },
+                            {
+                                intentId: "intent-b",
+                                url: "https://api.nahida.live/akasha/v2/uploads/intent-b",
+                                method: "POST",
+                                form: { token: "token-b", sha256: "b".repeat(64) },
+                            },
+                        ],
+                    },
+                },
+            ]),
+        );
+        mocks.request.mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    results: [
+                        { intentId: "intent-b", status: "failed", reason: "sha256_mismatch" },
+                        { intentId: "intent-a", status: "completed", fileId: "file-a" },
+                    ],
+                }),
+                { status: 200 },
+            ),
+        );
+        const progress: UploadProgress[] = [];
+
+        await expect(
+            uploadDriveFilesV2({
+                desktop,
+                currentId: "current",
+                requestId: "request-id",
+                files: [
+                    { ...file("first"), sha256: "a".repeat(64) },
+                    { ...file("second"), sha256: "b".repeat(64) },
+                ],
+                queue: new PQueue({ concurrency: 1 }),
+                prepareDirectFile: async () => ({ data: Buffer.from("payload") }),
+                onProgress: (event) => progress.push(event),
+            }),
+        ).rejects.toThrow("second.txt: sha256_mismatch");
+        expect(progress.map((event) => event.fileId).filter(Boolean)).toEqual(["first"]);
+        expect(progress.reduce((sum, event) => sum + event.bytes, 0)).toBe(10);
     });
 
     it("reports denied plan items as a failed upload", async () => {

--- a/src/main/lib/upload-v2.test.ts
+++ b/src/main/lib/upload-v2.test.ts
@@ -248,6 +248,167 @@ describe("uploadDriveFilesV2", () => {
         expect(progress.reduce((sum, event) => sum + event.bytes, 0)).toBe(20);
     });
 
+    it("uploads distinct small files in one pack request", async () => {
+        mocks.networkFetch.mockResolvedValue(
+            sseResponse([
+                {
+                    event: "complete",
+                    data: {
+                        requestId: "request-id",
+                        items: [
+                            { clientId: "first", status: "pending", intentId: "intent-a" },
+                            { clientId: "second", status: "pending", intentId: "intent-b" },
+                        ],
+                        uploads: [
+                            {
+                                intentId: "intent-a",
+                                url: "https://api.nahida.live/akasha/v2/uploads/intent-a",
+                                method: "POST",
+                                form: { token: "token-a", sha256: "a".repeat(64) },
+                            },
+                            {
+                                intentId: "intent-b",
+                                url: "https://api.nahida.live/akasha/v2/uploads/intent-b",
+                                method: "POST",
+                                form: { token: "token-b", sha256: "b".repeat(64) },
+                            },
+                        ],
+                    },
+                },
+            ]),
+        );
+        mocks.request.mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    results: [
+                        { intentId: "intent-a", status: "completed", fileId: "file-a" },
+                        { intentId: "intent-b", status: "completed", fileId: "file-b" },
+                    ],
+                }),
+                { status: 200 },
+            ),
+        );
+        const progress: UploadProgress[] = [];
+
+        await uploadDriveFilesV2({
+            desktop,
+            currentId: "current",
+            requestId: "request-id",
+            files: [
+                { ...file("first"), sha256: "a".repeat(64) },
+                { ...file("second"), sha256: "b".repeat(64) },
+            ],
+            queue: new PQueue({ concurrency: 2 }),
+            prepareDirectFile: async () => ({ data: Buffer.from("payload") }),
+            onProgress: (event) => progress.push(event),
+        });
+
+        expect(mocks.request).toHaveBeenCalledTimes(1);
+        expect(mocks.request.mock.calls[0]?.[0]).toBe(
+            "https://api.nahida.live/akasha/v2/uploads:pack",
+        );
+        expect(progress.filter((event) => event.fileId).map((event) => event.fileId)).toEqual([
+            "first",
+            "second",
+        ]);
+        expect(progress.reduce((sum, event) => sum + event.bytes, 0)).toBe(20);
+    });
+
+    it("keeps a file above the pack member limit on the single-intent path", async () => {
+        mocks.networkFetch.mockResolvedValue(
+            sseResponse([
+                {
+                    event: "complete",
+                    data: {
+                        requestId: "request-id",
+                        items: [{ clientId: "big", status: "pending", intentId: "intent" }],
+                        uploads: [
+                            {
+                                intentId: "intent",
+                                url: "https://api.nahida.live/akasha/v2/uploads/intent",
+                                method: "POST",
+                                form: { token: "token", sha256: "a".repeat(64) },
+                            },
+                        ],
+                    },
+                },
+            ]),
+        );
+        mocks.request.mockResolvedValue(
+            new Response(JSON.stringify({ status: "completed" }), { status: 200 }),
+        );
+
+        await uploadDriveFilesV2({
+            desktop,
+            currentId: "current",
+            requestId: "request-id",
+            files: [{ ...file("big"), size: 5 * 1024 * 1024 }],
+            queue: new PQueue({ concurrency: 1 }),
+            prepareDirectFile: async () => ({ data: Buffer.alloc(5 * 1024 * 1024) }),
+        });
+
+        expect(mocks.request).toHaveBeenCalledTimes(1);
+        expect(mocks.request.mock.calls[0]?.[0]).toBe(
+            "https://api.nahida.live/akasha/v2/uploads/intent",
+        );
+    });
+
+    it("keeps completed pack members and fails the rest", async () => {
+        mocks.networkFetch.mockResolvedValue(
+            sseResponse([
+                {
+                    event: "complete",
+                    data: {
+                        requestId: "request-id",
+                        items: [
+                            { clientId: "first", status: "pending", intentId: "intent-a" },
+                            { clientId: "second", status: "pending", intentId: "intent-b" },
+                        ],
+                        uploads: [
+                            {
+                                intentId: "intent-a",
+                                url: "https://api.nahida.live/akasha/v2/uploads/intent-a",
+                                method: "POST",
+                                form: { token: "token-a", sha256: "a".repeat(64) },
+                            },
+                            {
+                                intentId: "intent-b",
+                                url: "https://api.nahida.live/akasha/v2/uploads/intent-b",
+                                method: "POST",
+                                form: { token: "token-b", sha256: "b".repeat(64) },
+                            },
+                        ],
+                    },
+                },
+            ]),
+        );
+        mocks.request.mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    results: [
+                        { intentId: "intent-a", status: "completed", fileId: "file-a" },
+                        { intentId: "intent-b", status: "failed", reason: "sha256_mismatch" },
+                    ],
+                }),
+                { status: 200 },
+            ),
+        );
+
+        await expect(
+            uploadDriveFilesV2({
+                desktop,
+                currentId: "current",
+                requestId: "request-id",
+                files: [
+                    { ...file("first"), sha256: "a".repeat(64) },
+                    { ...file("second"), sha256: "b".repeat(64) },
+                ],
+                queue: new PQueue({ concurrency: 1 }),
+                prepareDirectFile: async () => ({ data: Buffer.from("payload") }),
+            }),
+        ).rejects.toThrow("second.txt: sha256_mismatch");
+    });
+
     it("reports denied plan items as a failed upload", async () => {
         mocks.networkFetch.mockResolvedValue(
             sseResponse([

--- a/src/main/lib/upload-v2.test.ts
+++ b/src/main/lib/upload-v2.test.ts
@@ -473,6 +473,70 @@ describe("uploadDriveFilesV2", () => {
         expect(progress.reduce((sum, event) => sum + event.bytes, 0)).toBe(10);
     });
 
+    it("propagates cancellation after the final pack flush", async () => {
+        const requestStarted = Promise.withResolvers<void>();
+        const requestFinished = Promise.withResolvers<Response>();
+        mocks.networkFetch.mockResolvedValue(
+            sseResponse([
+                {
+                    event: "complete",
+                    data: {
+                        requestId: "request-id",
+                        items: [
+                            { clientId: "first", status: "pending", intentId: "intent-a" },
+                            { clientId: "second", status: "pending", intentId: "intent-b" },
+                        ],
+                        uploads: [
+                            {
+                                intentId: "intent-a",
+                                url: "https://api.nahida.live/akasha/v2/uploads/intent-a",
+                                method: "POST",
+                                form: { token: "token-a", sha256: "a".repeat(64) },
+                            },
+                            {
+                                intentId: "intent-b",
+                                url: "https://api.nahida.live/akasha/v2/uploads/intent-b",
+                                method: "POST",
+                                form: { token: "token-b", sha256: "b".repeat(64) },
+                            },
+                        ],
+                    },
+                },
+            ]),
+        );
+        mocks.request.mockImplementation(() => {
+            requestStarted.resolve();
+            return requestFinished.promise;
+        });
+        const controller = new AbortController();
+        const upload = uploadDriveFilesV2({
+            desktop,
+            currentId: "current",
+            requestId: "request-id",
+            files: [
+                { ...file("first"), sha256: "a".repeat(64) },
+                { ...file("second"), sha256: "b".repeat(64) },
+            ],
+            queue: new PQueue({ concurrency: 1 }),
+            prepareDirectFile: async () => ({ data: Buffer.from("payload") }),
+            signal: controller.signal,
+        });
+        await requestStarted.promise;
+        controller.abort();
+        requestFinished.resolve(
+            new Response(
+                JSON.stringify({
+                    results: [
+                        { intentId: "intent-a", status: "completed", fileId: "file-a" },
+                        { intentId: "intent-b", status: "completed", fileId: "file-b" },
+                    ],
+                }),
+                { status: 200 },
+            ),
+        );
+        await expect(upload).rejects.toMatchObject({ name: "AbortError" });
+    });
+
     it("reports denied plan items as a failed upload", async () => {
         mocks.networkFetch.mockResolvedValue(
             sseResponse([

--- a/src/main/lib/upload-v2.ts
+++ b/src/main/lib/upload-v2.ts
@@ -255,10 +255,12 @@ export async function uploadDriveFilesV2({
         if (packed.length >= PACK_MAX_FILES || packedBytes >= PACK_PAYLOAD_BUDGET) {
             flushPacked();
             await queue.onSizeLessThan(Math.max(1, queue.concurrency));
+            signal?.throwIfAborted();
         }
     }
     flushPacked();
     await queue.onIdle();
+    signal?.throwIfAborted();
 
     if (rejected.length > 0) {
         failures.push(

--- a/src/main/lib/upload-v2.ts
+++ b/src/main/lib/upload-v2.ts
@@ -252,7 +252,10 @@ export async function uploadDriveFilesV2({
             logicalSize: source.size,
         });
         const packedBytes = packed.reduce((sum, member) => sum + member.payloadBytes, 0);
-        if (packed.length >= PACK_MAX_FILES || packedBytes >= PACK_PAYLOAD_BUDGET) flushPacked();
+        if (packed.length >= PACK_MAX_FILES || packedBytes >= PACK_PAYLOAD_BUDGET) {
+            flushPacked();
+            await queue.onSizeLessThan(Math.max(1, queue.concurrency));
+        }
     }
     flushPacked();
     await queue.onIdle();
@@ -335,15 +338,15 @@ async function uploadPack({
         if (result.status >= 200 && result.status < 300 && result.status !== 202) {
             const packResults = (result.payload as { results?: IntentPackResult[] } | undefined)
                 ?.results;
-            if (!packResults || packResults.length !== members.length) {
+            if (!packResults) {
                 onProgress?.({ bytes: -reportedBytes, isServerDeduplicated: false });
                 throw new Error(result.reason ?? "pack_result_missing");
             }
             const failures: string[] = [];
-            packResults.forEach((packResult, index) => {
-                const member = members[index];
+            members.forEach((member, index) => {
+                const packResult = packResultForIntent(packResults, member.upload.intentId);
                 const credited = creditedLogicalBytesForMember(members, index, uploadedPayload);
-                if (packResult.status === "completed") {
+                if (packResult?.status === "completed") {
                     if (credited < member.logicalSize) {
                         onProgress?.({
                             bytes: member.logicalSize - credited,
@@ -356,7 +359,9 @@ async function uploadPack({
                 if (credited > 0) {
                     onProgress?.({ bytes: -credited, isServerDeduplicated: false });
                 }
-                failures.push(`${member.source.name}: ${packResult.reason ?? packResult.status}`);
+                failures.push(
+                    `${member.source.name}: ${packResult?.reason ?? packResult?.status ?? "pack_result_missing"}`,
+                );
             });
             if (failures.length > 0) throw new Error(failures.join(", "));
             return;
@@ -365,6 +370,12 @@ async function uploadPack({
         if (!isRetryable(result) || attempt === RETRY_LIMIT) throw httpError(result);
         await retryDelay(attempt, signal);
     }
+}
+
+function packResultForIntent(results: IntentPackResult[], intentId: string) {
+    const matches = results.filter((result) => result.intentId === intentId);
+    if (matches.length !== 1) return undefined;
+    return matches[0];
 }
 
 function markIntentProgress(

--- a/src/main/lib/upload-v2.ts
+++ b/src/main/lib/upload-v2.ts
@@ -14,8 +14,17 @@ import { parseServerSentEvents } from "parse-sse";
 import type { NahidaDesktop } from "..";
 import type { FinalFile, UploadProgress } from "./upload";
 
+import {
+    creditedLogicalBytesForMember,
+    DIRECT_UPLOAD_THRESHOLD,
+    logicalBytesForPackProgress,
+    PACK_MAX_FILES,
+    PACK_PAYLOAD_BUDGET,
+    packUploadUrl,
+    partitionPackedUploads,
+} from "./upload-pack";
+
 const PLAN_PAGE_SIZE = 500;
-const DIRECT_UPLOAD_THRESHOLD = 80 * 1024 * 1024;
 const PART_SIZE = 25 * 1024 * 1024;
 const RETRY_LIMIT = 3;
 const COMPLETE_TIMEOUT_MS = 15 * 60 * 1000;
@@ -36,10 +45,26 @@ type UploadPlanEntry = {
     form: { token: string; sha256: string };
 };
 
+type IntentPackResult = {
+    intentId: string;
+    status: "completed" | "failed" | "pending";
+    fileId?: string;
+    reason?: string;
+};
+
 type HttpResult = {
     status: number;
     reason?: string;
-    payload?: { status?: string };
+    payload?: { status?: string; results?: IntentPackResult[] };
+};
+
+type PreparedUpload = {
+    upload: UploadPlanEntry;
+    source: FinalFile;
+    copies: FinalFile[];
+    prepared: { data: Buffer; compAlg?: "zstd" };
+    payloadBytes: number;
+    logicalSize: number;
 };
 
 export async function uploadDriveFilesV2({
@@ -162,39 +187,74 @@ export async function uploadDriveFilesV2({
     onPlanComplete?.();
 
     const failures: Error[] = [];
-    [...pendingByIntent.entries()].forEach(([intentId, targets]) => {
-        void queue.add(async () => {
-            const upload = uploads.get(intentId);
-            if (!upload) {
-                failures.push(new Error(`Upload intent missing for ${targets[0].name}`));
-                return;
-            }
-            try {
-                const source = targets[0];
-                await uploadIntent({
-                    desktop,
-                    upload,
-                    file: source,
-                    prepareDirectFile,
-                    signal,
-                    onProgress: (bytes) => onProgress?.({ bytes, isServerDeduplicated: false }),
-                });
-                onProgress?.({ bytes: 0, fileId: source.FID, isServerDeduplicated: false });
-                targets.slice(1).forEach((file) =>
-                    onProgress?.({
-                        bytes: file.size,
-                        fileId: file.FID,
-                        isServerDeduplicated: true,
-                    }),
-                );
-            } catch (error) {
-                if (!signal?.aborted) {
-                    desktop.logger.error(error, `UploadV2:intent:${intentId}`);
-                    failures.push(error instanceof Error ? error : new Error(String(error)));
+    const packed: PreparedUpload[] = [];
+    const flushPacked = () => {
+        const groups = partitionPackedUploads(packed.splice(0));
+        for (const group of groups) {
+            void queue.add(async () => {
+                try {
+                    if (group.kind === "single") {
+                        await uploadPreparedIntent({
+                            desktop,
+                            member: group.member,
+                            signal,
+                            onProgress,
+                        });
+                        return;
+                    }
+                    await uploadPack({
+                        desktop,
+                        members: group.members,
+                        signal,
+                        onProgress,
+                    });
+                } catch (error) {
+                    if (!signal?.aborted) {
+                        desktop.logger.error(error, "UploadV2:pack");
+                        failures.push(error instanceof Error ? error : new Error(String(error)));
+                    }
                 }
-            }
+            });
+        }
+    };
+
+    for (const [intentId, targets] of pendingByIntent.entries()) {
+        signal?.throwIfAborted();
+        const upload = uploads.get(intentId);
+        if (!upload) {
+            failures.push(new Error(`Upload intent missing for ${targets[0].name}`));
+            continue;
+        }
+        const source = targets[0];
+        if (source.size >= DIRECT_UPLOAD_THRESHOLD) {
+            void queue.add(async () => {
+                try {
+                    await uploadParts(desktop, upload, source, signal, (bytes) =>
+                        onProgress?.({ bytes, isServerDeduplicated: false }),
+                    );
+                    markIntentProgress(source, targets.slice(1), onProgress);
+                } catch (error) {
+                    if (!signal?.aborted) {
+                        desktop.logger.error(error, `UploadV2:intent:${intentId}`);
+                        failures.push(error instanceof Error ? error : new Error(String(error)));
+                    }
+                }
+            });
+            continue;
+        }
+        const prepared = await prepareDirectFile(source);
+        packed.push({
+            upload,
+            source,
+            copies: targets.slice(1),
+            prepared,
+            payloadBytes: prepared.data.byteLength,
+            logicalSize: source.size,
         });
-    });
+        const packedBytes = packed.reduce((sum, member) => sum + member.payloadBytes, 0);
+        if (packed.length >= PACK_MAX_FILES || packedBytes >= PACK_PAYLOAD_BUDGET) flushPacked();
+    }
+    flushPacked();
     await queue.onIdle();
 
     if (rejected.length > 0) {
@@ -212,28 +272,114 @@ export async function uploadDriveFilesV2({
     if (failures.length > 0) throw new Error(failures.map((error) => error.message).join("\n"));
 }
 
-async function uploadIntent({
+async function uploadPreparedIntent({
     desktop,
-    upload,
-    file,
-    prepareDirectFile,
+    member,
     signal,
     onProgress,
 }: {
     desktop: NahidaDesktop;
-    upload: UploadPlanEntry;
-    file: FinalFile;
-    prepareDirectFile: (file: FinalFile) => Promise<{ data: Buffer; compAlg?: "zstd" }>;
+    member: PreparedUpload;
     signal?: AbortSignal;
-    onProgress?: (bytes: number) => void;
+    onProgress?: (progress: UploadProgress) => void;
 }) {
     signal?.throwIfAborted();
-    if (file.size < DIRECT_UPLOAD_THRESHOLD) {
-        const prepared = await prepareDirectFile(file);
-        await uploadDirect(desktop, upload, file, prepared, signal, onProgress);
-        return;
+    await uploadDirect(desktop, member.upload, member.source, member.prepared, signal, (bytes) =>
+        onProgress?.({ bytes, isServerDeduplicated: false }),
+    );
+    markIntentProgress(member.source, member.copies, onProgress);
+}
+
+async function uploadPack({
+    desktop,
+    members,
+    signal,
+    onProgress,
+}: {
+    desktop: NahidaDesktop;
+    members: PreparedUpload[];
+    signal?: AbortSignal;
+    onProgress?: (progress: UploadProgress) => void;
+}) {
+    const pack = Buffer.concat(members.map((member) => member.prepared.data));
+    const manifest = JSON.stringify({
+        entries: members.map((member) => ({
+            intentId: member.upload.intentId,
+            token: member.upload.form.token,
+            sha256: member.upload.form.sha256,
+            payloadBytes: member.payloadBytes,
+            ...(member.prepared.compAlg ? { compAlg: member.prepared.compAlg } : {}),
+        })),
+    });
+
+    for (let attempt = 0; attempt <= RETRY_LIMIT; attempt++) {
+        signal?.throwIfAborted();
+        let reportedBytes = 0;
+        let uploadedPayload = 0;
+        const result = await sendMultipart({
+            desktop,
+            url: packUploadUrl(members[0].upload.url),
+            method: "POST",
+            fields: [["manifest", manifest]],
+            file: pack,
+            filename: "pack.bin",
+            fileFieldName: "pack",
+            signal,
+            onProgress: (bytes) => {
+                uploadedPayload += bytes;
+                const next = logicalBytesForPackProgress(members, uploadedPayload);
+                onProgress?.({ bytes: next - reportedBytes, isServerDeduplicated: false });
+                reportedBytes = next;
+            },
+        });
+        if (result.status >= 200 && result.status < 300 && result.status !== 202) {
+            const packResults = (result.payload as { results?: IntentPackResult[] } | undefined)
+                ?.results;
+            if (!packResults || packResults.length !== members.length) {
+                onProgress?.({ bytes: -reportedBytes, isServerDeduplicated: false });
+                throw new Error(result.reason ?? "pack_result_missing");
+            }
+            const failures: string[] = [];
+            packResults.forEach((packResult, index) => {
+                const member = members[index];
+                const credited = creditedLogicalBytesForMember(members, index, uploadedPayload);
+                if (packResult.status === "completed") {
+                    if (credited < member.logicalSize) {
+                        onProgress?.({
+                            bytes: member.logicalSize - credited,
+                            isServerDeduplicated: false,
+                        });
+                    }
+                    markIntentProgress(member.source, member.copies, onProgress);
+                    return;
+                }
+                if (credited > 0) {
+                    onProgress?.({ bytes: -credited, isServerDeduplicated: false });
+                }
+                failures.push(`${member.source.name}: ${packResult.reason ?? packResult.status}`);
+            });
+            if (failures.length > 0) throw new Error(failures.join(", "));
+            return;
+        }
+        if (reportedBytes > 0) onProgress?.({ bytes: -reportedBytes, isServerDeduplicated: false });
+        if (!isRetryable(result) || attempt === RETRY_LIMIT) throw httpError(result);
+        await retryDelay(attempt, signal);
     }
-    await uploadParts(desktop, upload, file, signal, onProgress);
+}
+
+function markIntentProgress(
+    source: FinalFile,
+    copies: FinalFile[],
+    onProgress?: (progress: UploadProgress) => void,
+) {
+    onProgress?.({ bytes: 0, fileId: source.FID, isServerDeduplicated: false });
+    copies.forEach((file) =>
+        onProgress?.({
+            bytes: file.size,
+            fileId: file.FID,
+            isServerDeduplicated: true,
+        }),
+    );
 }
 
 async function uploadDirect(
@@ -399,6 +545,7 @@ async function sendMultipart({
     fields,
     file,
     filename,
+    fileFieldName = "file",
     signal,
     onProgress,
 }: {
@@ -408,11 +555,19 @@ async function sendMultipart({
     fields: Array<[string, string]>;
     file: Uint8Array;
     filename: string;
+    fileFieldName?: string;
     signal?: AbortSignal;
     onProgress?: (bytes: number) => void;
 }) {
     const boundary = `----nahida-desktop-${randomUUID()}`;
-    const multipart = createMultipartBody(boundary, fields, file, filename, onProgress);
+    const multipart = createMultipartBody(
+        boundary,
+        fields,
+        file,
+        filename,
+        fileFieldName,
+        onProgress,
+    );
     try {
         const response = await ky(url, {
             method,
@@ -466,6 +621,7 @@ function createMultipartBody(
     fields: Array<[string, string]>,
     file: Uint8Array,
     filename: string,
+    fileFieldName: string,
     onProgress?: (bytes: number) => void,
 ) {
     const encoder = new TextEncoder();
@@ -481,7 +637,7 @@ function createMultipartBody(
         ),
     );
     const header = encoder.encode(
-        `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${escape(filename)}"\r\nContent-Type: application/octet-stream\r\n\r\n`,
+        `--${boundary}\r\nContent-Disposition: form-data; name="${escape(fileFieldName)}"; filename="${escape(filename)}"\r\nContent-Type: application/octet-stream\r\n\r\n`,
     );
     const footer = encoder.encode(`\r\n--${boundary}--\r\n`);
     let fieldIndex = 0;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core drive upload behavior and error/progress accounting for batched requests; well covered by tests but affects data integrity paths (sha256, partial failures, cancellation).
> 
> **Overview**
> Adds **batched pack uploads** for Akasha v2 so multiple small files can share one `uploads:pack` request instead of separate per-intent POSTs.
> 
> New `upload-pack` helpers define payload/file limits, group members into packs vs single uploads, rewrite intent URLs to the pack endpoint, and map streamed pack bytes back to per-file logical progress. **`uploadDriveFilesV2`** now prepares small files up front, flushes packs when limits are hit, sends a manifest plus concatenated `pack.bin`, and maps per-intent results (including partial batch failure and out-of-order responses). Files at or above **80MiB** still use multipart parts; oversized pack members stay on the single-intent path. Multipart sending supports a configurable file field name (`pack` vs `file`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af34146b6d2f37325ce6c6d56b852242d630af25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Small files can now be combined into efficient multipart upload requests.
  * Larger files continue to use direct uploads automatically.
  * Upload progress is tracked accurately for each file, including partially completed batches.
  * Individual files in a batch report their own success or failure.
  * Upload results remain correctly associated with each file, even when returned in a different order.
* **Bug Fixes**
  * Improved retry handling and error reporting for partially failed uploads.
  * Improved handling of upload URLs containing query parameters or fragments.
  * Upload cancellation is handled more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->