### PR TITLE
fix(mod-viewer): bind hash-only IB textures onto named parts

### DIFF
--- a/src/main/lib/mod-viewer/draw-groups.ts
+++ b/src/main/lib/mod-viewer/draw-groups.ts
@@ -1,3 +1,4 @@
+import { closeSync, openSync, readSync } from "node:fs";
 import { open } from "node:fs/promises";
 import path from "node:path";
 
@@ -48,6 +49,8 @@ const AUX_MAP_CHANNELS: Record<string, "normal_map" | "light_map" | "material_ma
 };
 const HASH_TEXTURE_SUFFIX = /(Diffuse|NormalMap|LightMap|MaterialMap)$/i;
 const WWMI_DUMP_TEX_RE = /(?:^|[/\\])Components-(\d+)\s+t=/i;
+const IB_COMPONENT_DUMP_RE =
+    /(?:^|[/\\])([0-9a-f]{8})_(\d+)_([0-9a-f]{8})_Hash_(DiffuseMap|LightMap|NormalMap|MaterialMap)\./i;
 const DDS_SRGB_DXGI = new Set([29, 72, 75, 78, 91, 93, 99]);
 
 export type TextureAssignment = { res: string; cond: Dnf };
@@ -128,6 +131,7 @@ type SectionInfo = {
     ibHistory: TextureAssignment[];
     vb0History: TextureAssignment[];
     vb1History: TextureAssignment[];
+    thisHistory: TextureAssignment[];
     auxMaps: Record<string, AuxState>;
 };
 
@@ -151,6 +155,7 @@ export function buildDrawGroups(
     seen: Record<string, number> = {},
     gatingVars?: Set<string>,
     animation?: { vars: Set<string>; domains: Record<string, string[]> },
+    modDir?: string,
 ): DrawGroup[] {
     const scanVars = gatingVars ?? new Set<string>();
     const secInfo = scanSectionsForDraws(sections, varPrefix, scanVars, animation?.domains);
@@ -411,7 +416,9 @@ export function buildDrawGroups(
             draws,
         });
     }
-    return collapseAnimationDraws(groups, animation?.vars);
+    const collapsed = collapseAnimationDraws(groups, animation?.vars);
+    bindHashImageTextures(collapsed, secInfo, resources, modDir);
+    return collapsed;
 }
 
 export async function attachWwmiDumpTextures(
@@ -483,6 +490,290 @@ export async function attachWwmiDumpTextures(
             draw.textureDefaultFile ??= picked;
         }
     }
+}
+
+export function attachIbComponentDumpTextures(
+    groups: DrawGroup[],
+    resources: Record<string, ResourceInfo>,
+): void {
+    const dumps = Object.values(resources).flatMap((info) => {
+        const file = info.filename;
+        const match = file ? IB_COMPONENT_DUMP_RE.exec(file.replaceAll("\\", "/")) : undefined;
+        if (!file || !match) {
+            return [];
+        }
+        return [
+            {
+                file,
+                ibHash: match[1].toLowerCase(),
+                index: match[2],
+                role: match[4].toLowerCase(),
+            },
+        ];
+    });
+    if (dumps.length === 0) {
+        return;
+    }
+
+    for (const group of groups) {
+        const ref = ibComponentDumpRef(group);
+        if (!ref) {
+            continue;
+        }
+        const ibDumps = dumps.filter((entry) => entry.ibHash === ref.ibHash);
+        const diffuse = pickIbComponentDumpFile(ibDumps, ref.index, "diffusemap");
+        const light = pickIbComponentDumpFile(ibDumps, ref.index, "lightmap");
+        const normal = pickIbComponentDumpFile(ibDumps, ref.index, "normalmap");
+        const material = pickIbComponentDumpFile(ibDumps, ref.index, "materialmap");
+        group.diffuseFile ??= diffuse;
+        for (const draw of group.draws) {
+            draw.textureDefaultFile ??= diffuse;
+            draw.lightMapDefaultFile ??= light;
+            draw.normalMapDefaultFile ??= normal;
+            draw.materialMapDefaultFile ??= material;
+        }
+    }
+}
+
+function ibComponentDumpRef(group: DrawGroup): { ibHash: string; index: string } | undefined {
+    const match = /(?:^|_)IB_([0-9a-f]{8})(?:_[A-Za-z][A-Za-z0-9]*)*_Component(\d+)$/i.exec(
+        group.displayName || group.name,
+    );
+    if (!match) {
+        return undefined;
+    }
+    return { ibHash: match[1].toLowerCase(), index: match[2] };
+}
+
+function pickIbComponentDumpFile(
+    dumps: Array<{ file: string; index: string; role: string }>,
+    index: string,
+    role: string,
+): string | undefined {
+    const roleDumps = dumps.filter((entry) => entry.role === role);
+    const indexed = roleDumps.find((entry) => entry.index === index)?.file;
+    if (indexed) {
+        return indexed;
+    }
+    const unique = [...new Set(roleDumps.map((entry) => entry.file))];
+    return unique.length === 1 ? unique[0] : undefined;
+}
+
+type HashImageSlot = {
+    files: Array<{ file: string; cond: Dnf }>;
+    role: "diffuse" | "light_map";
+    vars: Set<string>;
+    area: number;
+};
+
+function bindHashImageTextures(
+    groups: DrawGroup[],
+    secInfo: Record<string, SectionInfo>,
+    resources: Record<string, ResourceInfo>,
+    modDir?: string,
+): void {
+    const needed = groups.filter(
+        (group) =>
+            ibComponentDumpRef(group) && group.draws.some((draw) => !draw.textureDefaultFile),
+    );
+    if (needed.length === 0) {
+        return;
+    }
+
+    const slots = Object.entries(secInfo).flatMap(([name, info]) => {
+        if (
+            !name.startsWith("TextureOverride") ||
+            HASH_TEXTURE_SUFFIX.test(name) ||
+            info.ib ||
+            info.draws.length > 0
+        ) {
+            return [];
+        }
+        const files = info.thisHistory.flatMap((entry) => {
+            const file = resourceLookup(resources, entry.res).filename;
+            if (!file || !/\.(dds|png|jpe?g)$/i.test(file)) {
+                return [];
+            }
+            return [{ file, cond: entry.cond }];
+        });
+        if (files.length === 0) {
+            return [];
+        }
+        const hint = hashImageHint(files[0].file, modDir);
+        return [
+            {
+                files,
+                role: hint.role,
+                vars: new Set(files.flatMap((entry) => dnfVars(entry.cond))),
+                area: hint.area,
+            } satisfies HashImageSlot,
+        ];
+    });
+    if (slots.length === 0) {
+        return;
+    }
+
+    const diffuseSlots = slots.filter((slot) => slot.role === "diffuse");
+    const lightsByArea = slots
+        .filter((slot) => slot.role === "light_map")
+        .reduce((map, slot) => {
+            const list = map.get(slot.area) ?? [];
+            list.push(slot);
+            return map.set(slot.area, list);
+        }, new Map<number, HashImageSlot[]>());
+    const paired = new Map(
+        diffuseSlots.map((slot) => {
+            const lights = lightsByArea.get(slot.area) ?? [];
+            const light = slot.area > 0 ? lights.shift() : undefined;
+            return [slot, light] as const;
+        }),
+    );
+
+    const byIb = needed.reduce((map, group) => {
+        const ibHash = ibComponentDumpRef(group)?.ibHash;
+        if (!ibHash) {
+            return map;
+        }
+        return map.set(ibHash, [...(map.get(ibHash) ?? []), group]);
+    }, new Map<string, DrawGroup[]>());
+    const unused = new Set(diffuseSlots);
+    const unbound = new Set(byIb.keys());
+
+    const scored = [...unbound].flatMap((ibHash) => {
+        const groupVars = new Set(
+            (byIb.get(ibHash) ?? []).flatMap((group) =>
+                group.draws.flatMap((draw) => dnfVars(draw.conditions)),
+            ),
+        );
+        return [...unused].flatMap((slot) => {
+            const score = overlapScore(groupVars, slot.vars);
+            return score > 0 ? [{ ibHash, slot, score, tightness: slot.vars.size }] : [];
+        });
+    });
+    for (const pick of [...scored].sort(
+        (left, right) =>
+            right.score - left.score ||
+            left.tightness - right.tightness ||
+            right.slot.area - left.slot.area,
+    )) {
+        if (!unbound.has(pick.ibHash) || !unused.has(pick.slot)) {
+            continue;
+        }
+        applyHashImageSlot(byIb.get(pick.ibHash) ?? [], pick.slot, paired.get(pick.slot));
+        unbound.delete(pick.ibHash);
+        unused.delete(pick.slot);
+    }
+
+    const leftoverIbs = [...unbound].sort(
+        (left, right) => ibDrawWeight(byIb.get(right) ?? []) - ibDrawWeight(byIb.get(left) ?? []),
+    );
+    const leftoverSlots = [...unused].sort((left, right) => right.area - left.area || 0);
+    for (const [index, ibHash] of leftoverIbs.entries()) {
+        const slot = leftoverSlots[index];
+        if (slot) {
+            applyHashImageSlot(byIb.get(ibHash) ?? [], slot, paired.get(slot));
+        }
+    }
+}
+
+function applyHashImageSlot(groups: DrawGroup[], slot: HashImageSlot, light?: HashImageSlot): void {
+    const defaultFile =
+        slot.files.find((entry) => isUnconstrained(entry.cond))?.file ?? slot.files[0]?.file;
+    const variants = slot.files.map((entry) => ({ conditions: entry.cond, file: entry.file }));
+    const keepVariants =
+        variants.length > 1 || (variants[0] && !isUnconstrained(variants[0].conditions));
+    const lightFile = light?.files[0]?.file;
+    for (const group of groups) {
+        group.diffuseFile ??= defaultFile;
+        for (const draw of group.draws) {
+            draw.textureDefaultFile ??= defaultFile;
+            if (keepVariants && !draw.textureVariants?.length) {
+                draw.textureVariants = variants;
+            }
+            if (lightFile) {
+                draw.lightMapDefaultFile ??= lightFile;
+            }
+        }
+    }
+}
+
+function hashImageHint(
+    relative: string,
+    modDir?: string,
+): { role: "diffuse" | "light_map"; area: number } {
+    const lower = relative.replaceAll("\\", "/").toLowerCase();
+    if (/hash_lightmap|_lightmap\./i.test(lower) && !/hash_diffusemap|diffuse/i.test(lower)) {
+        return { role: "light_map", area: peekImageArea(relative, modDir) };
+    }
+    if (/hash_diffusemap|diffuse/i.test(lower) || !lower.endsWith(".dds") || !modDir) {
+        return { role: "diffuse", area: peekImageArea(relative, modDir) };
+    }
+    const peeked = peekDdsRole(safeResourcePath(modDir, relative));
+    return peeked ?? { role: "diffuse", area: 0 };
+}
+
+function peekImageArea(relative: string, modDir?: string): number {
+    if (!modDir || !relative.toLowerCase().endsWith(".dds")) {
+        return 0;
+    }
+    return peekDdsRole(safeResourcePath(modDir, relative))?.area ?? 0;
+}
+
+function peekDdsRole(
+    filePath: string | null,
+): { role: "diffuse" | "light_map"; area: number } | null {
+    if (!filePath) {
+        return null;
+    }
+    try {
+        const header = readFileSyncPrefix(filePath, 148);
+        if (header.length < 128 || header.toString("ascii", 0, 4) !== "DDS ") {
+            return null;
+        }
+        const area = header.readUInt32LE(16) * header.readUInt32LE(12);
+        if (header.toString("ascii", 84, 88) !== "DX10" || header.length < 132) {
+            return { role: "diffuse", area };
+        }
+        return {
+            role: DDS_SRGB_DXGI.has(header.readUInt32LE(128)) ? "diffuse" : "light_map",
+            area,
+        };
+    } catch {
+        return null;
+    }
+}
+
+function readFileSyncPrefix(filePath: string, length: number): Buffer {
+    const fd = openSync(filePath, "r");
+    try {
+        const header = Buffer.alloc(length);
+        const read = readSync(fd, header, 0, length, 0);
+        return header.subarray(0, read);
+    } finally {
+        closeSync(fd);
+    }
+}
+
+function dnfVars(dnf: Dnf): string[] {
+    return dnf.flatMap((group) => group.map((clause) => clause.var));
+}
+
+function overlapScore(groupVars: Set<string>, slotVars: Set<string>): number {
+    return [...slotVars].filter((slotVar) =>
+        [...groupVars].some(
+            (groupVar) =>
+                groupVar === slotVar ||
+                groupVar.startsWith(slotVar) ||
+                slotVar.startsWith(groupVar),
+        ),
+    ).length;
+}
+
+function ibDrawWeight(groups: DrawGroup[]): number {
+    return groups.reduce(
+        (sum, group) => sum + group.draws.reduce((inner, draw) => inner + (draw.count ?? 0), 0),
+        0,
+    );
 }
 
 export function pickWwmiDumpDiffuse(
@@ -709,6 +1000,11 @@ function scanSectionsForDraws(
                 }
             }
 
+            const selfAssign = /^this\s*=\s*(?:ref\s+)?(\S+)/i.exec(line);
+            if (selfAssign && selfAssign[1].toLowerCase() !== "null") {
+                info.thisHistory.push({ res: selfAssign[1], cond: stackedCond(condStack) });
+            }
+
             let diffuse = /^Resource\\[^\\]+\\Diffuse\s*=\s*(?:ref\s+)?(\S+)/i.exec(line);
             if (!diffuse) {
                 const ps = /^ps-t\d+\s*=\s*(\S+)/i.exec(line);
@@ -840,6 +1136,7 @@ function scanSectionsForDraws(
             ibHistory: [],
             vb0History: [],
             vb1History: [],
+            thisHistory: [],
             auxMaps: {},
         };
         scan(lines, info, [], new Set([name]), name);
@@ -848,6 +1145,7 @@ function scanSectionsForDraws(
         info.auxMapsAtEnd = auxSnapshot(info);
         secInfo[name] = info;
     }
+    collapseSharedHashTextureOverrides(secInfo, sections);
     attachHashTextureOverrides(secInfo);
     return secInfo;
 }
@@ -1076,6 +1374,102 @@ function lookupCompValue<T>(mapping: Record<string, T>, component: string): T | 
         return mapping[strippedWord];
     }
     return undefined;
+}
+
+function collapseSharedHashTextureOverrides(
+    secInfo: Record<string, SectionInfo>,
+    sections: IniSections,
+): void {
+    const grouped = Object.keys(secInfo).reduce((map, name) => {
+        const role = name.startsWith("TextureOverride")
+            ? HASH_TEXTURE_SUFFIX.exec(name)?.[1]
+            : undefined;
+        const meta = role ? sectionMatchMeta(sections[name] ?? []) : undefined;
+        if (!role || !meta?.hash) {
+            return map;
+        }
+        const key = `${role.toLowerCase()}:${meta.hash}:${meta.matchFirstIndex ?? ""}`;
+        return map.set(key, [...(map.get(key) ?? []), { name, role, priority: meta.priority }]);
+    }, new Map<string, Array<{ name: string; role: string; priority: number }>>());
+
+    for (const group of grouped.values()) {
+        if (group.length < 2) {
+            continue;
+        }
+        const winner = group.reduce((best, entry) =>
+            entry.priority >= best.priority ? entry : best,
+        );
+        const source = secInfo[winner.name];
+        for (const entry of group) {
+            if (entry.name !== winner.name) {
+                replaceHashTextureSection(secInfo[entry.name], source, winner.role);
+            }
+        }
+    }
+}
+
+function sectionMatchMeta(lines: IniLine[]): {
+    hash?: string;
+    matchFirstIndex?: string;
+    priority: number;
+} {
+    return lines.reduce<{ hash?: string; matchFirstIndex?: string; priority: number }>(
+        (meta, raw) => {
+            const line = stripComment(raw.text);
+            const hash = /^hash\s*=\s*([0-9a-f]+)/i.exec(line)?.[1];
+            const matchFirstIndex = /^match_first_index\s*=\s*(\S+)/i.exec(line)?.[1];
+            const priority = /^match_priority\s*=\s*(-?\d+)/i.exec(line)?.[1];
+            return {
+                hash: hash ? hash.toLowerCase() : meta.hash,
+                matchFirstIndex: matchFirstIndex ?? meta.matchFirstIndex,
+                priority: priority !== undefined ? Number(priority) : meta.priority,
+            };
+        },
+        { priority: 0 },
+    );
+}
+
+function replaceHashTextureSection(target: SectionInfo, source: SectionInfo, role: string): void {
+    if (/^Diffuse$/i.test(role)) {
+        if (!source.diffuse) {
+            return;
+        }
+        target.diffuse = source.diffuse;
+        target.diffusePool = [...source.diffusePool];
+        target.diffuseVariantsAtEnd = [...source.diffuseVariantsAtEnd];
+        target.diffuseHistoryAtEnd = [...source.diffuseHistoryAtEnd];
+        target.diffuseHistory = [...source.diffuseHistory];
+        target.curDiffuseVariants = [...source.curDiffuseVariants];
+        for (const draw of target.draws) {
+            draw.diffuseVariants = [...source.diffuseHistory];
+            draw.diffuseHistory = [...source.diffuseHistory];
+        }
+        return;
+    }
+    const channel = AUX_MAP_CHANNELS[role.toLowerCase()];
+    if (!channel) {
+        return;
+    }
+    const state = source.auxMapsAtEnd[channel] ?? source.auxMaps[channel];
+    if (!state || (state.history.length === 0 && state.variants.length === 0)) {
+        return;
+    }
+    const copied = {
+        variants: [...state.variants],
+        history: [...(state.history.length > 0 ? state.history : state.variants)],
+    };
+    target.auxMaps[channel] = {
+        ...copied,
+        chainKey: null,
+        lastCond: null,
+    };
+    target.auxMapsAtEnd[channel] = copied;
+    for (const drawState of target.auxDrawStates) {
+        drawState[channel] = {
+            variants: [...copied.variants],
+            history: [...copied.history],
+        };
+    }
 }
 
 function attachHashTextureOverrides(secInfo: Record<string, SectionInfo>): void {

--- a/src/main/lib/mod-viewer/draw-groups.ts
+++ b/src/main/lib/mod-viewer/draw-groups.ts
@@ -417,6 +417,7 @@ export function buildDrawGroups(
         });
     }
     const collapsed = collapseAnimationDraws(groups, animation?.vars);
+    attachIbComponentDumpTextures(collapsed, resources);
     bindHashImageTextures(collapsed, secInfo, resources, modDir);
     return collapsed;
 }

--- a/src/main/lib/mod-viewer/load.test.ts
+++ b/src/main/lib/mod-viewer/load.test.ts
@@ -964,6 +964,486 @@ filename = light.png
         assert.ok(bodyB.every((mesh) => mesh.lightMapKey));
     });
 
+    it("uses the last same-hash Diffuse and LightMap this= like 3DMigoto", async () => {
+        const root = await makeMod({
+            ini: `[TextureOverrideBodyA]
+hash = 3b4647d4
+match_first_index = 0
+ib = ResourceBodyAIB
+vb0 = ResourcePos
+vb1 = ResourceTc
+drawindexed = 3, 0, 0
+[TextureOverrideBodyB]
+hash = 3b4647d4
+match_first_index = 14598
+ib = ResourceBodyBIB
+vb0 = ResourcePos
+vb1 = ResourceTc
+drawindexed = 3, 0, 0
+[TextureOverrideBodyC]
+hash = 3b4647d4
+match_first_index = 32934
+ib = ResourceBodyCIB
+vb0 = ResourcePos
+vb1 = ResourceTc
+drawindexed = 3, 0, 0
+[TextureOverrideBodyADiffuse]
+hash = f9761bbf
+this = ResourceBodyADiffuse
+[TextureOverrideBodyBDiffuse]
+hash = f9761bbf
+this = ResourceBodyBDiffuse
+[TextureOverrideBodyCDiffuse]
+hash = f9761bbf
+this = ResourceBodyCDiffuse
+[TextureOverrideBodyALightMap]
+hash = 87adc723
+this = ResourceBodyALightMap
+[TextureOverrideBodyCLightMap]
+hash = 87adc723
+this = ResourceBodyCLightMap
+[ResourcePos]
+filename = pos.buf
+stride = 40
+[ResourceTc]
+filename = tc.buf
+stride = 20
+[ResourceBodyAIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+[ResourceBodyBIB]
+filename = bodyb.ib
+format = DXGI_FORMAT_R32_UINT
+[ResourceBodyCIB]
+filename = bodyc.ib
+format = DXGI_FORMAT_R32_UINT
+[ResourceBodyADiffuse]
+filename = bodya.png
+[ResourceBodyBDiffuse]
+filename = bodyb.png
+[ResourceBodyCDiffuse]
+filename = bodyc.png
+[ResourceBodyALightMap]
+filename = bodya-light.png
+[ResourceBodyCLightMap]
+filename = bodyc-light.png
+`,
+            extra: async (dir) => {
+                await fse.writeFile(
+                    path.join(dir, "bodyb.ib"),
+                    Buffer.from(new Uint32Array([0, 1, 2]).buffer),
+                );
+                await fse.writeFile(
+                    path.join(dir, "bodyc.ib"),
+                    Buffer.from(new Uint32Array([0, 1, 2]).buffer),
+                );
+                await fse.writeFile(path.join(dir, "bodya.png"), PNG_1X1);
+                await fse.writeFile(path.join(dir, "bodyb.png"), PNG_1X1);
+                await fse.writeFile(path.join(dir, "bodyc.png"), PNG_1X1);
+                await fse.writeFile(path.join(dir, "bodya-light.png"), PNG_1X1);
+                await fse.writeFile(path.join(dir, "bodyc-light.png"), PNG_1X1);
+            },
+        });
+
+        const payload = await loadModViewerPayload(root);
+        const bodyA = payload.meshes.filter((mesh) => mesh.component === "BodyA");
+        const bodyB = payload.meshes.filter((mesh) => mesh.component === "BodyB");
+        assert.ok(bodyA.length >= 1);
+        assert.ok(bodyB.length >= 1);
+        assert.ok(bodyA.every((mesh) => String(mesh.texKey).includes("bodyc.png")));
+        assert.ok(bodyB.every((mesh) => String(mesh.texKey).includes("bodyc.png")));
+        assert.ok(bodyA.every((mesh) => String(mesh.lightMapKey).includes("bodyc-light.png")));
+        assert.ok(bodyA.every((mesh) => !String(mesh.texKey).includes("bodya.png")));
+    });
+
+    it("keeps name-matched Diffuse when shared-hash siblings use different hashes", async () => {
+        const root = await makeMod({
+            ini: `[TextureOverrideBodyA]
+ib = ResourceBodyAIB
+vb0 = ResourcePos
+vb1 = ResourceTc
+drawindexed = 3, 0, 0
+[TextureOverrideBodyC]
+ib = ResourceBodyCIB
+vb0 = ResourcePos
+vb1 = ResourceTc
+drawindexed = 3, 0, 0
+[TextureOverrideBodyADiffuse]
+hash = f9761bbf
+this = ResourceBodyADiffuse
+[TextureOverrideBodyCDiffuse]
+hash = f0226f67
+this = ResourceBodyCDiffuse
+[ResourcePos]
+filename = pos.buf
+stride = 40
+[ResourceTc]
+filename = tc.buf
+stride = 20
+[ResourceBodyAIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+[ResourceBodyCIB]
+filename = bodyc.ib
+format = DXGI_FORMAT_R32_UINT
+[ResourceBodyADiffuse]
+filename = bodya.png
+[ResourceBodyCDiffuse]
+filename = bodyc.png
+`,
+            extra: async (dir) => {
+                await fse.writeFile(
+                    path.join(dir, "bodyc.ib"),
+                    Buffer.from(new Uint32Array([0, 1, 2]).buffer),
+                );
+                await fse.writeFile(path.join(dir, "bodya.png"), PNG_1X1);
+                await fse.writeFile(path.join(dir, "bodyc.png"), PNG_1X1);
+            },
+        });
+
+        const payload = await loadModViewerPayload(root);
+        const bodyA = payload.meshes.filter((mesh) => mesh.component === "BodyA");
+        const bodyC = payload.meshes.filter((mesh) => mesh.component === "BodyC");
+        assert.ok(bodyA.every((mesh) => String(mesh.texKey).includes("bodya.png")));
+        assert.ok(bodyC.every((mesh) => String(mesh.texKey).includes("bodyc.png")));
+    });
+
+    it("binds SRMI IB-Component Hash_DiffuseMap dumps onto sibling components with one atlas", async () => {
+        const root = await makeMod({
+            ini: `[TextureOverride_VB_3b4647d4_Position]
+hash = 3b4647d4
+vb0 = ResourcePos
+[TextureOverride_VB_3b4647d4_Texcoord]
+hash = 3b4647d4
+vb1 = ResourceTc
+[TextureOverride_IB_3b4647d4_Component1]
+hash = 3b4647d4
+match_first_index = 0
+ib = Resource_3b4647d4_Component1
+drawindexed = 3, 0, 0
+[TextureOverride_IB_3b4647d4_Component2]
+hash = 3b4647d4
+match_first_index = 14598
+ib = Resource_3b4647d4_Component2
+drawindexed = 3, 0, 0
+[ResourcePos]
+filename = pos.buf
+stride = 40
+[ResourceTc]
+filename = tc.buf
+stride = 20
+[Resource_3b4647d4_Component1]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+[Resource_3b4647d4_Component2]
+filename = bodyb.ib
+format = DXGI_FORMAT_R32_UINT
+[Resource_Texture_f9761bbf]
+filename = Texture/3b4647d4_1_f9761bbf_Hash_DiffuseMap.png
+[TextureOverride_f9761bbf]
+hash = f9761bbf
+this = Resource_Texture_f9761bbf
+[Resource_Texture_87adc723]
+filename = Texture/3b4647d4_1_87adc723_Hash_LightMap.png
+[TextureOverride_87adc723]
+hash = 87adc723
+this = Resource_Texture_87adc723
+`,
+            extra: async (dir) => {
+                await fse.writeFile(
+                    path.join(dir, "bodyb.ib"),
+                    Buffer.from(new Uint32Array([0, 1, 2]).buffer),
+                );
+                await fse.ensureDir(path.join(dir, "Texture"));
+                await fse.writeFile(
+                    path.join(dir, "Texture", "3b4647d4_1_f9761bbf_Hash_DiffuseMap.png"),
+                    PNG_1X1,
+                );
+                await fse.writeFile(
+                    path.join(dir, "Texture", "3b4647d4_1_87adc723_Hash_LightMap.png"),
+                    PNG_1X1,
+                );
+            },
+        });
+
+        const payload = await loadModViewerPayload(root);
+        const component1 = payload.meshes.filter(
+            (mesh) => mesh.component === "_IB_3b4647d4_Component1",
+        );
+        const component2 = payload.meshes.filter(
+            (mesh) => mesh.component === "_IB_3b4647d4_Component2",
+        );
+        assert.ok(component1.length >= 1);
+        assert.ok(component2.length >= 1);
+        assert.ok(component1.every((mesh) => String(mesh.texKey).includes("Hash_DiffuseMap")));
+        assert.ok(component2.every((mesh) => String(mesh.texKey).includes("Hash_DiffuseMap")));
+        assert.ok(component2.every((mesh) => String(mesh.lightMapKey).includes("Hash_LightMap")));
+    });
+
+    it("does not share distinct IB-Component dump atlases across other components", async () => {
+        const root = await makeMod({
+            ini: `[TextureOverride_VB_3b4647d4_Position]
+hash = 3b4647d4
+vb0 = ResourcePos
+[TextureOverride_VB_3b4647d4_Texcoord]
+hash = 3b4647d4
+vb1 = ResourceTc
+[TextureOverride_IB_3b4647d4_Component1]
+hash = 3b4647d4
+ib = Resource_3b4647d4_Component1
+drawindexed = 3, 0, 0
+[TextureOverride_IB_3b4647d4_Component2]
+hash = 3b4647d4
+ib = Resource_3b4647d4_Component2
+drawindexed = 3, 0, 0
+[TextureOverride_IB_3b4647d4_Component3]
+hash = 3b4647d4
+ib = Resource_3b4647d4_Component3
+drawindexed = 3, 0, 0
+[ResourcePos]
+filename = pos.buf
+stride = 40
+[ResourceTc]
+filename = tc.buf
+stride = 20
+[Resource_3b4647d4_Component1]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+[Resource_3b4647d4_Component2]
+filename = bodyb.ib
+format = DXGI_FORMAT_R32_UINT
+[Resource_3b4647d4_Component3]
+filename = bodyc.ib
+format = DXGI_FORMAT_R32_UINT
+[Resource_Texture_aaaaaaa1]
+filename = Texture/3b4647d4_1_aaaaaaa1_Hash_DiffuseMap.png
+[Resource_Texture_aaaaaaa2]
+filename = Texture/3b4647d4_2_aaaaaaa2_Hash_DiffuseMap.png
+`,
+            extra: async (dir) => {
+                await fse.writeFile(
+                    path.join(dir, "bodyb.ib"),
+                    Buffer.from(new Uint32Array([0, 1, 2]).buffer),
+                );
+                await fse.writeFile(
+                    path.join(dir, "bodyc.ib"),
+                    Buffer.from(new Uint32Array([0, 1, 2]).buffer),
+                );
+                await fse.ensureDir(path.join(dir, "Texture"));
+                await fse.writeFile(
+                    path.join(dir, "Texture", "3b4647d4_1_aaaaaaa1_Hash_DiffuseMap.png"),
+                    PNG_1X1,
+                );
+                await fse.writeFile(
+                    path.join(dir, "Texture", "3b4647d4_2_aaaaaaa2_Hash_DiffuseMap.png"),
+                    PNG_2X2,
+                );
+            },
+        });
+
+        const payload = await loadModViewerPayload(root);
+        const component1 = payload.meshes.filter(
+            (mesh) => mesh.component === "_IB_3b4647d4_Component1",
+        );
+        const component2 = payload.meshes.filter(
+            (mesh) => mesh.component === "_IB_3b4647d4_Component2",
+        );
+        const component3 = payload.meshes.filter(
+            (mesh) => mesh.component === "_IB_3b4647d4_Component3",
+        );
+        assert.ok(component1.length >= 1);
+        assert.ok(component2.length >= 1);
+        assert.ok(component3.length >= 1);
+        assert.ok(component1.every((mesh) => String(mesh.texKey).includes("aaaaaaa1")));
+        assert.ok(component2.every((mesh) => String(mesh.texKey).includes("aaaaaaa2")));
+        assert.ok(component3.every((mesh) => !mesh.texKey));
+    });
+
+    it("does not bind IB-Component dump textures onto BodyA sections", async () => {
+        const root = await makeMod({
+            ini: `[TextureOverrideBodyA]
+ib = ResourceBodyAIB
+vb0 = ResourcePos
+vb1 = ResourceTc
+drawindexed = 3, 0, 0
+[ResourcePos]
+filename = pos.buf
+stride = 40
+[ResourceTc]
+filename = tc.buf
+stride = 20
+[ResourceBodyAIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+[Resource_Texture_f9761bbf]
+filename = Texture/3b4647d4_1_f9761bbf_Hash_DiffuseMap.png
+`,
+            extra: async (dir) => {
+                await fse.ensureDir(path.join(dir, "Texture"));
+                await fse.writeFile(
+                    path.join(dir, "Texture", "3b4647d4_1_f9761bbf_Hash_DiffuseMap.png"),
+                    PNG_1X1,
+                );
+            },
+        });
+
+        const payload = await loadModViewerPayload(root);
+        assert.equal(payload.meshes.length, 1);
+        assert.equal(payload.meshes[0].texKey, null);
+    });
+
+    it("binds hash-only this= images onto IB-named parts using matching toggle vars", async () => {
+        const root = await makeMod({
+            ini: `[Constants]
+global persist $eyes = 0
+global persist $cloth = 0
+global persist $clothcolor = 0
+[KeyEyes]
+type = cycle
+$eyes = 0,1
+[KeyCloth]
+type = cycle
+$cloth = 0,1
+[KeyClothColor]
+type = cycle
+$clothcolor = 0,1
+[TextureOverride_VB_aaaaaaa1_face_Position]
+hash = aaaaaaa1
+vb0 = ResourcePos
+[TextureOverride_VB_aaaaaaa1_face_Texcoord]
+hash = aaaaaaa1
+vb1 = ResourceTc
+[TextureOverride_VB_bbbbbbbb_body_Position]
+hash = bbbbbbbb
+vb0 = ResourcePos
+[TextureOverride_VB_bbbbbbbb_body_Texcoord]
+hash = bbbbbbbb
+vb1 = ResourceTc
+[TextureOverride_IB_aaaaaaa1_face_Component1]
+hash = aaaaaaa1
+ib = ResourceFaceIB
+if $eyes == 0
+drawindexed = 3, 0, 0
+endif
+[TextureOverride_IB_bbbbbbbb_body_Component2]
+hash = bbbbbbbb
+ib = ResourceBodyIB
+if $cloth == 0
+drawindexed = 3, 0, 0
+endif
+[TextureOverride_7b3e8cd1]
+hash = 7b3e8cd1
+if $eyes == 0
+this = ResourceFaceTex
+endif
+[TextureOverride_7b6fe593]
+hash = 7b6fe593
+if $clothcolor == 0
+this = ResourceBodyTex
+endif
+[ResourcePos]
+filename = pos.buf
+stride = 40
+[ResourceTc]
+filename = tc.buf
+stride = 20
+[ResourceFaceIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+[ResourceBodyIB]
+filename = bodyb.ib
+format = DXGI_FORMAT_R32_UINT
+[ResourceFaceTex]
+filename = face.png
+[ResourceBodyTex]
+filename = bodytex.png
+`,
+            extra: async (dir) => {
+                await fse.writeFile(
+                    path.join(dir, "bodyb.ib"),
+                    Buffer.from(new Uint32Array([0, 1, 2]).buffer),
+                );
+                await fse.writeFile(path.join(dir, "face.png"), PNG_1X1);
+                await fse.writeFile(path.join(dir, "bodytex.png"), PNG_2X2);
+            },
+        });
+
+        const payload = await loadModViewerPayload(root);
+        const face = payload.meshes.filter((mesh) => mesh.component.includes("face_Component1"));
+        const body = payload.meshes.filter((mesh) => mesh.component.includes("body_Component2"));
+        assert.ok(face.length >= 1);
+        assert.ok(body.length >= 1);
+        assert.ok(face.every((mesh) => String(mesh.texKey).includes("face.png")));
+        assert.ok(body.every((mesh) => String(mesh.texKey).includes("bodytex.png")));
+    });
+
+    it("assigns leftover hash-only images to heavier IB parts first", async () => {
+        const root = await makeMod({
+            ini: `[TextureOverride_VB_aaaaaaa1_weapon_Position]
+hash = aaaaaaa1
+vb0 = ResourcePos
+[TextureOverride_VB_aaaaaaa1_weapon_Texcoord]
+hash = aaaaaaa1
+vb1 = ResourceTc
+[TextureOverride_VB_bbbbbbbb_fire_Position]
+hash = bbbbbbbb
+vb0 = ResourcePos
+[TextureOverride_VB_bbbbbbbb_fire_Texcoord]
+hash = bbbbbbbb
+vb1 = ResourceTc
+[TextureOverride_IB_aaaaaaa1_weapon_Component1]
+hash = aaaaaaa1
+ib = ResourceWeaponIB
+drawindexed = 3, 0, 0
+drawindexed = 3, 0, 0
+[TextureOverride_IB_bbbbbbbb_fire_Component1]
+hash = bbbbbbbb
+ib = ResourceFireIB
+drawindexed = 3, 0, 0
+[TextureOverride_adac9211]
+hash = adac9211
+this = ResourceWeaponTex
+[TextureOverride_d2a654b2]
+hash = d2a654b2
+this = ResourceFireTex
+[ResourcePos]
+filename = pos.buf
+stride = 40
+[ResourceTc]
+filename = tc.buf
+stride = 20
+[ResourceWeaponIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+[ResourceFireIB]
+filename = fire.ib
+format = DXGI_FORMAT_R32_UINT
+[ResourceWeaponTex]
+filename = weapon.png
+[ResourceFireTex]
+filename = fire.png
+`,
+            extra: async (dir) => {
+                await fse.writeFile(
+                    path.join(dir, "fire.ib"),
+                    Buffer.from(new Uint32Array([0, 1, 2]).buffer),
+                );
+                await fse.writeFile(path.join(dir, "weapon.png"), PNG_2X2);
+                await fse.writeFile(path.join(dir, "fire.png"), PNG_1X1);
+            },
+        });
+
+        const payload = await loadModViewerPayload(root);
+        const weapon = payload.meshes.filter((mesh) =>
+            mesh.component.includes("weapon_Component1"),
+        );
+        const fire = payload.meshes.filter((mesh) => mesh.component.includes("fire_Component1"));
+        assert.ok(weapon.length >= 1);
+        assert.ok(fire.length >= 1);
+        assert.ok(weapon.every((mesh) => String(mesh.texKey).includes("weapon.png")));
+        assert.ok(fire.every((mesh) => String(mesh.texKey).includes("fire.png")));
+    });
+
     it("prefers sRGB then larger WWMI dump textures", () => {
         assert.equal(
             pickWwmiDumpDiffuse([

--- a/src/main/lib/mod-viewer/load.test.ts
+++ b/src/main/lib/mod-viewer/load.test.ts
@@ -1259,6 +1259,91 @@ filename = Texture/3b4647d4_2_aaaaaaa2_Hash_DiffuseMap.png
         assert.ok(component3.every((mesh) => !mesh.texKey));
     });
 
+    it("keeps per-component dump atlases when a hash-only this= leftover also exists", async () => {
+        const root = await makeMod({
+            ini: `[TextureOverride_VB_3b4647d4_Position]
+hash = 3b4647d4
+vb0 = ResourcePos
+[TextureOverride_VB_3b4647d4_Texcoord]
+hash = 3b4647d4
+vb1 = ResourceTc
+[TextureOverride_IB_3b4647d4_Component1]
+hash = 3b4647d4
+ib = Resource_3b4647d4_Component1
+drawindexed = 3, 0, 0
+[TextureOverride_IB_3b4647d4_Component2]
+hash = 3b4647d4
+ib = Resource_3b4647d4_Component2
+drawindexed = 3, 0, 0
+[TextureOverride_IB_3b4647d4_Component3]
+hash = 3b4647d4
+ib = Resource_3b4647d4_Component3
+drawindexed = 3, 0, 0
+[ResourcePos]
+filename = pos.buf
+stride = 40
+[ResourceTc]
+filename = tc.buf
+stride = 20
+[Resource_3b4647d4_Component1]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+[Resource_3b4647d4_Component2]
+filename = bodyb.ib
+format = DXGI_FORMAT_R32_UINT
+[Resource_3b4647d4_Component3]
+filename = bodyc.ib
+format = DXGI_FORMAT_R32_UINT
+[Resource_Texture_aaaaaaa1]
+filename = Texture/3b4647d4_1_aaaaaaa1_Hash_DiffuseMap.png
+[Resource_Texture_aaaaaaa2]
+filename = Texture/3b4647d4_2_aaaaaaa2_Hash_DiffuseMap.png
+[TextureOverride_deadbeef]
+hash = deadbeef
+this = ResourceOther
+[ResourceOther]
+filename = other.png
+`,
+            extra: async (dir) => {
+                await fse.writeFile(
+                    path.join(dir, "bodyb.ib"),
+                    Buffer.from(new Uint32Array([0, 1, 2]).buffer),
+                );
+                await fse.writeFile(
+                    path.join(dir, "bodyc.ib"),
+                    Buffer.from(new Uint32Array([0, 1, 2]).buffer),
+                );
+                await fse.ensureDir(path.join(dir, "Texture"));
+                await fse.writeFile(
+                    path.join(dir, "Texture", "3b4647d4_1_aaaaaaa1_Hash_DiffuseMap.png"),
+                    PNG_1X1,
+                );
+                await fse.writeFile(
+                    path.join(dir, "Texture", "3b4647d4_2_aaaaaaa2_Hash_DiffuseMap.png"),
+                    PNG_2X2,
+                );
+                await fse.writeFile(path.join(dir, "other.png"), PNG_1X1);
+            },
+        });
+
+        const payload = await loadModViewerPayload(root);
+        const component1 = payload.meshes.filter(
+            (mesh) => mesh.component === "_IB_3b4647d4_Component1",
+        );
+        const component2 = payload.meshes.filter(
+            (mesh) => mesh.component === "_IB_3b4647d4_Component2",
+        );
+        const component3 = payload.meshes.filter(
+            (mesh) => mesh.component === "_IB_3b4647d4_Component3",
+        );
+        assert.ok(component1.length >= 1);
+        assert.ok(component2.length >= 1);
+        assert.ok(component3.length >= 1);
+        assert.ok(component1.every((mesh) => String(mesh.texKey).includes("aaaaaaa1")));
+        assert.ok(component2.every((mesh) => String(mesh.texKey).includes("aaaaaaa2")));
+        assert.ok(component3.every((mesh) => String(mesh.texKey).includes("other.png")));
+    });
+
     it("does not bind IB-Component dump textures onto BodyA sections", async () => {
         const root = await makeMod({
             ini: `[TextureOverrideBodyA]

--- a/src/main/lib/mod-viewer/load.ts
+++ b/src/main/lib/mod-viewer/load.ts
@@ -4,7 +4,6 @@ import type { ViewerStateValue, ViewerVariable, ModViewerPayload } from "@shared
 
 import { animationFrameValues, extractPresentAnimations } from "./animations";
 import {
-    attachIbComponentDumpTextures,
     attachShapeSliders,
     attachWwmiDumpTextures,
     buildDrawGroups,
@@ -105,7 +104,6 @@ export async function loadModViewerPayload(modPath: string): Promise<ModViewerPa
             folderPath,
         );
         await attachWwmiDumpTextures(iniGroups, resources, folderPath);
-        attachIbComponentDumpTextures(iniGroups, resources);
         attachShapeSliders(iniGroups, shapes);
         groups.push(...iniGroups);
         Object.assign(toggleKeys, toggles);

--- a/src/main/lib/mod-viewer/load.ts
+++ b/src/main/lib/mod-viewer/load.ts
@@ -4,6 +4,7 @@ import type { ViewerStateValue, ViewerVariable, ModViewerPayload } from "@shared
 
 import { animationFrameValues, extractPresentAnimations } from "./animations";
 import {
+    attachIbComponentDumpTextures,
     attachShapeSliders,
     attachWwmiDumpTextures,
     buildDrawGroups,
@@ -101,8 +102,10 @@ export async function loadModViewerPayload(modPath: string): Promise<ModViewerPa
                 vars: new Set(presentAnimations.flatMap((clip) => clip.variableIds)),
                 domains: animationDomains,
             },
+            folderPath,
         );
         await attachWwmiDumpTextures(iniGroups, resources, folderPath);
+        attachIbComponentDumpTextures(iniGroups, resources);
         attachShapeSliders(iniGroups, shapes);
         groups.push(...iniGroups);
         Object.assign(toggleKeys, toggles);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes are localized to mod viewer texture resolution heuristics with strong tests, but incorrect binding could still show wrong textures on complex INIs without failing loudly.
> 
> **Overview**
> Improves mod viewer texture assignment for SRMI-style mods where draw groups use **IB_Component** names and textures come from dump filenames or hash-only `TextureOverride` sections with `this=` assignments.
> 
> **INI scanning** now records **thisHistory** for every `this=` line (not only diffuse/aux paths) and **collapses** multiple `TextureOverride*Diffuse/LightMap/…` sections that share the same hash and `match_first_index`, copying the highest-`match_priority` winner onto siblings so behavior aligns with 3DMigoto’s last-wins shared-hash overrides.
> 
> After draw groups are built, **attachIbComponentDumpTextures** maps resource files matching `…_Hash_DiffuseMap/LightMap/…` onto `_IB_<hash>_ComponentN` groups by IB hash and component index. **bindHashImageTextures** fills remaining gaps on those IB-named parts by scoring hash-only override slots against draw toggle variables (with area/heuristic pairing for light maps and a fallback by draw weight). DDS role hints use a small header peek when `modDir` is passed from **load.ts**.
> 
> **load.test.ts** adds broad coverage for shared-hash overrides, per-component dumps, variable-matched binding, and guards against mis-binding onto plain `BodyA` or unrelated sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6374f49930a51017a14eac815726f1baa7547b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved mod viewer texture discovery and assignment for component IB dump files.
  - Added support for diffuse, light-map, normal-map, and material-map textures.
  - Improved texture matching using hashes, names, image areas, DDS roles, and fallback priorities.
  - Added support for shared texture overrides and conditional texture assignments.

- **Bug Fixes**
  - Prevented incorrect texture assignments to protected or unrelated meshes.
  - Improved isolation and binding of component atlas textures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->