### PR TITLE
feat(mod-viewer): cap preview textures at a 2048² pixel budget

### DIFF
--- a/src/main/lib/mod-viewer/mesh-builder.test.ts
+++ b/src/main/lib/mod-viewer/mesh-builder.test.ts
@@ -3,12 +3,13 @@ import os from "node:os";
 import path from "node:path";
 
 import fse from "fs-extra";
+import sharp from "sharp";
 import { afterEach, describe, it } from "vitest";
 
 import type { DrawGroup, DrawRecord } from "./draw-groups";
 
 import { DNF_TRUE } from "./dnf";
-import { buildMeshResult } from "./mesh-builder";
+import { buildMeshResult, viewerPreviewTextureSize } from "./mesh-builder";
 
 const tempRoots: string[] = [];
 
@@ -63,6 +64,39 @@ describe("buildMeshResult", () => {
         assert.deepEqual(result.textures["diffuse::diffuse.png"]?.bytes, png);
         assert.equal(result.textures["diffuse::alt.jpg"]?.mimeType, "image/jpeg");
         assert.deepEqual(result.textures["diffuse::alt.jpg"]?.bytes, jpeg);
+    });
+
+    it("downscales oversized png textures to the viewer pixel budget", async () => {
+        const root = await makeMeshDir();
+        await sharp({
+            create: {
+                width: 4096,
+                height: 4096,
+                channels: 4,
+                background: { r: 32, g: 64, b: 96, alpha: 1 },
+            },
+        })
+            .png()
+            .toFile(path.join(root, "diffuse.png"));
+        const result = await buildMeshResult(
+            [makeGroup([makeDraw({ label: "ok", textureDefaultFile: "diffuse.png" })])],
+            root,
+        );
+        const encoded = result.textures["diffuse::diffuse.png"];
+        assert.equal(encoded?.mimeType, "image/png");
+        assert.ok(encoded);
+        const metadata = await sharp(encoded.bytes).metadata();
+        assert.equal(metadata.width, 2048);
+        assert.equal(metadata.height, 2048);
+    });
+});
+
+describe("viewerPreviewTextureSize", () => {
+    it("halves until the preview pixel budget is met", () => {
+        assert.deepEqual(viewerPreviewTextureSize(8192, 8192), { width: 2048, height: 2048 });
+        assert.deepEqual(viewerPreviewTextureSize(2048, 8192), { width: 1024, height: 4096 });
+        assert.deepEqual(viewerPreviewTextureSize(4096, 4096), { width: 2048, height: 2048 });
+        assert.deepEqual(viewerPreviewTextureSize(2048, 2048), { width: 2048, height: 2048 });
     });
 });
 

--- a/src/main/lib/mod-viewer/mesh-builder.test.ts
+++ b/src/main/lib/mod-viewer/mesh-builder.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
+import { crc32 } from "node:zlib";
 
 import fse from "fs-extra";
 import sharp from "sharp";
@@ -37,10 +38,18 @@ describe("buildMeshResult", () => {
         assert.deepEqual([...result.meshes[0].indices], [0, 1, 2]);
     });
 
-    it("keeps png and jpeg textures with their mime types after buffer-limit reads", async () => {
+    it("keeps valid png and jpeg textures with their mime types after buffer-limit reads", async () => {
         const root = await makeMeshDir();
-        const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
-        const jpeg = Buffer.from([0xff, 0xd8, 0xff]);
+        const png = await sharp({
+            create: { width: 1, height: 1, channels: 3, background: { r: 12, g: 34, b: 56 } },
+        })
+            .png()
+            .toBuffer();
+        const jpeg = await sharp({
+            create: { width: 1, height: 1, channels: 3, background: { r: 78, g: 90, b: 12 } },
+        })
+            .jpeg()
+            .toBuffer();
         await fse.writeFile(path.join(root, "diffuse.png"), png);
         await fse.writeFile(path.join(root, "alt.jpg"), jpeg);
         const result = await buildMeshResult(
@@ -64,6 +73,46 @@ describe("buildMeshResult", () => {
         assert.deepEqual(result.textures["diffuse::diffuse.png"]?.bytes, png);
         assert.equal(result.textures["diffuse::alt.jpg"]?.mimeType, "image/jpeg");
         assert.deepEqual(result.textures["diffuse::alt.jpg"]?.bytes, jpeg);
+    });
+
+    it("omits unreadable png and jpeg textures instead of keeping original bytes", async () => {
+        const root = await makeMeshDir();
+        await fse.writeFile(path.join(root, "diffuse.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+        await fse.writeFile(path.join(root, "alt.jpg"), Buffer.from([0xff, 0xd8, 0xff]));
+        const result = await buildMeshResult(
+            [
+                makeGroup([
+                    makeDraw({
+                        label: "ok",
+                        textureDefaultFile: "diffuse.png",
+                        textureAssignments: [
+                            {
+                                conditions: [[{ var: "color", value: "1", negate: false }]],
+                                file: "alt.jpg",
+                            },
+                        ],
+                    }),
+                ]),
+            ],
+            root,
+        );
+        assert.equal(result.textures["diffuse::diffuse.png"], undefined);
+        assert.equal(result.textures["diffuse::alt.jpg"], undefined);
+        assert.equal(result.meshes[0]?.texKey, null);
+        assert.deepEqual(result.meshes[0]?.textureVariants, []);
+    });
+
+    it("omits png textures whose declared size exceeds sharp limitInputPixels", async () => {
+        const root = await makeMeshDir();
+        const png = pngWithDeclaredSize(20_000, 20_000);
+        await assert.rejects(() => sharp(png).metadata());
+        await fse.writeFile(path.join(root, "diffuse.png"), png);
+        const result = await buildMeshResult(
+            [makeGroup([makeDraw({ label: "ok", textureDefaultFile: "diffuse.png" })])],
+            root,
+        );
+        assert.equal(result.textures["diffuse::diffuse.png"], undefined);
+        assert.equal(result.meshes[0]?.texKey, null);
     });
 
     it("downscales oversized png textures to the viewer pixel budget", async () => {
@@ -142,4 +191,26 @@ function makeDraw(overrides: Partial<DrawRecord>): DrawRecord {
         sources: [],
         ...overrides,
     };
+}
+
+function pngWithDeclaredSize(width: number, height: number): Buffer {
+    const ihdr = Buffer.alloc(13);
+    ihdr.writeUInt32BE(width, 0);
+    ihdr.writeUInt32BE(height, 4);
+    ihdr[8] = 8;
+    ihdr[9] = 6;
+    return Buffer.concat([
+        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+        pngChunk("IHDR", ihdr),
+        pngChunk("IEND", Buffer.alloc(0)),
+    ]);
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+    const body = Buffer.concat([Buffer.from(type), data]);
+    const length = Buffer.alloc(4);
+    length.writeUInt32BE(data.length);
+    const checksum = Buffer.alloc(4);
+    checksum.writeUInt32BE(crc32(body));
+    return Buffer.concat([length, body, checksum]);
 }

--- a/src/main/lib/mod-viewer/mesh-builder.ts
+++ b/src/main/lib/mod-viewer/mesh-builder.ts
@@ -118,17 +118,6 @@ export async function buildMeshResult(
         }
         const unique = deduplicateDraws(group);
 
-        const texKeyFor = (relative: string | undefined, role: ViewerTextureRole = "diffuse") => {
-            if (!relative) {
-                return null;
-            }
-            const resolved = safeResourcePath(modDir, relative);
-            if (!resolved) {
-                return null;
-            }
-            return textureKey(path.relative(modDir, resolved).replaceAll("\\", "/"), role);
-        };
-
         const ensureTexture = async (
             relative: string | undefined,
             role: ViewerTextureRole = "diffuse",
@@ -140,15 +129,16 @@ export async function buildMeshResult(
             const key = textureKey(path.relative(modDir, resolved).replaceAll("\\", "/"), role);
             if (!textures[key]) {
                 const encoded = await encodeTexture(resolved, role, readBuffer);
-                if (encoded) {
-                    textures[key] = {
-                        texKey: key,
-                        role,
-                        bytes: encoded.bytes,
-                        mimeType: encoded.mimeType,
-                        relativePath: path.relative(modDir, resolved).replaceAll("\\", "/"),
-                    };
+                if (!encoded) {
+                    return null;
                 }
+                textures[key] = {
+                    texKey: key,
+                    role,
+                    bytes: encoded.bytes,
+                    mimeType: encoded.mimeType,
+                    relativePath: path.relative(modDir, resolved).replaceAll("\\", "/"),
+                };
             }
             return key;
         };
@@ -380,7 +370,7 @@ export async function buildMeshResult(
                 uvs,
                 indices,
                 conditions: draw.conditions,
-                texKey: texKey ?? texKeyFor(draw.textureDefaultFile),
+                texKey,
                 textureVariants,
                 normalMapKey: normal.key,
                 normalMapVariants: normal.variants,
@@ -725,11 +715,11 @@ async function encodeTexture(
 async function downscaleViewerTexture(encoded: {
     bytes: Buffer;
     mimeType: "image/png" | "image/jpeg";
-}): Promise<{ bytes: Buffer; mimeType: "image/png" | "image/jpeg" }> {
+}): Promise<{ bytes: Buffer; mimeType: "image/png" | "image/jpeg" } | null> {
     try {
         const metadata = await sharp(encoded.bytes).metadata();
         if (!metadata.width || !metadata.height) {
-            return encoded;
+            return null;
         }
         const target = viewerPreviewTextureSize(metadata.width, metadata.height);
         if (target.width === metadata.width && target.height === metadata.height) {
@@ -742,6 +732,6 @@ async function downscaleViewerTexture(encoded: {
                 : await resized.png().toBuffer();
         return { bytes, mimeType: encoded.mimeType };
     } catch {
-        return encoded;
+        return null;
     }
 }

--- a/src/main/lib/mod-viewer/mesh-builder.ts
+++ b/src/main/lib/mod-viewer/mesh-builder.ts
@@ -9,6 +9,7 @@ import type {
     ViewerTextureRole,
 } from "@shared/mod-viewer/types";
 import fse from "fs-extra";
+import sharp from "sharp";
 
 import type { DrawGroup, DrawRecord } from "./draw-groups";
 import type { ShapeSlider } from "./shapes";
@@ -24,6 +25,7 @@ const MAX_BUFFER_FILE_BYTES = 512 * 1024 * 1024;
 const MAX_TOTAL_BUFFER_BYTES = 2 * 1024 * 1024 * 1024;
 const MIN_AXIS_SPREAD = 1e-4;
 const MIN_IN_RANGE = 0.95;
+const VIEWER_TEXTURE_MAX_PIXELS = 2048 * 2048;
 
 export type MeshBuildResult = {
     meshes: ViewerMesh[];
@@ -668,6 +670,22 @@ async function buildShapeBuffers(
     return result;
 }
 
+export function viewerPreviewTextureSize(
+    width: number,
+    height: number,
+): { width: number; height: number } {
+    let nextWidth = width;
+    let nextHeight = height;
+    while (
+        nextWidth * nextHeight > VIEWER_TEXTURE_MAX_PIXELS &&
+        (nextWidth > 1 || nextHeight > 1)
+    ) {
+        nextWidth = Math.max(1, Math.floor(nextWidth / 2));
+        nextHeight = Math.max(1, Math.floor(nextHeight / 2));
+    }
+    return { width: nextWidth, height: nextHeight };
+}
+
 async function encodeTexture(
     filePath: string,
     role: ViewerTextureRole,
@@ -675,10 +693,13 @@ async function encodeTexture(
 ): Promise<{ bytes: Buffer; mimeType: "image/png" | "image/jpeg" } | null> {
     const ext = path.extname(filePath).toLowerCase();
     if (ext === ".png") {
-        return { bytes: await readBuffer(filePath), mimeType: "image/png" };
+        return downscaleViewerTexture({ bytes: await readBuffer(filePath), mimeType: "image/png" });
     }
     if (ext === ".jpg" || ext === ".jpeg") {
-        return { bytes: await readBuffer(filePath), mimeType: "image/jpeg" };
+        return downscaleViewerTexture({
+            bytes: await readBuffer(filePath),
+            mimeType: "image/jpeg",
+        });
     }
     if (ext !== ".dds") {
         return null;
@@ -695,8 +716,32 @@ async function encodeTexture(
     if (!prepared?.image) {
         return null;
     }
-    return {
+    return downscaleViewerTexture({
         bytes: prepared.image,
         mimeType: prepared.mimeType === "image/jpeg" ? "image/jpeg" : "image/png",
-    };
+    });
+}
+
+async function downscaleViewerTexture(encoded: {
+    bytes: Buffer;
+    mimeType: "image/png" | "image/jpeg";
+}): Promise<{ bytes: Buffer; mimeType: "image/png" | "image/jpeg" }> {
+    try {
+        const metadata = await sharp(encoded.bytes).metadata();
+        if (!metadata.width || !metadata.height) {
+            return encoded;
+        }
+        const target = viewerPreviewTextureSize(metadata.width, metadata.height);
+        if (target.width === metadata.width && target.height === metadata.height) {
+            return encoded;
+        }
+        const resized = sharp(encoded.bytes).resize(target.width, target.height);
+        const bytes =
+            encoded.mimeType === "image/jpeg"
+                ? await resized.jpeg({ quality: 85 }).toBuffer()
+                : await resized.png().toBuffer();
+        return { bytes, mimeType: encoded.mimeType };
+    } catch {
+        return encoded;
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the mod-viewer texture encoding path for all diffuse/normal/light/material previews; failures now omit textures instead of showing raw bytes, which can change which meshes render with textures but avoids corrupted or huge payloads.
> 
> **Overview**
> Mod-viewer mesh builds now **process PNG, JPEG, and DDS textures through sharp** instead of passing file bytes straight into preview results. Oversized images are **downscaled** with `viewerPreviewTextureSize` (repeated halving until width×height ≤ 2048²); JPEGs stay at quality 85.
> 
> **Invalid or unreadable textures are dropped** rather than forwarded: corrupt PNG/JPEG stubs, missing metadata, sharp failures, and PNGs whose declared dimensions exceed sharp’s input limits no longer appear in `textures` or mesh `texKey` / variant lists.
> 
> Tests were updated to use real tiny images from sharp and cover omission, limit cases, and 4096→2048 downscaling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 279d61d74733e8933270eb8df522d194026cf054. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Viewer previews now automatically resize oversized PNG, JPEG, and DDS textures to a maximum of 2048×2048 pixels.
  * Preview dimensions are adjusted proportionally to stay within the supported pixel limit.

* **Bug Fixes**
  * Improved handling of unreadable or invalid textures by excluding them from previews instead of displaying corrupted or unusable data.
  * Added validation for texture metadata and encoding to ensure only successfully processed textures are displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->