### PR TITLE
fix(mod-viewer): pick WWMI diffuse by sRGB and color

### DIFF
--- a/src/main/lib/mod-viewer/draw-groups.ts
+++ b/src/main/lib/mod-viewer/draw-groups.ts
@@ -52,6 +52,8 @@ const AUX_MAP_CHANNELS: Record<string, "normal_map" | "light_map" | "material_ma
 };
 const HASH_TEXTURE_SUFFIX = /(Diffuse|NormalMap|LightMap|MaterialMap)$/i;
 const WWMI_DUMP_TEX_RE = /(?:^|[/\\])Components-(\d+(?:-\d+)*)\s+t=/i;
+const MAX_HINT_DECODE_BYTES = 32 * 1024 * 1024;
+const MAX_HINT_DECODE_AREA = 4096 * 4096;
 const IB_COMPONENT_DUMP_RE =
     /(?:^|[/\\])([0-9a-f]{8})_(\d+)_([0-9a-f]{8})_Hash_(DiffuseMap|LightMap|NormalMap|MaterialMap)\./i;
 const DDS_SRGB_DXGI = new Set([29, 72, 75, 78, 91, 93, 99]);
@@ -484,15 +486,16 @@ export async function attachWwmiDumpTextures(
         }
     }
 
-    const excludedByIndex = new Map(
-        targets.flatMap((group) => {
-            const index = wwmiComponentIndex(group);
-            if (!index || !needsDump.has(index)) {
-                return [];
-            }
-            return [[index, new Set(group.nonDiffuseTextureFiles)] as const];
-        }),
-    );
+    const excludedByIndex = targets.reduce((map, group) => {
+        const index = wwmiComponentIndex(group);
+        if (!index || !needsDump.has(index)) {
+            return map;
+        }
+        return map.set(
+            index,
+            new Set([...(map.get(index) ?? []), ...group.nonDiffuseTextureFiles]),
+        );
+    }, new Map<string, Set<string>>());
 
     const filesByIndex = Object.values(resources).reduce((map, info) => {
         const file = info.filename;
@@ -912,6 +915,17 @@ async function inspectWwmiTextureHint(filePath: string): Promise<WwmiTextureHint
     const bytes = (await fse.stat(filePath)).size;
     const ext = path.extname(filePath).toLowerCase();
     if (ext === ".png") {
+        if (bytes > MAX_HINT_DECODE_BYTES) {
+            return {
+                srgb: true,
+                colorSpace: "srgb",
+                area: 0,
+                bytes,
+                isLikelyFlat: false,
+                isLikelyNormal: false,
+                isLikelyPacked: false,
+            };
+        }
         const png = PNG.sync.read(await fse.readFile(filePath));
         return hintFromAnalysis(
             analyzePng(png.data, png.width, png.height),
@@ -961,7 +975,7 @@ async function inspectWwmiTextureHint(filePath: string): Promise<WwmiTextureHint
     const srgbState = parseDdsSrgbState(header);
     const colorSpace = srgbState === true ? "srgb" : srgbState === false ? "linear" : "unknown";
     const packedFormat = DDS_PACKED_FOURCC.has(fourcc) || DDS_PACKED_DXGI.has(dxgi);
-    if (colorSpace === "linear" || packedFormat) {
+    if (colorSpace === "linear" || packedFormat || area > MAX_HINT_DECODE_AREA) {
         return {
             srgb: colorSpace === "srgb",
             colorSpace,

--- a/src/main/lib/mod-viewer/draw-groups.ts
+++ b/src/main/lib/mod-viewer/draw-groups.ts
@@ -2,8 +2,11 @@ import { closeSync, openSync, readSync } from "node:fs";
 import { open } from "node:fs/promises";
 import path from "node:path";
 
+import { decodeDdsToRgba8 } from "@native/mod-tools";
+import { analyzePng, parseDdsSrgbState } from "@native/static-glb";
 import type { Dnf } from "@shared/mod-viewer/types";
 import fse from "fs-extra";
+import { PNG } from "pngjs";
 
 import type { ShapeSlider } from "./shapes";
 
@@ -48,12 +51,14 @@ const AUX_MAP_CHANNELS: Record<string, "normal_map" | "light_map" | "material_ma
     materialmap: "material_map",
 };
 const HASH_TEXTURE_SUFFIX = /(Diffuse|NormalMap|LightMap|MaterialMap)$/i;
-const WWMI_DUMP_TEX_RE = /(?:^|[/\\])Components-(\d+)\s+t=/i;
+const WWMI_DUMP_TEX_RE = /(?:^|[/\\])Components-(\d+(?:-\d+)*)\s+t=/i;
 const IB_COMPONENT_DUMP_RE =
     /(?:^|[/\\])([0-9a-f]{8})_(\d+)_([0-9a-f]{8})_Hash_(DiffuseMap|LightMap|NormalMap|MaterialMap)\./i;
 const DDS_SRGB_DXGI = new Set([29, 72, 75, 78, 91, 93, 99]);
+const DDS_PACKED_DXGI = new Set([80, 81, 83, 84]);
+const DDS_PACKED_FOURCC = new Set(["ATI1", "ATI2", "BC4U", "BC4S", "BC5U", "BC5S"]);
 
-export type TextureAssignment = { res: string; cond: Dnf };
+export type TextureAssignment = { res: string; cond: Dnf; authored?: boolean };
 
 export type DrawRecord = {
     label: string;
@@ -69,6 +74,7 @@ export type DrawRecord = {
     positionStride?: number;
     texcoordStride?: number;
     textureDefaultFile?: string;
+    textureAuthored?: boolean;
     textureVariants?: Array<{ conditions: Dnf; file: string }>;
     textureAssignments?: Array<{ conditions: Dnf; file: string }>;
     positionVariants?: Array<{ conditions: Dnf; file: string; stride: number }>;
@@ -92,6 +98,7 @@ export type DrawGroup = {
     ibFile: string;
     diffuseFile?: string;
     diffusePoolFiles: Array<{ res: string; file: string }>;
+    nonDiffuseTextureFiles: string[];
     indexSize: number;
     draws: DrawRecord[];
     shapeSliders?: ShapeSlider[];
@@ -127,6 +134,7 @@ type SectionInfo = {
     curDiffuseVariants: TextureAssignment[];
     diffuseChainKey?: string;
     diffuseLastCond?: Dnf;
+    nonDiffuseSlotPool: string[];
     diffuseHistory: TextureAssignment[];
     ibHistory: TextureAssignment[];
     vb0History: TextureAssignment[];
@@ -307,11 +315,13 @@ export function buildDrawGroups(
                 .filter((entry): entry is { conditions: Dnf; file: string } => !!entry);
             if (variants.length > 0) {
                 draw.textureDefaultFile = variants[0].file;
+                draw.textureAuthored = assignedDiffuse.some((entry) => entry.authored);
             } else {
                 const fallback = lookupRoleResource(snapshot.ib ?? ibRes, "Diffuse", resources);
                 const file = fallback ? resourceLookup(resources, fallback).filename : undefined;
                 if (file) {
                     draw.textureDefaultFile = file;
+                    draw.textureAuthored = true;
                 }
             }
             if (variants.length > 1) {
@@ -412,6 +422,14 @@ export function buildDrawGroups(
                 ? resourceLookup(resources, info.diffuse).filename
                 : undefined,
             diffusePoolFiles: poolFiles,
+            nonDiffuseTextureFiles: [
+                ...new Set(
+                    info.nonDiffuseSlotPool.flatMap((res) => {
+                        const file = resourceLookup(resources, res).filename;
+                        return file ? [file] : [];
+                    }),
+                ),
+            ],
             indexSize: ibIndexSize(ibRi.format),
             draws,
         });
@@ -427,26 +445,70 @@ export async function attachWwmiDumpTextures(
     resources: Record<string, ResourceInfo>,
     modDir: string,
 ): Promise<void> {
-    const needed = new Set(
-        groups.flatMap((group) => {
-            const index = wwmiComponentIndex(group);
-            if (!index || group.draws.every((draw) => draw.textureDefaultFile)) {
-                return [];
-            }
-            return [index];
-        }),
+    const targets = groups.filter(
+        (group) => wwmiComponentIndex(group) && group.draws.some((draw) => !draw.textureAuthored),
     );
-    if (needed.size === 0) {
+    if (targets.length === 0) {
         return;
     }
 
+    const hintCache = new Map<string, Promise<WwmiTextureHint | null>>();
+    const inspect = (relative: string | undefined) => {
+        const resolved = safeResourcePath(modDir, relative);
+        if (!resolved) {
+            return Promise.resolve(null);
+        }
+        const cached = hintCache.get(resolved);
+        if (cached) {
+            return cached;
+        }
+        const pending = inspectWwmiTextureHint(resolved).catch(() => null);
+        hintCache.set(resolved, pending);
+        return pending;
+    };
+
+    const needsDump = new Set<string>();
+    for (const group of targets) {
+        const index = wwmiComponentIndex(group);
+        if (!index) {
+            continue;
+        }
+        for (const draw of group.draws) {
+            if (draw.textureAuthored) {
+                continue;
+            }
+            const hint = await inspect(draw.textureDefaultFile);
+            if (!hint || !isLikelyWwmiDiffuse(hint)) {
+                needsDump.add(index);
+            }
+        }
+    }
+
+    const excludedByIndex = new Map(
+        targets.flatMap((group) => {
+            const index = wwmiComponentIndex(group);
+            if (!index || !needsDump.has(index)) {
+                return [];
+            }
+            return [[index, new Set(group.nonDiffuseTextureFiles)] as const];
+        }),
+    );
+
     const filesByIndex = Object.values(resources).reduce((map, info) => {
         const file = info.filename;
-        const index = file ? WWMI_DUMP_TEX_RE.exec(file.replaceAll("\\", "/"))?.[1] : undefined;
-        if (!file || !index || !needed.has(index)) {
+        const indices = file
+            ? WWMI_DUMP_TEX_RE.exec(file.replaceAll("\\", "/"))?.[1]?.split("-")
+            : undefined;
+        if (!file || !indices) {
             return map;
         }
-        return map.set(index, [...(map.get(index) ?? []), file]);
+        for (const index of indices) {
+            if (!needsDump.has(index) || excludedByIndex.get(index)?.has(file)) {
+                continue;
+            }
+            map.set(index, [...(map.get(index) ?? []), file]);
+        }
+        return map;
     }, new Map<string, string[]>());
 
     const pickedByIndex = new Map(
@@ -456,20 +518,16 @@ export async function attachWwmiDumpTextures(
                     const scored = (
                         await Promise.all(
                             files.map(async (file, order) => {
-                                const resolved = safeResourcePath(modDir, file);
-                                if (!resolved || !(await fse.pathExists(resolved))) {
-                                    return null;
-                                }
-                                const hint = await inspectWwmiTextureHint(resolved).catch(
-                                    () => null,
-                                );
-                                if (!hint) {
+                                const hint = await inspect(file);
+                                if (!hint || !isLikelyWwmiDiffuse(hint)) {
                                     return null;
                                 }
                                 return {
                                     file,
                                     order,
-                                    ...hint,
+                                    srgb: hint.srgb,
+                                    area: hint.area,
+                                    bytes: hint.bytes,
                                 };
                             }),
                         )
@@ -481,14 +539,31 @@ export async function attachWwmiDumpTextures(
         ).filter((entry): entry is NonNullable<typeof entry> => !!entry),
     );
 
-    for (const group of groups) {
-        const picked = pickedByIndex.get(wwmiComponentIndex(group) ?? "");
-        if (!picked) {
-            continue;
-        }
-        group.diffuseFile ??= picked;
+    for (const group of targets) {
+        const dumpPick = pickedByIndex.get(wwmiComponentIndex(group) ?? "");
         for (const draw of group.draws) {
-            draw.textureDefaultFile ??= picked;
+            if (draw.textureAuthored) {
+                continue;
+            }
+            const currentHint = await inspect(draw.textureDefaultFile);
+            if (currentHint && isLikelyWwmiDiffuse(currentHint)) {
+                draw.textureVariants = await keepLikelyDiffuseVariants(
+                    draw.textureVariants,
+                    inspect,
+                );
+                draw.textureAssignments = await keepLikelyDiffuseVariants(
+                    draw.textureAssignments,
+                    inspect,
+                );
+                continue;
+            }
+            if (!dumpPick) {
+                continue;
+            }
+            draw.textureDefaultFile = dumpPick;
+            group.diffuseFile ??= dumpPick;
+            draw.textureVariants = undefined;
+            draw.textureAssignments = undefined;
         }
     }
 }
@@ -777,17 +852,169 @@ function ibDrawWeight(groups: DrawGroup[]): number {
     );
 }
 
+export type WwmiTextureHint = {
+    srgb: boolean;
+    colorSpace: "srgb" | "linear" | "unknown";
+    area: number;
+    bytes: number;
+    isLikelyFlat: boolean;
+    isLikelyNormal: boolean;
+    isLikelyPacked: boolean;
+};
+
+export function isLikelyWwmiDiffuse(hint: WwmiTextureHint): boolean {
+    if (hint.colorSpace === "linear") {
+        return false;
+    }
+    return !hint.isLikelyFlat && !hint.isLikelyNormal && !hint.isLikelyPacked;
+}
+
 export function pickWwmiDumpDiffuse(
     candidates: Array<{ file: string; srgb: boolean; area: number; bytes: number; order: number }>,
 ): string | undefined {
     const ranked = [...candidates].sort(
         (left, right) =>
+            wwmiDumpShareCount(left.file) - wwmiDumpShareCount(right.file) ||
             Number(right.srgb) - Number(left.srgb) ||
             right.area - left.area ||
             right.bytes - left.bytes ||
             left.order - right.order,
     );
     return ranked[0]?.file;
+}
+
+function wwmiDumpShareCount(file: string): number {
+    return WWMI_DUMP_TEX_RE.exec(file.replaceAll("\\", "/"))?.[1]?.split("-").length || 1;
+}
+
+async function keepLikelyDiffuseVariants(
+    variants: Array<{ conditions: Dnf; file: string }> | undefined,
+    inspect: (relative: string | undefined) => Promise<WwmiTextureHint | null>,
+) {
+    if (!variants?.length) {
+        return variants;
+    }
+    const kept = (
+        await Promise.all(
+            variants.map(async (variant) => {
+                const hint = await inspect(variant.file);
+                return hint && isLikelyWwmiDiffuse(hint) ? variant : null;
+            }),
+        )
+    ).filter((variant): variant is NonNullable<typeof variant> => !!variant);
+    return kept.length > 0 ? kept : undefined;
+}
+
+async function inspectWwmiTextureHint(filePath: string): Promise<WwmiTextureHint | null> {
+    if (!(await fse.pathExists(filePath))) {
+        return null;
+    }
+    const bytes = (await fse.stat(filePath)).size;
+    const ext = path.extname(filePath).toLowerCase();
+    if (ext === ".png") {
+        const png = PNG.sync.read(await fse.readFile(filePath));
+        return hintFromAnalysis(
+            analyzePng(png.data, png.width, png.height),
+            "srgb",
+            png.width * png.height,
+            bytes,
+        );
+    }
+    if (ext === ".jpg" || ext === ".jpeg") {
+        return {
+            srgb: true,
+            colorSpace: "srgb",
+            area: 0,
+            bytes,
+            isLikelyFlat: false,
+            isLikelyNormal: false,
+            isLikelyPacked: false,
+        };
+    }
+    if (ext !== ".dds" || bytes < 128) {
+        return {
+            srgb: false,
+            colorSpace: "unknown",
+            area: 0,
+            bytes,
+            isLikelyFlat: false,
+            isLikelyNormal: false,
+            isLikelyPacked: false,
+        };
+    }
+
+    const header = await readFilePrefix(filePath, Math.min(148, bytes));
+    if (header.length < 128) {
+        return {
+            srgb: false,
+            colorSpace: "unknown",
+            area: 0,
+            bytes,
+            isLikelyFlat: false,
+            isLikelyNormal: false,
+            isLikelyPacked: false,
+        };
+    }
+    const area = header.readUInt32LE(16) * header.readUInt32LE(12);
+    const fourcc = header.toString("ascii", 84, 88);
+    const dxgi = fourcc === "DX10" && header.length >= 132 ? header.readUInt32LE(128) : -1;
+    const srgbState = parseDdsSrgbState(header);
+    const colorSpace = srgbState === true ? "srgb" : srgbState === false ? "linear" : "unknown";
+    const packedFormat = DDS_PACKED_FOURCC.has(fourcc) || DDS_PACKED_DXGI.has(dxgi);
+    if (colorSpace === "linear" || packedFormat) {
+        return {
+            srgb: colorSpace === "srgb",
+            colorSpace,
+            area,
+            bytes,
+            isLikelyFlat: false,
+            isLikelyNormal: packedFormat,
+            isLikelyPacked: packedFormat,
+        };
+    }
+    const decoded = await decodeDdsToRgba8(filePath);
+    return hintFromAnalysis(
+        analyzePng(decoded.data, decoded.width, decoded.height),
+        colorSpace,
+        area,
+        bytes,
+    );
+}
+
+function hintFromAnalysis(
+    analysis: {
+        channelRangeMax: number;
+        luminanceStdDev: number;
+        meanR: number;
+        meanG: number;
+        meanB: number;
+        blueDominance: number;
+    },
+    colorSpace: WwmiTextureHint["colorSpace"],
+    area: number,
+    bytes: number,
+): WwmiTextureHint {
+    const means = [analysis.meanR, analysis.meanG, analysis.meanB];
+    return {
+        srgb: colorSpace === "srgb",
+        colorSpace,
+        area,
+        bytes,
+        isLikelyFlat:
+            analysis.channelRangeMax <= 12 ||
+            (analysis.luminanceStdDev <= 0.035 && analysis.channelRangeMax <= 24) ||
+            analysis.luminanceStdDev <= 0.012,
+        isLikelyNormal:
+            analysis.meanB >= 0.7 &&
+            Math.abs(analysis.meanR - 0.5) <= 0.18 &&
+            Math.abs(analysis.meanG - 0.5) <= 0.18 &&
+            analysis.blueDominance >= 0.12 &&
+            analysis.channelRangeMax <= 72 &&
+            analysis.luminanceStdDev <= 0.12,
+        isLikelyPacked:
+            means.some((value) => value <= 0.04) &&
+            means.some((value) => Math.abs(value - 0.5) <= 0.15),
+    };
 }
 
 export function attachShapeSliders(groups: DrawGroup[], shapeSliders: ShapeSlider[]): void {
@@ -813,39 +1040,6 @@ function wwmiComponentIndex(group: DrawGroup): string | undefined {
         /^Component(\d+)$/i.exec(group.displayName)?.[1] ??
         /^Component(\d+)$/i.exec(group.name)?.[1]
     );
-}
-
-async function inspectWwmiTextureHint(
-    filePath: string,
-): Promise<{ srgb: boolean; area: number; bytes: number }> {
-    const bytes = (await fse.stat(filePath)).size;
-    const ext = path.extname(filePath).toLowerCase();
-    if (ext === ".png") {
-        return { srgb: true, area: await readPngArea(filePath), bytes };
-    }
-    if (ext === ".jpg" || ext === ".jpeg") {
-        return { srgb: true, area: 0, bytes };
-    }
-    if (ext !== ".dds" || bytes < 128) {
-        return { srgb: false, area: 0, bytes };
-    }
-    const header = await readFilePrefix(filePath, Math.min(148, bytes));
-    if (header.length < 128) {
-        return { srgb: false, area: 0, bytes };
-    }
-    const area = header.readUInt32LE(16) * header.readUInt32LE(12);
-    if (header.toString("ascii", 84, 88) !== "DX10" || header.length < 132) {
-        return { srgb: false, area, bytes };
-    }
-    return { srgb: DDS_SRGB_DXGI.has(header.readUInt32LE(128)), area, bytes };
-}
-
-async function readPngArea(filePath: string): Promise<number> {
-    const header = await readFilePrefix(filePath, 24);
-    if (header.length < 24) {
-        return 0;
-    }
-    return header.readUInt32BE(16) * header.readUInt32BE(20);
 }
 
 async function readFilePrefix(filePath: string, length: number): Promise<Buffer> {
@@ -1007,16 +1201,26 @@ function scanSectionsForDraws(
             }
 
             let diffuse = /^Resource\\[^\\]+\\Diffuse\s*=\s*(?:ref\s+)?(\S+)/i.exec(line);
+            let authoredDiffuse = Boolean(diffuse);
             if (!diffuse) {
-                const ps = /^ps-t\d+\s*=\s*(\S+)/i.exec(line);
-                if (ps && /Diffuse/i.test(ps[1])) {
-                    diffuse = ps;
+                const ps = /^ps-t(\d+)\s*=\s*(?:ref\s+)?(\S+)/i.exec(line);
+                if (ps && ps[1] !== "0" && !/Diffuse/i.test(ps[2])) {
+                    info.nonDiffuseSlotPool.push(ps[2]);
+                }
+                if (
+                    ps &&
+                    !/(NormalMap|LightMap|MaterialMap)/i.test(ps[2]) &&
+                    (ps[1] === "0" || /Diffuse/i.test(ps[2]))
+                ) {
+                    diffuse = [ps[0], ps[2]] as unknown as RegExpExecArray;
+                    authoredDiffuse = /Diffuse/i.test(ps[2]);
                 }
             }
             if (!diffuse) {
                 const self = /^this\s*=\s*(?:ref\s+)?(\S+)/i.exec(line);
                 if (self && (/Diffuse/i.test(self[1]) || /^Diffuse$/i.test(sectionRole ?? ""))) {
                     diffuse = self;
+                    authoredDiffuse = true;
                 }
             }
             if (diffuse) {
@@ -1044,9 +1248,9 @@ function scanSectionsForDraws(
                 ) {
                     info.curDiffuseVariants.pop();
                 }
-                info.curDiffuseVariants.push({ res, cond });
+                info.curDiffuseVariants.push({ res, cond, authored: authoredDiffuse });
                 info.diffuseLastCond = cond;
-                info.diffuseHistory.push({ res, cond });
+                info.diffuseHistory.push({ res, cond, authored: authoredDiffuse });
             }
 
             let aux =
@@ -1134,6 +1338,7 @@ function scanSectionsForDraws(
             auxMapsAtEnd: {},
             curDiffuseVariants: [],
             diffuseHistory: [],
+            nonDiffuseSlotPool: [],
             ibHistory: [],
             vb0History: [],
             vb1History: [],

--- a/src/main/lib/mod-viewer/draw-groups.ts
+++ b/src/main/lib/mod-viewer/draw-groups.ts
@@ -54,6 +54,7 @@ const HASH_TEXTURE_SUFFIX = /(Diffuse|NormalMap|LightMap|MaterialMap)$/i;
 const WWMI_DUMP_TEX_RE = /(?:^|[/\\])Components-(\d+(?:-\d+)*)\s+t=/i;
 const MAX_HINT_DECODE_BYTES = 32 * 1024 * 1024;
 const MAX_HINT_DECODE_AREA = 4096 * 4096;
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const IB_COMPONENT_DUMP_RE =
     /(?:^|[/\\])([0-9a-f]{8})_(\d+)_([0-9a-f]{8})_Hash_(DiffuseMap|LightMap|NormalMap|MaterialMap)\./i;
 const DDS_SRGB_DXGI = new Set([29, 72, 75, 78, 91, 93, 99]);
@@ -915,11 +916,12 @@ async function inspectWwmiTextureHint(filePath: string): Promise<WwmiTextureHint
     const bytes = (await fse.stat(filePath)).size;
     const ext = path.extname(filePath).toLowerCase();
     if (ext === ".png") {
-        if (bytes > MAX_HINT_DECODE_BYTES) {
+        const area = pngIhdrArea(await readFilePrefix(filePath, 24)) ?? 0;
+        if (bytes > MAX_HINT_DECODE_BYTES || area > MAX_HINT_DECODE_AREA) {
             return {
                 srgb: true,
                 colorSpace: "srgb",
-                area: 0,
+                area,
                 bytes,
                 isLikelyFlat: false,
                 isLikelyNormal: false,
@@ -975,7 +977,12 @@ async function inspectWwmiTextureHint(filePath: string): Promise<WwmiTextureHint
     const srgbState = parseDdsSrgbState(header);
     const colorSpace = srgbState === true ? "srgb" : srgbState === false ? "linear" : "unknown";
     const packedFormat = DDS_PACKED_FOURCC.has(fourcc) || DDS_PACKED_DXGI.has(dxgi);
-    if (colorSpace === "linear" || packedFormat || area > MAX_HINT_DECODE_AREA) {
+    if (
+        colorSpace === "linear" ||
+        packedFormat ||
+        area > MAX_HINT_DECODE_AREA ||
+        bytes > MAX_HINT_DECODE_BYTES
+    ) {
         return {
             srgb: colorSpace === "srgb",
             colorSpace,
@@ -993,6 +1000,22 @@ async function inspectWwmiTextureHint(filePath: string): Promise<WwmiTextureHint
         area,
         bytes,
     );
+}
+
+function pngIhdrArea(header: Buffer): number | undefined {
+    if (
+        header.length < 24 ||
+        !header.subarray(0, 8).equals(PNG_SIGNATURE) ||
+        header.toString("ascii", 12, 16) !== "IHDR"
+    ) {
+        return undefined;
+    }
+    const width = header.readUInt32BE(16);
+    const height = header.readUInt32BE(20);
+    if (width === 0 || height === 0) {
+        return undefined;
+    }
+    return width * height;
 }
 
 function hintFromAnalysis(

--- a/src/main/lib/mod-viewer/load.test.ts
+++ b/src/main/lib/mod-viewer/load.test.ts
@@ -1910,6 +1910,54 @@ filename = Textures/Components-2 t=742c5c7b.png
         assert.ok(payload.meshes.every((mesh) => !String(mesh.texKey).includes("e02d9167")));
     });
 
+    it("unions WWMI non-diffuse dump exclusions across shared component indexes", async () => {
+        const root = await makeMod({
+            ini: `[TextureOverrideComponent3]
+hash = 8d8097bc
+ib = ResourceIndexBuffer
+vb0 = ResourcePositionBuffer
+vb1 = ResourceTexCoordBuffer
+ps-t1 = ResourceTexture31
+drawindexed = 3, 0, 0
+[TextureOverridecomponent3]
+hash = 8d8097bd
+ib = ResourceIndexBuffer
+vb0 = ResourcePositionBuffer
+vb1 = ResourceTexCoordBuffer
+drawindexed = 3, 0, 0
+[ResourcePositionBuffer]
+filename = pos.buf
+stride = 40
+[ResourceTexCoordBuffer]
+filename = tc.buf
+stride = 20
+[ResourceIndexBuffer]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+[ResourceTexture31]
+filename = Textures/Components-3 t=e02d9167.png
+[ResourceTextureOther]
+filename = Textures/Components-3 t=742c5c7b.png
+`,
+            extra: async (dir) => {
+                await fse.ensureDir(path.join(dir, "Textures"));
+                await fse.writeFile(
+                    path.join(dir, "Textures", "Components-3 t=e02d9167.png"),
+                    makeColorPng(32, 32),
+                );
+                await fse.writeFile(
+                    path.join(dir, "Textures", "Components-3 t=742c5c7b.png"),
+                    makeColorPng(),
+                );
+            },
+        });
+
+        const payload = await loadModViewerPayload(root);
+        assert.ok(payload.meshes.length >= 2);
+        assert.ok(payload.meshes.every((mesh) => String(mesh.texKey).includes("742c5c7b.png")));
+        assert.ok(payload.meshes.every((mesh) => !String(mesh.texKey).includes("e02d9167")));
+    });
+
     it("replaces unnamed WWMI ps-t0 when it is a flat color map", async () => {
         const root = await makeMod({
             ini: `[TextureOverrideComponent3]

--- a/src/main/lib/mod-viewer/load.test.ts
+++ b/src/main/lib/mod-viewer/load.test.ts
@@ -4,10 +4,11 @@ import path from "node:path";
 
 import { applyVariableSelection, evaluateViewerState } from "@shared/mod-viewer/eval";
 import fse from "fs-extra";
+import { PNG } from "pngjs";
 import { afterEach, describe, it } from "vitest";
 
 import { DNF_FALSE, isUnconstrained, sameDnf } from "./dnf";
-import { buildDrawGroups, pickWwmiDumpDiffuse } from "./draw-groups";
+import { buildDrawGroups, isLikelyWwmiDiffuse, pickWwmiDumpDiffuse } from "./draw-groups";
 import { extractResources, parseIniFile, parseIniText } from "./ini";
 import { loadModViewerPayload } from "./load";
 
@@ -20,6 +21,31 @@ const PNG_2X2 = Buffer.from(
     "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAE0lEQVR4AWP8z8DwnwEImBigAAAfFwICgH3ifwAAAABJRU5ErkJggg==",
     "base64",
 );
+
+function makeColorPng(width = 16, height = 16) {
+    const png = new PNG({ width, height });
+    for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+            const offset = (y * width + x) * 4;
+            png.data[offset] = Math.round((x / Math.max(width - 1, 1)) * 255);
+            png.data[offset + 1] = Math.round((y / Math.max(height - 1, 1)) * 255);
+            png.data[offset + 2] = 90;
+            png.data[offset + 3] = 255;
+        }
+    }
+    return PNG.sync.write(png);
+}
+
+function makeFlatPng(width = 16, height = 16) {
+    const png = new PNG({ width, height });
+    for (let index = 0; index < width * height; index++) {
+        png.data[index * 4] = 240;
+        png.data[index * 4 + 1] = 240;
+        png.data[index * 4 + 2] = 240;
+        png.data[index * 4 + 3] = 255;
+    }
+    return PNG.sync.write(png);
+}
 
 afterEach(async () => {
     await Promise.all(tempRoots.splice(0).map((root) => fse.remove(root)));
@@ -1558,6 +1584,46 @@ filename = fire.png
         );
     });
 
+    it("prefers exclusive WWMI dump textures over shared Components-N-M dumps", () => {
+        assert.equal(
+            pickWwmiDumpDiffuse([
+                {
+                    file: "Textures/Components-0-1-2-3-4-5 t=e9612536.dds",
+                    srgb: true,
+                    area: 2048 * 2048,
+                    bytes: 4_194_452,
+                    order: 0,
+                },
+                {
+                    file: "Textures/Components-3 t=7d8d1ae0.dds",
+                    srgb: false,
+                    area: 512 * 512,
+                    bytes: 262_292,
+                    order: 1,
+                },
+            ]),
+            "Textures/Components-3 t=7d8d1ae0.dds",
+        );
+    });
+
+    it("rejects linear, flat, packed, and normal-looking WWMI dump hints", () => {
+        const ok: Parameters<typeof isLikelyWwmiDiffuse>[0] = {
+            srgb: true,
+            colorSpace: "srgb",
+            area: 1024,
+            bytes: 100,
+            isLikelyFlat: false,
+            isLikelyNormal: false,
+            isLikelyPacked: false,
+        };
+        assert.equal(isLikelyWwmiDiffuse(ok), true);
+        assert.equal(isLikelyWwmiDiffuse({ ...ok, colorSpace: "unknown" }), true);
+        assert.equal(isLikelyWwmiDiffuse({ ...ok, colorSpace: "linear", srgb: false }), false);
+        assert.equal(isLikelyWwmiDiffuse({ ...ok, isLikelyFlat: true }), false);
+        assert.equal(isLikelyWwmiDiffuse({ ...ok, isLikelyNormal: true }), false);
+        assert.equal(isLikelyWwmiDiffuse({ ...ok, isLikelyPacked: true }), false);
+    });
+
     it("binds WWMI Components-N dump textures when hash overrides have no Diffuse name", async () => {
         const root = await makeMod({
             ini: `[TextureOverrideComponent2]
@@ -1601,7 +1667,7 @@ this = ResourceTexture4
                 await fse.ensureDir(path.join(dir, "Textures"));
                 await fse.writeFile(
                     path.join(dir, "Textures", "Components-2 t=0454fc47.png"),
-                    PNG_1X1,
+                    makeColorPng(),
                 );
                 await fse.writeFile(
                     path.join(dir, "Textures", "Components-3 t=1944212c.jpg"),
@@ -1609,7 +1675,7 @@ this = ResourceTexture4
                 );
                 await fse.writeFile(
                     path.join(dir, "Textures", "Components-3 t=f58624fb.png"),
-                    PNG_2X2,
+                    makeColorPng(32, 32),
                 );
             },
         });
@@ -1691,7 +1757,7 @@ this = ResourceTexture0
                 await fse.ensureDir(path.join(dir, "Textures"));
                 await fse.writeFile(
                     path.join(dir, "Textures", "Components-3 t=f58624fb.png"),
-                    PNG_2X2,
+                    makeColorPng(),
                 );
             },
         });
@@ -1699,6 +1765,191 @@ this = ResourceTexture0
         const payload = await loadModViewerPayload(root);
         assert.equal(payload.meshes.length, 1);
         assert.equal(payload.meshes[0].texKey, null);
+    });
+
+    it("binds WWMI ps-t0 resources without Diffuse in the name", async () => {
+        const root = await makeMod({
+            ini: `[Constants]
+global persist $socks = 0
+[KeySocks]
+type = cycle
+$socks = 0, 1
+[TextureOverrideComponent3]
+hash = 8d8097bc
+ib = ResourceIndexBuffer
+vb0 = ResourcePositionBuffer
+vb1 = ResourceTexCoordBuffer
+if $socks == 0
+ps-t0 = ResourceTexture35
+ps-t3 = ResourceTexture32
+endif
+if $socks == 1
+ps-t0 = ResourceTexture35A
+ps-t3 = ResourceTexture32
+endif
+drawindexed = 3, 0, 0
+[ResourcePositionBuffer]
+filename = pos.buf
+stride = 40
+[ResourceTexCoordBuffer]
+filename = tc.buf
+stride = 20
+[ResourceIndexBuffer]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+[ResourceTexture32]
+filename = Textures/Components-3 t=348c9329.png
+[ResourceTexture35]
+filename = Textures/Components-3 t=7d8d1ae0.png
+[ResourceTexture35A]
+filename = Textures/Components-3 t=7d8d1ae0A.png
+`,
+            extra: async (dir) => {
+                await fse.ensureDir(path.join(dir, "Textures"));
+                await fse.writeFile(
+                    path.join(dir, "Textures", "Components-3 t=348c9329.png"),
+                    makeColorPng(32, 32),
+                );
+                await fse.writeFile(
+                    path.join(dir, "Textures", "Components-3 t=7d8d1ae0.png"),
+                    makeColorPng(),
+                );
+                await fse.writeFile(
+                    path.join(dir, "Textures", "Components-3 t=7d8d1ae0A.png"),
+                    makeColorPng(),
+                );
+            },
+        });
+
+        const payload = await loadModViewerPayload(root);
+        assert.ok(payload.meshes.length >= 1);
+        assert.ok(payload.meshes.every((mesh) => String(mesh.texKey).includes("7d8d1ae0")));
+        assert.ok(payload.meshes.every((mesh) => !String(mesh.texKey).includes("348c9329")));
+        const socksOff = evaluateViewerState(payload, { socks: "0" });
+        const socksOn = evaluateViewerState(payload, { socks: "1" });
+        assert.ok(String(socksOff.meshes[0]?.texKey).includes("7d8d1ae0.png"));
+        assert.ok(String(socksOn.meshes[0]?.texKey).includes("7d8d1ae0A.png"));
+    });
+
+    it("binds shared WWMI Components-N-M dumps onto components without exclusive files", async () => {
+        const root = await makeMod({
+            ini: `[TextureOverrideComponent5]
+hash = 8d8097bc
+ib = ResourceIndexBuffer
+vb0 = ResourcePositionBuffer
+vb1 = ResourceTexCoordBuffer
+drawindexed = 3, 0, 0
+[ResourcePositionBuffer]
+filename = pos.buf
+stride = 40
+[ResourceTexCoordBuffer]
+filename = tc.buf
+stride = 20
+[ResourceIndexBuffer]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+[ResourceTexture11]
+filename = Textures/Components-0-1-2-3-4-5 t=e9612536.png
+[TextureOverrideTexture11]
+hash = e9612536
+this = ResourceTexture11
+`,
+            extra: async (dir) => {
+                await fse.ensureDir(path.join(dir, "Textures"));
+                await fse.writeFile(
+                    path.join(dir, "Textures", "Components-0-1-2-3-4-5 t=e9612536.png"),
+                    makeColorPng(),
+                );
+            },
+        });
+
+        const payload = await loadModViewerPayload(root);
+        assert.ok(payload.meshes.length >= 1);
+        assert.ok(payload.meshes.every((mesh) => String(mesh.texKey).includes("e9612536.png")));
+    });
+
+    it("does not pick WWMI dump textures assigned to non-diffuse ps-t slots", async () => {
+        const root = await makeMod({
+            ini: `[TextureOverrideComponent2]
+hash = 8d8097bc
+ib = ResourceIndexBuffer
+vb0 = ResourcePositionBuffer
+vb1 = ResourceTexCoordBuffer
+ps-t1 = ResourceTexture31
+drawindexed = 3, 0, 0
+[ResourcePositionBuffer]
+filename = pos.buf
+stride = 40
+[ResourceTexCoordBuffer]
+filename = tc.buf
+stride = 20
+[ResourceIndexBuffer]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+[ResourceTexture31]
+filename = Textures/Components-2 t=e02d9167.png
+[ResourceTextureOther]
+filename = Textures/Components-2 t=742c5c7b.png
+`,
+            extra: async (dir) => {
+                await fse.ensureDir(path.join(dir, "Textures"));
+                await fse.writeFile(
+                    path.join(dir, "Textures", "Components-2 t=e02d9167.png"),
+                    makeColorPng(32, 32),
+                );
+                await fse.writeFile(
+                    path.join(dir, "Textures", "Components-2 t=742c5c7b.png"),
+                    makeColorPng(),
+                );
+            },
+        });
+
+        const payload = await loadModViewerPayload(root);
+        assert.ok(payload.meshes.length >= 1);
+        assert.ok(payload.meshes.every((mesh) => String(mesh.texKey).includes("742c5c7b.png")));
+        assert.ok(payload.meshes.every((mesh) => !String(mesh.texKey).includes("e02d9167")));
+    });
+
+    it("replaces unnamed WWMI ps-t0 when it is a flat color map", async () => {
+        const root = await makeMod({
+            ini: `[TextureOverrideComponent3]
+hash = 8d8097bc
+ib = ResourceIndexBuffer
+vb0 = ResourcePositionBuffer
+vb1 = ResourceTexCoordBuffer
+ps-t0 = ResourceTexture35
+drawindexed = 3, 0, 0
+[ResourcePositionBuffer]
+filename = pos.buf
+stride = 40
+[ResourceTexCoordBuffer]
+filename = tc.buf
+stride = 20
+[ResourceIndexBuffer]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+[ResourceTexture35]
+filename = Textures/Components-3 t=7d8d1ae0.png
+[ResourceTexture4]
+filename = Textures/Components-3 t=f58624fb.png
+`,
+            extra: async (dir) => {
+                await fse.ensureDir(path.join(dir, "Textures"));
+                await fse.writeFile(
+                    path.join(dir, "Textures", "Components-3 t=7d8d1ae0.png"),
+                    makeFlatPng(),
+                );
+                await fse.writeFile(
+                    path.join(dir, "Textures", "Components-3 t=f58624fb.png"),
+                    makeColorPng(),
+                );
+            },
+        });
+
+        const payload = await loadModViewerPayload(root);
+        assert.ok(payload.meshes.length >= 1);
+        assert.ok(payload.meshes.every((mesh) => String(mesh.texKey).includes("f58624fb.png")));
+        assert.ok(payload.meshes.every((mesh) => !String(mesh.texKey).includes("7d8d1ae0")));
     });
 
     it("plays Present time animations as position variants without a toggle", async () => {

--- a/src/main/lib/mod-viewer/load.test.ts
+++ b/src/main/lib/mod-viewer/load.test.ts
@@ -36,6 +36,25 @@ function makeColorPng(width = 16, height = 16) {
     return PNG.sync.write(png);
 }
 
+function makePngIhdr(width: number, height: number) {
+    const header = Buffer.alloc(24);
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(header);
+    header.writeUInt32BE(13, 8);
+    header.write("IHDR", 12);
+    header.writeUInt32BE(width, 16);
+    header.writeUInt32BE(height, 20);
+    return header;
+}
+
+function makeDdsHeader(width: number, height: number) {
+    const header = Buffer.alloc(128);
+    header.write("DDS ", 0);
+    header.writeUInt32LE(124, 4);
+    header.writeUInt32LE(height, 12);
+    header.writeUInt32LE(width, 16);
+    return header;
+}
+
 function makeFlatPng(width = 16, height = 16) {
     const png = new PNG({ width, height });
     for (let index = 0; index < width * height; index++) {
@@ -1956,6 +1975,90 @@ filename = Textures/Components-3 t=742c5c7b.png
         assert.ok(payload.meshes.length >= 2);
         assert.ok(payload.meshes.every((mesh) => String(mesh.texKey).includes("742c5c7b.png")));
         assert.ok(payload.meshes.every((mesh) => !String(mesh.texKey).includes("e02d9167")));
+    });
+
+    it("skips decoding oversized PNG candidates using IHDR area", async () => {
+        const root = await makeMod({
+            ini: `[TextureOverrideComponent3]
+hash = 8d8097bc
+ib = ResourceIndexBuffer
+vb0 = ResourcePositionBuffer
+vb1 = ResourceTexCoordBuffer
+ps-t0 = ResourceTexture35
+drawindexed = 3, 0, 0
+[ResourcePositionBuffer]
+filename = pos.buf
+stride = 40
+[ResourceTexCoordBuffer]
+filename = tc.buf
+stride = 20
+[ResourceIndexBuffer]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+[ResourceTexture35]
+filename = Textures/Components-3 t=7d8d1ae0.png
+[ResourceTexture4]
+filename = Textures/Components-3 t=f58624fb.png
+`,
+            extra: async (dir) => {
+                await fse.ensureDir(path.join(dir, "Textures"));
+                await fse.writeFile(
+                    path.join(dir, "Textures", "Components-3 t=7d8d1ae0.png"),
+                    makePngIhdr(8192, 8192),
+                );
+                await fse.writeFile(
+                    path.join(dir, "Textures", "Components-3 t=f58624fb.png"),
+                    makeColorPng(),
+                );
+            },
+        });
+
+        const payload = await loadModViewerPayload(root);
+        assert.ok(payload.meshes.length >= 1);
+        assert.ok(payload.meshes.every((mesh) => String(mesh.texKey).includes("7d8d1ae0.png")));
+        assert.ok(payload.meshes.every((mesh) => !String(mesh.texKey).includes("f58624fb")));
+    });
+
+    it("skips decoding oversized DDS candidates using header area", async () => {
+        const root = await makeMod({
+            ini: `[TextureOverrideComponent3]
+hash = 8d8097bc
+ib = ResourceIndexBuffer
+vb0 = ResourcePositionBuffer
+vb1 = ResourceTexCoordBuffer
+ps-t0 = ResourceTexture35
+drawindexed = 3, 0, 0
+[ResourcePositionBuffer]
+filename = pos.buf
+stride = 40
+[ResourceTexCoordBuffer]
+filename = tc.buf
+stride = 20
+[ResourceIndexBuffer]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+[ResourceTexture35]
+filename = Textures/Components-3 t=7d8d1ae0.dds
+[ResourceTexture4]
+filename = Textures/Components-3 t=f58624fb.png
+`,
+            extra: async (dir) => {
+                await fse.ensureDir(path.join(dir, "Textures"));
+                await fse.writeFile(
+                    path.join(dir, "Textures", "Components-3 t=7d8d1ae0.dds"),
+                    makeDdsHeader(8192, 8192),
+                );
+                await fse.writeFile(
+                    path.join(dir, "Textures", "Components-3 t=f58624fb.png"),
+                    makeColorPng(),
+                );
+            },
+        });
+
+        const payload = await loadModViewerPayload(root);
+        assert.ok(payload.meshes.length >= 1);
+        assert.equal(payload.meshes[0]?.texKey, null);
+        assert.ok(Object.keys(payload.textures).every((key) => !key.includes("f58624fb")));
     });
 
     it("replaces unnamed WWMI ps-t0 when it is a flat color map", async () => {

--- a/src/main/lib/mod-viewer/mesh-builder.test.ts
+++ b/src/main/lib/mod-viewer/mesh-builder.test.ts
@@ -93,6 +93,7 @@ function makeGroup(draws: DrawRecord[]): DrawGroup {
         texcoordUvOff: 4,
         ibFile: "body.ib",
         diffusePoolFiles: [],
+        nonDiffuseTextureFiles: [],
         indexSize: 4,
         draws,
     };

--- a/src/main/lib/mod-viewer/mesh-builder.test.ts
+++ b/src/main/lib/mod-viewer/mesh-builder.test.ts
@@ -64,6 +64,17 @@ describe("buildMeshResult", () => {
         assert.equal(result.textures["diffuse::alt.jpg"]?.mimeType, "image/jpeg");
         assert.deepEqual(result.textures["diffuse::alt.jpg"]?.bytes, jpeg);
     });
+
+    it("omits unsupported textures from mesh results", async () => {
+        const root = await makeMeshDir();
+        await fse.writeFile(path.join(root, "diffuse.txt"), Buffer.from("not an image"));
+        const result = await buildMeshResult(
+            [makeGroup([makeDraw({ textureDefaultFile: "diffuse.txt" })])],
+            root,
+        );
+        assert.equal(result.meshes[0]?.texKey, null);
+        assert.deepEqual(result.textures, {});
+    });
 });
 
 async function makeMeshDir() {

--- a/src/main/lib/mod-viewer/mesh-builder.ts
+++ b/src/main/lib/mod-viewer/mesh-builder.ts
@@ -116,17 +116,6 @@ export async function buildMeshResult(
         }
         const unique = deduplicateDraws(group);
 
-        const texKeyFor = (relative: string | undefined, role: ViewerTextureRole = "diffuse") => {
-            if (!relative) {
-                return null;
-            }
-            const resolved = safeResourcePath(modDir, relative);
-            if (!resolved) {
-                return null;
-            }
-            return textureKey(path.relative(modDir, resolved).replaceAll("\\", "/"), role);
-        };
-
         const ensureTexture = async (
             relative: string | undefined,
             role: ViewerTextureRole = "diffuse",
@@ -138,15 +127,16 @@ export async function buildMeshResult(
             const key = textureKey(path.relative(modDir, resolved).replaceAll("\\", "/"), role);
             if (!textures[key]) {
                 const encoded = await encodeTexture(resolved, role, readBuffer);
-                if (encoded) {
-                    textures[key] = {
-                        texKey: key,
-                        role,
-                        bytes: encoded.bytes,
-                        mimeType: encoded.mimeType,
-                        relativePath: path.relative(modDir, resolved).replaceAll("\\", "/"),
-                    };
+                if (!encoded) {
+                    return null;
                 }
+                textures[key] = {
+                    texKey: key,
+                    role,
+                    bytes: encoded.bytes,
+                    mimeType: encoded.mimeType,
+                    relativePath: path.relative(modDir, resolved).replaceAll("\\", "/"),
+                };
             }
             return key;
         };
@@ -378,7 +368,7 @@ export async function buildMeshResult(
                 uvs,
                 indices,
                 conditions: draw.conditions,
-                texKey: texKey ?? texKeyFor(draw.textureDefaultFile),
+                texKey,
                 textureVariants,
                 normalMapKey: normal.key,
                 normalMapVariants: normal.variants,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect mod-viewer texture binding for WWMI mods with heuristic classification; wrong picks could still mis-display meshes, but authored textures are protected and coverage is expanded.
> 
> **Overview**
> WWMI **Components-N** dump binding is reworked so diffuse picks are based on image analysis, not just sRGB and size. Draws track whether diffuse was **authored** in the INI; explicit assignments (including `Resource\...\Diffuse`, `ps-t0`, and named diffuse `this=`) are not overwritten by dump fallbacks.
> 
> **Texture hints** decode PNG/DDS (with size caps) and classify flat, normal-like, linear, and packed maps so they are not treated as diffuse. Dump selection prefers **component-exclusive** files over shared `Components-0-1-2-...` names, excludes textures bound to non-diffuse `ps-t` slots, and can replace weak `ps-t0` assignments (e.g. flat color) with a better dump.
> 
> INI scanning records **non-diffuse slot** resources for exclusion; shared component indexes union those exclusions. **Mesh building** skips unsupported texture files instead of registering invalid entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15a8fb68b64e5504a50da21fe7ffc44c263767d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved texture detection and selection for PNG, JPEG, and DDS assets.
  * Reduced incorrect use of non-diffuse, flat-color, normal-map, and packed textures as diffuse textures.
  * Preserved valid authored texture variants and explicit texture assignments, including numbered texture slots.
  * Improved handling of oversized images, toggle-dependent textures, and shared texture dumps.
  * Prevented unsupported or invalid textures from being registered when building meshes.

* **Tests**
  * Expanded coverage for texture classification, slot selection, fallbacks, shared dumps, authored textures, and oversized assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->