### PR TITLE
feat(texture-resizer): allow batch processing selected textures

### DIFF
--- a/src/renderer/src/components/mod/texture-resize-dialog.tsx
+++ b/src/renderer/src/components/mod/texture-resize-dialog.tsx
@@ -19,6 +19,7 @@ export function TextureResizeDialog({
       <DialogContent
         className="flex h-[min(85vh,900px)] w-[min(80rem,calc(100%-32rem))] max-w-none flex-col overflow-hidden sm:max-w-none"
         onClick={(event) => event.stopPropagation()}
+        showCloseButton={false}
       >
         <TextureResizerWorkspace mode="mod" modName={modName} fixedTargetPath={modPath} />
       </DialogContent>

--- a/src/renderer/src/components/tools/texture-resizer-form.tsx
+++ b/src/renderer/src/components/tools/texture-resizer-form.tsx
@@ -34,6 +34,7 @@ interface TextureResizerFormProps {
   currentFormat?: string;
   currentColorSpace?: TextureColorSpace;
   formatConversionMessage?: string | null;
+  sharedResize?: boolean;
   resizeSource?: {
     width: number;
     height: number;
@@ -52,6 +53,7 @@ export function TextureResizerForm({
   currentFormat,
   currentColorSpace = "unknown",
   formatConversionMessage,
+  sharedResize = false,
   resizeSource = null,
 }: TextureResizerFormProps) {
   const { t } = useTranslation();
@@ -66,6 +68,10 @@ export function TextureResizerForm({
   const colorSpaceOptions = [
     { value: "srgb", label: t("page.tools.texture_resizer.color_space.srgb") },
     { value: "linear", label: t("page.tools.texture_resizer.color_space.linear") },
+  ] as const;
+  const modeOptions = [
+    { value: "percent", label: t("page.tools.texture_resizer.mode_options.percent") },
+    { value: "custom", label: t("page.tools.texture_resizer.mode_options.custom") },
   ] as const;
   const operationOptions = [
     { value: "resize", label: t("page.tools.texture_resizer.operation_options.resize") },
@@ -255,7 +261,7 @@ export function TextureResizerForm({
                   });
                 }}
               >
-                <SelectTrigger disabled={disabled} className="w-64">
+                <SelectTrigger disabled={disabled} className="w-full">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -294,7 +300,7 @@ export function TextureResizerForm({
                   });
                 }}
               >
-                <SelectTrigger disabled={disabled} className="w-32">
+                <SelectTrigger disabled={disabled} className="w-full">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -321,9 +327,43 @@ export function TextureResizerForm({
       ) : showResizeInputs ? (
         <div className="grid gap-4 md:grid-cols-2">
           {operationField}
-          <div className="rounded-md border bg-background/40 p-3 text-xs text-muted-foreground">
-            {t("page.tools.texture_resizer.custom_hint")}
-          </div>
+          {sharedResize ? (
+            <div className="space-y-2">
+              <label className="text-xs font-medium tracking-widest text-muted-foreground uppercase">
+                {t("page.tools.texture_resizer.mode")}
+              </label>
+              <Select
+                value={settings.mode}
+                items={modeOptions}
+                onValueChange={(value) => {
+                  if (value === null) return;
+                  const nextMode = modeOptions.find((option) => option.value === value)?.value;
+                  if (!nextMode) return;
+                  updateSettings({ mode: nextMode });
+                }}
+              >
+                <SelectTrigger disabled={disabled} className="w-56">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {modeOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                {t(`page.tools.texture_resizer.mode_descriptions.${settings.mode}`)}
+              </p>
+            </div>
+          ) : (
+            <div className="rounded-md border bg-background/40 p-3 text-xs text-muted-foreground">
+              {t("page.tools.texture_resizer.custom_hint")}
+            </div>
+          )}
         </div>
       ) : useHorizontalConvertLayout && showOutputFormat ? (
         <div className="grid gap-4 md:grid-cols-2">
@@ -372,7 +412,97 @@ export function TextureResizerForm({
         operationField
       )}
 
-      {showResizeInputs && (
+      {showResizeInputs && sharedResize && settings.mode === "percent" && (
+        <div className="space-y-3 rounded-md border bg-background/40 p-3">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="text-sm font-medium">{t("page.tools.texture_resizer.percent")}</div>
+              <div className="text-xs text-muted-foreground">
+                {t("page.tools.texture_resizer.mode_descriptions.percent")}
+              </div>
+            </div>
+            <div className="text-sm font-medium">{settings.percent}%</div>
+          </div>
+          <Slider
+            min={1}
+            max={99}
+            step={1}
+            value={settings.percent}
+            disabled={disabled}
+            onValueChange={(value) => {
+              const percent = Array.isArray(value) ? (value[0] ?? 1) : value;
+              updateSettings({
+                percent,
+                mode: "percent",
+              });
+            }}
+          />
+        </div>
+      )}
+
+      {showResizeInputs && sharedResize && settings.mode === "custom" && (
+        <div className="space-y-3 rounded-md border bg-background/40 p-3">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-xs font-medium tracking-widest text-muted-foreground uppercase">
+                {t("page.tools.texture_resizer.custom_width")}
+              </label>
+              <Input
+                type="number"
+                min={1024}
+                step={1024}
+                value={settings.customWidth}
+                disabled={disabled}
+                onChange={(event) => {
+                  const parsed = Number.parseInt(event.target.value, 10);
+                  if (!Number.isFinite(parsed)) return;
+                  updateSettings({
+                    customWidth: parsed,
+                    mode: "custom",
+                  });
+                }}
+                onBlur={() => {
+                  updateSettings({
+                    customWidth: snapDimension(settings.customWidth),
+                    mode: "custom",
+                  });
+                }}
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs font-medium tracking-widest text-muted-foreground uppercase">
+                {t("page.tools.texture_resizer.custom_height")}
+              </label>
+              <Input
+                type="number"
+                min={1024}
+                step={1024}
+                value={settings.customHeight}
+                disabled={disabled}
+                onChange={(event) => {
+                  const parsed = Number.parseInt(event.target.value, 10);
+                  if (!Number.isFinite(parsed)) return;
+                  updateSettings({
+                    customHeight: parsed,
+                    mode: "custom",
+                  });
+                }}
+                onBlur={() => {
+                  updateSettings({
+                    customHeight: snapDimension(settings.customHeight),
+                    mode: "custom",
+                  });
+                }}
+              />
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {t("page.tools.texture_resizer.custom_hint")}
+          </p>
+        </div>
+      )}
+
+      {showResizeInputs && !sharedResize && (
         <>
           {resizeSource && resizeCandidates.length > 0 && selectedResizeCandidate ? (
             <div className="space-y-3 rounded-md border bg-background/40 p-3">
@@ -497,6 +627,16 @@ export function TextureResizerForm({
       </div>
     </div>
   );
+}
+
+function snapDimension(value: number) {
+  const normalized = Math.max(1024, Math.round(value));
+  const remainder = normalized % 1024;
+  if (remainder === 0) {
+    return normalized;
+  }
+
+  return remainder < 512 ? normalized - remainder : normalized + (1024 - remainder);
 }
 
 function formatResizePercent(width: number, originalWidth: number): string {

--- a/src/renderer/src/components/tools/texture-resizer-form.tsx
+++ b/src/renderer/src/components/tools/texture-resizer-form.tsx
@@ -455,9 +455,8 @@ export function TextureResizerForm({
                 disabled={disabled}
                 onChange={(event) => {
                   const parsed = Number.parseInt(event.target.value, 10);
-                  if (!Number.isFinite(parsed)) return;
                   updateSettings({
-                    customWidth: parsed,
+                    customWidth: Number.isFinite(parsed) ? parsed : 0,
                     mode: "custom",
                   });
                 }}
@@ -481,9 +480,8 @@ export function TextureResizerForm({
                 disabled={disabled}
                 onChange={(event) => {
                   const parsed = Number.parseInt(event.target.value, 10);
-                  if (!Number.isFinite(parsed)) return;
                   updateSettings({
-                    customHeight: parsed,
+                    customHeight: Number.isFinite(parsed) ? parsed : 0,
                     mode: "custom",
                   });
                 }}

--- a/src/renderer/src/components/tools/texture-resizer-workspace.tsx
+++ b/src/renderer/src/components/tools/texture-resizer-workspace.tsx
@@ -36,7 +36,7 @@ import {
 } from "@shared/utils";
 import { useForm } from "@tanstack/react-form";
 import { FolderOpenIcon, ImageIcon, Loader2Icon, RefreshCwIcon } from "lucide-react";
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -80,6 +80,7 @@ export function TextureResizerWorkspace({
     Record<string, TextureResizeSettings>
   >({});
   const [upscaleProgress, setUpscaleProgress] = useState<TextureUpscaleProgressEvent | null>(null);
+  const batchRunningRef = useRef(false);
   const settingsForm = useForm({
     defaultValues: DEFAULT_SETTINGS,
     onSubmit: async () => {},
@@ -257,7 +258,7 @@ export function TextureResizerWorkspace({
   };
 
   const processSelectedTextures = async (dialogSettings: TextureResizeSettings) => {
-    if (batchProgress != null) {
+    if (batchRunningRef.current) {
       return;
     }
 
@@ -265,6 +266,8 @@ export function TextureResizerWorkspace({
     if (selected.length === 0) {
       return;
     }
+
+    batchRunningRef.current = true;
 
     const flushedPerTexture = activeDialogTexturePath
       ? {
@@ -279,8 +282,8 @@ export function TextureResizerWorkspace({
     let updated = 0;
     let failed = 0;
     let skipped = 0;
-    let lastSettings = dialogSettings;
     let lastFileResult: TextureResizeFileResult | undefined;
+    let errorMessage: string | undefined;
 
     for (const [index, texture] of selected.entries()) {
       setBatchProgress({ current: index + 1, total: selected.length });
@@ -288,7 +291,6 @@ export function TextureResizerWorkspace({
         bulkApply || selected.length === 1
           ? adaptSettingsForTexture(dialogSettings, texture)
           : (flushedPerTexture[texture.filePath] ?? dialogSettings);
-      lastSettings = nextSettings;
 
       if (!canRun(nextSettings, texture)) {
         skipped += 1;
@@ -297,7 +299,6 @@ export function TextureResizerWorkspace({
 
       setRunningFilePath(texture.filePath);
       setUpscaleProgress(null);
-      settingsForm.reset(nextSettings);
       try {
         const nextResult = await window.api.invoke("tools:resizeTextureFile", {
           filePath: texture.filePath,
@@ -314,14 +315,16 @@ export function TextureResizerWorkspace({
           continue;
         }
         skipped += 1;
-      } catch {
+      } catch (error) {
         failed += 1;
+        errorMessage ??= toErrorMessage(error);
       }
     }
 
     setRunningFilePath(null);
     setUpscaleProgress(null);
     setBatchProgress(null);
+    batchRunningRef.current = false;
     setDialogOpen(false);
     setSelectedPaths(new Set());
 
@@ -331,10 +334,11 @@ export function TextureResizerWorkspace({
       failed,
       skipped,
       lastFileResult,
+      errorMessage,
     });
 
     if (loadedTargetPath) {
-      await loadTextures(loadedTargetPath, lastSettings);
+      await loadTextures(loadedTargetPath, dialogSettings);
     }
   };
 
@@ -790,10 +794,7 @@ function adaptSettingsForTexture(
       ? settings.outputFormat
       : texture.outputFormatDefault;
 
-  if (
-    (settings.operation === "resize_and_convert" || settings.operation === "convert") &&
-    !texture.canConvertFormat
-  ) {
+  if (settings.operation === "resize_and_convert" && !texture.canConvertFormat) {
     return {
       ...settings,
       operation: "resize",
@@ -959,6 +960,7 @@ function showTextureResizeResultToast(
     failed: number;
     skipped: number;
     lastFileResult?: TextureResizeFileResult;
+    errorMessage?: string;
   },
 ) {
   const description = t("page.tools.texture_resizer.toast.completed_description", {
@@ -974,9 +976,16 @@ function showTextureResizeResultToast(
     return;
   }
 
+  if (result.selectedCount === 1 && result.failed > 0) {
+    toast.error(t("page.tools.texture_resizer.toast.failed"), {
+      description: result.errorMessage ?? description,
+    });
+    return;
+  }
+
   if (result.updated === 0 && result.failed > 0) {
     toast.error(t("page.tools.texture_resizer.toast.failed"), {
-      description,
+      description: result.errorMessage ? `${description}\n${result.errorMessage}` : description,
     });
     return;
   }
@@ -984,6 +993,13 @@ function showTextureResizeResultToast(
   if (result.updated === 0) {
     toast.warning(t("page.tools.texture_resizer.toast.none_processed"), {
       description,
+    });
+    return;
+  }
+
+  if (result.failed > 0) {
+    toast.warning(t("page.tools.texture_resizer.toast.completed"), {
+      description: result.errorMessage ? `${description}\n${result.errorMessage}` : description,
     });
     return;
   }

--- a/src/renderer/src/components/tools/texture-resizer-workspace.tsx
+++ b/src/renderer/src/components/tools/texture-resizer-workspace.tsx
@@ -4,6 +4,7 @@ import {
   formatTextureFormatLabel,
 } from "@renderer/components/tools/texture-resizer-form";
 import { Button } from "@renderer/components/ui/button";
+import { Checkbox } from "@renderer/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -15,7 +16,10 @@ import {
 import { Input } from "@renderer/components/ui/input";
 import { Progress } from "@renderer/components/ui/progress";
 import { ScrollArea } from "@renderer/components/ui/scroll-area";
+import { Switch } from "@renderer/components/ui/switch";
+import { cn } from "@renderer/lib/utils";
 import type {
+  TextureColorSpace,
   TextureResizeFileResult,
   TextureResizeListItem,
   TextureResizeSettings,
@@ -62,10 +66,19 @@ export function TextureResizerWorkspace({
   const { t } = useTranslation();
   const [targetPath, setTargetPath] = useState(fixedTargetPath ?? "");
   const [textures, setTextures] = useState<TextureResizeListItem[]>([]);
+  const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set());
   const [isListing, setIsListing] = useState(false);
   const [runningFilePath, setRunningFilePath] = useState<string | null>(null);
+  const [batchProgress, setBatchProgress] = useState<{ current: number; total: number } | null>(
+    null,
+  );
   const [loadedTargetPath, setLoadedTargetPath] = useState("");
-  const [selectedTexture, setSelectedTexture] = useState<TextureResizeListItem | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [bulkApply, setBulkApply] = useState(true);
+  const [activeDialogTexturePath, setActiveDialogTexturePath] = useState<string | null>(null);
+  const [perTextureSettings, setPerTextureSettings] = useState<
+    Record<string, TextureResizeSettings>
+  >({});
   const [upscaleProgress, setUpscaleProgress] = useState<TextureUpscaleProgressEvent | null>(null);
   const settingsForm = useForm({
     defaultValues: DEFAULT_SETTINGS,
@@ -75,6 +88,16 @@ export function TextureResizerWorkspace({
     defaultValues: DEFAULT_SETTINGS,
     onSubmit: async () => {},
   });
+
+  const isBusy = isListing || runningFilePath !== null || batchProgress !== null;
+  const processableTextures = textures.filter((texture) => texture.canProcess);
+  const dialogTextures = textures.filter((texture) => selectedPaths.has(texture.filePath));
+  const allProcessableSelected =
+    processableTextures.length > 0 &&
+    processableTextures.every((texture) => selectedPaths.has(texture.filePath));
+  const someProcessableSelected = processableTextures.some((texture) =>
+    selectedPaths.has(texture.filePath),
+  );
 
   useEffect(() => {
     setTargetPath(fixedTargetPath ?? "");
@@ -130,6 +153,12 @@ export function TextureResizerWorkspace({
           : await window.api.invoke("tools:listTextureFolder", normalizedTargetPath, nextSettings);
       setTextures(nextTextures);
       setLoadedTargetPath(normalizedTargetPath);
+      const available = new Set(
+        nextTextures.filter((texture) => texture.canProcess).map((texture) => texture.filePath),
+      );
+      setSelectedPaths(
+        (current) => new Set([...current].filter((filePath) => available.has(filePath))),
+      );
     } catch (error) {
       toast.error(t("page.tools.texture_resizer.toast.load_failed"), {
         description: toErrorMessage(error),
@@ -139,34 +168,173 @@ export function TextureResizerWorkspace({
     }
   };
 
-  const processTexture = async (filePath: string, nextSettings: TextureResizeSettings) => {
-    if (runningFilePath) {
+  const toggleTexture = (filePath: string, selected: boolean) => {
+    setSelectedPaths((current) => {
+      const next = new Set(current);
+      if (selected) {
+        next.add(filePath);
+        return next;
+      }
+      next.delete(filePath);
+      return next;
+    });
+  };
+
+  const toggleAllProcessable = (selected: boolean) => {
+    if (selected) {
+      setSelectedPaths(new Set(processableTextures.map((texture) => texture.filePath)));
+      return;
+    }
+    setSelectedPaths(new Set());
+  };
+
+  const openProcessDialog = () => {
+    const selected = textures.filter((texture) => selectedPaths.has(texture.filePath));
+    if (selected.length === 0) {
       return;
     }
 
-    setRunningFilePath(filePath);
+    const shared = settingsForm.state.values;
+    const useBulk = selected.length > 1;
+    setBulkApply(useBulk);
+    setActiveDialogTexturePath(selected[0].filePath);
+    setPerTextureSettings(
+      Object.fromEntries(
+        selected.map((texture) => [texture.filePath, buildDialogSettings(shared, texture)]),
+      ),
+    );
+    dialogSettingsForm.reset(
+      useBulk
+        ? buildSharedDialogSettings(shared, selected)
+        : buildDialogSettings(shared, selected[0]),
+    );
+    setDialogOpen(true);
+  };
+
+  const selectDialogTexture = (filePath: string) => {
+    if (filePath === activeDialogTexturePath) {
+      return;
+    }
+
+    const flushed = activeDialogTexturePath
+      ? {
+          ...perTextureSettings,
+          [activeDialogTexturePath]: dialogSettingsForm.state.values,
+        }
+      : perTextureSettings;
+    setPerTextureSettings(flushed);
+    const nextSettings = flushed[filePath];
+    if (nextSettings) {
+      dialogSettingsForm.reset(nextSettings);
+    }
+    setActiveDialogTexturePath(filePath);
+  };
+
+  const handleBulkApplyChange = (checked: boolean) => {
+    if (checked) {
+      setBulkApply(true);
+      return;
+    }
+
+    const shared = dialogSettingsForm.state.values;
+    const nextPerTexture = Object.fromEntries(
+      dialogTextures.map((texture) => [texture.filePath, buildDialogSettings(shared, texture)]),
+    );
+    setPerTextureSettings(nextPerTexture);
+    const first = dialogTextures[0];
+    if (first) {
+      dialogSettingsForm.reset(nextPerTexture[first.filePath]);
+      setActiveDialogTexturePath(first.filePath);
+    }
+    setBulkApply(false);
+  };
+
+  const closeDialog = () => {
+    if (batchProgress != null) {
+      return;
+    }
+    setDialogOpen(false);
+  };
+
+  const processSelectedTextures = async (dialogSettings: TextureResizeSettings) => {
+    if (batchProgress != null) {
+      return;
+    }
+
+    const selected = textures.filter((texture) => selectedPaths.has(texture.filePath));
+    if (selected.length === 0) {
+      return;
+    }
+
+    const flushedPerTexture = activeDialogTexturePath
+      ? {
+          ...perTextureSettings,
+          [activeDialogTexturePath]: dialogSettings,
+        }
+      : perTextureSettings;
+
+    setBatchProgress({ current: 0, total: selected.length });
     setUpscaleProgress(null);
-    try {
-      settingsForm.reset(nextSettings);
-      const nextResult = await window.api.invoke("tools:resizeTextureFile", {
-        filePath,
-        settings: nextSettings,
-      });
-      const fileResult = nextResult.files[0];
-      toast.success(t("page.tools.texture_resizer.toast.single_completed"), {
-        description: describeFileResult(t, fileResult),
-      });
-      setSelectedTexture(null);
-      if (loadedTargetPath) {
-        await loadTextures(loadedTargetPath, nextSettings);
+
+    let updated = 0;
+    let failed = 0;
+    let skipped = 0;
+    let lastSettings = dialogSettings;
+    let lastFileResult: TextureResizeFileResult | undefined;
+
+    for (const [index, texture] of selected.entries()) {
+      setBatchProgress({ current: index + 1, total: selected.length });
+      const nextSettings =
+        bulkApply || selected.length === 1
+          ? adaptSettingsForTexture(dialogSettings, texture)
+          : (flushedPerTexture[texture.filePath] ?? dialogSettings);
+      lastSettings = nextSettings;
+
+      if (!canRun(nextSettings, texture)) {
+        skipped += 1;
+        continue;
       }
-    } catch (error) {
-      toast.error(t("page.tools.texture_resizer.toast.failed"), {
-        description: toErrorMessage(error),
-      });
-    } finally {
-      setRunningFilePath(null);
+
+      setRunningFilePath(texture.filePath);
       setUpscaleProgress(null);
+      settingsForm.reset(nextSettings);
+      try {
+        const nextResult = await window.api.invoke("tools:resizeTextureFile", {
+          filePath: texture.filePath,
+          settings: nextSettings,
+        });
+        const fileResult = nextResult.files[0];
+        lastFileResult = fileResult;
+        if (fileResult?.status === "updated") {
+          updated += 1;
+          continue;
+        }
+        if (fileResult?.status === "failed" || !fileResult) {
+          failed += 1;
+          continue;
+        }
+        skipped += 1;
+      } catch {
+        failed += 1;
+      }
+    }
+
+    setRunningFilePath(null);
+    setUpscaleProgress(null);
+    setBatchProgress(null);
+    setDialogOpen(false);
+    setSelectedPaths(new Set());
+
+    showTextureResizeResultToast(t, {
+      selectedCount: selected.length,
+      updated,
+      failed,
+      skipped,
+      lastFileResult,
+    });
+
+    if (loadedTargetPath) {
+      await loadTextures(loadedTargetPath, lastSettings);
     }
   };
 
@@ -180,14 +348,14 @@ export function TextureResizerWorkspace({
             value={targetPath}
             onChange={(event) => setTargetPath(event.target.value)}
             placeholder={t("page.tools.texture_resizer.target_folder_placeholder")}
-            disabled={isListing || runningFilePath !== null}
+            disabled={isBusy}
           />
           <Button
             type="button"
             variant="outline"
             className="shrink-0 gap-1"
             onClick={() => void browseTargetPath()}
-            disabled={isListing || runningFilePath !== null}
+            disabled={isBusy}
           >
             <FolderOpenIcon className="size-4" />
             {t("page.tools.texture_resizer.browse")}
@@ -199,7 +367,7 @@ export function TextureResizerWorkspace({
         {mode === "folder" && (
           <Button
             onClick={() => void loadTextures()}
-            disabled={!hasTarget || isListing || runningFilePath !== null}
+            disabled={!hasTarget || isBusy}
             className="gap-2"
           >
             {isListing ? (
@@ -216,9 +384,7 @@ export function TextureResizerWorkspace({
             onClick={() =>
               void loadTextures(mode === "mod" ? (fixedTargetPath ?? targetPath) : loadedTargetPath)
             }
-            disabled={
-              isListing || runningFilePath !== null || (!loadedTargetPath && mode !== "mod")
-            }
+            disabled={isBusy || (!loadedTargetPath && mode !== "mod")}
             className="gap-2"
           >
             {isListing ? (
@@ -228,6 +394,21 @@ export function TextureResizerWorkspace({
             )}
             {t("page.tools.texture_resizer.refresh")}
           </Button>
+        )}
+        {textures.length > 0 && (
+          <div className="ml-auto flex flex-wrap items-center gap-2">
+            <span className="text-xs text-muted-foreground">
+              {t("page.tools.texture_resizer.selected_count", { count: selectedPaths.size })}
+            </span>
+            <Button
+              className="gap-2"
+              disabled={selectedPaths.size === 0 || isBusy}
+              onClick={openProcessDialog}
+            >
+              <ImageIcon className="size-4" />
+              {t("page.tools.texture_resizer.process_selected")}
+            </Button>
+          </div>
         )}
       </div>
 
@@ -246,20 +427,32 @@ export function TextureResizerWorkspace({
           <div className="relative w-full">
             {textures.length > 0 ? (
               <table className="w-full table-auto border-collapse text-sm">
+                <thead>
+                  <tr>
+                    <td colSpan={4} />
+                    <td className="w-[1%] p-2 pr-6 text-right align-middle">
+                      <div className="flex justify-end">
+                        <Checkbox
+                          checked={allProcessableSelected}
+                          indeterminate={someProcessableSelected && !allProcessableSelected}
+                          disabled={isBusy || processableTextures.length === 0}
+                          aria-label={t("page.tools.texture_resizer.select_all")}
+                          onCheckedChange={(checked) => toggleAllProcessable(checked === true)}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                </thead>
                 <tbody>
                   {textures.map((texture, index) => (
                     <Fragment key={texture.filePath}>
                       <TextureItemRow
                         texture={texture}
                         t={t}
+                        selected={selectedPaths.has(texture.filePath)}
                         isRunning={runningFilePath === texture.filePath}
-                        disabled={isListing || runningFilePath !== null}
-                        onProcess={() => {
-                          setSelectedTexture(texture);
-                          dialogSettingsForm.reset(
-                            buildDialogSettings(settingsForm.state.values, texture),
-                          );
-                        }}
+                        disabled={isBusy}
+                        onToggle={(selected) => toggleTexture(texture.filePath, selected)}
                       />
                       {index < textures.length - 1 && (
                         <tr aria-hidden="true">
@@ -284,10 +477,10 @@ export function TextureResizerWorkspace({
       </div>
 
       <Dialog
-        open={selectedTexture != null}
+        open={dialogOpen}
         onOpenChange={(open) => {
-          if (!open && runningFilePath == null) {
-            setSelectedTexture(null);
+          if (!open) {
+            closeDialog();
           }
         }}
       >
@@ -295,8 +488,12 @@ export function TextureResizerWorkspace({
           <DialogHeader>
             <DialogTitle>{t("page.tools.texture_resizer.dialog.title")}</DialogTitle>
             <DialogDescription>
-              {selectedTexture?.fileName ??
-                t("page.tools.texture_resizer.dialog.description_fallback")}
+              {dialogTextures.length > 1 && bulkApply
+                ? t("page.tools.texture_resizer.dialog.description_multiple", {
+                    count: dialogTextures.length,
+                  })
+                : (dialogTextures.find((texture) => texture.filePath === activeDialogTexturePath)
+                    ?.fileName ?? t("page.tools.texture_resizer.dialog.description_fallback"))}
             </DialogDescription>
           </DialogHeader>
 
@@ -304,52 +501,106 @@ export function TextureResizerWorkspace({
             <dialogSettingsForm.Subscribe
               selector={(state) => state.values}
               children={(dialogSettings) => {
+                const activeTexture =
+                  dialogTextures.find((texture) => texture.filePath === activeDialogTexturePath) ??
+                  dialogTextures[0] ??
+                  null;
+                const formTexture = bulkApply ? null : activeTexture;
                 const selectedTexturePreview =
-                  selectedTexture != null
-                    ? resolveTexturePreview(selectedTexture, dialogSettings)
-                    : null;
+                  formTexture != null ? resolveTexturePreview(formTexture, dialogSettings) : null;
+                const sharedFormats = intersectOutputFormats(dialogTextures);
+                const sharedColor = sharedColorSpace(dialogTextures);
 
                 return (
                   <div className="space-y-3 pr-4">
-                    {selectedTexture && (
-                      <div className="space-y-1 text-xs text-muted-foreground">
-                        <div className="break-all">{selectedTexture.relativePath}</div>
+                    {dialogTextures.length > 1 && (
+                      <div className="flex items-center justify-between rounded-md border bg-background/40 p-3">
                         <div>
-                          {selectedTexture.originalWidth}x{selectedTexture.originalHeight} -&gt;{" "}
-                          {selectedTexturePreview?.width ?? selectedTexture.targetWidth}x
-                          {selectedTexturePreview?.height ?? selectedTexture.targetHeight}
+                          <div className="text-sm font-medium">
+                            {t("page.tools.texture_resizer.bulk_apply")}
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            {t("page.tools.texture_resizer.bulk_apply_description")}
+                          </div>
+                        </div>
+                        <Switch
+                          checked={bulkApply}
+                          onCheckedChange={handleBulkApplyChange}
+                          disabled={batchProgress != null}
+                        />
+                      </div>
+                    )}
+                    {!bulkApply && dialogTextures.length > 1 && (
+                      <div className="flex flex-wrap gap-1">
+                        {dialogTextures.map((texture) => (
+                          <Button
+                            key={texture.filePath}
+                            type="button"
+                            size="sm"
+                            variant={
+                              texture.filePath === activeDialogTexturePath ? "default" : "outline"
+                            }
+                            disabled={batchProgress != null}
+                            onClick={() => selectDialogTexture(texture.filePath)}
+                          >
+                            {texture.fileName}
+                          </Button>
+                        ))}
+                      </div>
+                    )}
+                    {formTexture && (
+                      <div className="space-y-1 text-xs text-muted-foreground">
+                        <div className="break-all">{formTexture.relativePath}</div>
+                        <div>
+                          {formTexture.originalWidth}x{formTexture.originalHeight} -&gt;{" "}
+                          {selectedTexturePreview?.width ?? formTexture.targetWidth}x
+                          {selectedTexturePreview?.height ?? formTexture.targetHeight}
                         </div>
                         <div>
-                          {formatTextureFormatLabel(selectedTexture.format)} /{" "}
-                          {t(
-                            `page.tools.texture_resizer.color_space.${selectedTexture.colorSpace}`,
-                          )}
+                          {formatTextureFormatLabel(formTexture.format)} /{" "}
+                          {t(`page.tools.texture_resizer.color_space.${formTexture.colorSpace}`)}
                         </div>
                         <div>
                           {t("page.tools.texture_resizer.current_output_format")}:{" "}
                           {formatTextureFormatLabel(
-                            dialogSettings.outputFormat || selectedTexture.outputFormatDefault,
+                            dialogSettings.outputFormat || formTexture.outputFormatDefault,
                           )}
                         </div>
-                        {selectedTexture.formatConversionMessage && (
-                          <div>{selectedTexture.formatConversionMessage}</div>
+                        {formTexture.formatConversionMessage && (
+                          <div>{formTexture.formatConversionMessage}</div>
                         )}
-                        {selectedTexture.message &&
+                        {formTexture.message &&
                           isTextureUpscaleOperation(dialogSettings.operation) && (
-                            <div>{selectedTexture.message}</div>
+                            <div>{formTexture.message}</div>
                           )}
                       </div>
                     )}
-                    {runningFilePath === selectedTexture?.filePath && upscaleProgress && (
+                    {batchProgress && (
                       <div className="space-y-2 rounded-md border bg-background/40 p-3">
                         <div className="text-xs text-muted-foreground">
-                          {upscaleProgress.message ??
-                            t("page.tools.texture_resizer.upscale_progress.working")}
+                          {runningFilePath
+                            ? dialogTextures.find((texture) => texture.filePath === runningFilePath)
+                                ?.fileName
+                            : null}{" "}
+                          {t("page.tools.texture_resizer.batch_progress", {
+                            current: batchProgress.current,
+                            total: batchProgress.total,
+                          })}
                         </div>
-                        <Progress
-                          value={upscaleProgress.percent}
-                          className={upscaleProgress.percent == null ? "animate-pulse" : undefined}
-                        />
+                        {upscaleProgress && (
+                          <>
+                            <div className="text-xs text-muted-foreground">
+                              {upscaleProgress.message ??
+                                t("page.tools.texture_resizer.upscale_progress.working")}
+                            </div>
+                            <Progress
+                              value={upscaleProgress.percent}
+                              className={
+                                upscaleProgress.percent == null ? "animate-pulse" : undefined
+                              }
+                            />
+                          </>
+                        )}
                       </div>
                     )}
                     <TextureResizerForm
@@ -364,18 +615,41 @@ export function TextureResizerWorkspace({
                         dialogSettingsForm.setFieldValue("backup", nextSettings.backup);
                         dialogSettingsForm.setFieldValue("upscaleScale", nextSettings.upscaleScale);
                         dialogSettingsForm.setFieldValue("upscaleModel", nextSettings.upscaleModel);
+                        if (!bulkApply && activeDialogTexturePath) {
+                          setPerTextureSettings((current) => ({
+                            ...current,
+                            [activeDialogTexturePath]: nextSettings,
+                          }));
+                        }
                       }}
-                      disabled={runningFilePath != null}
+                      disabled={batchProgress != null}
                       showTargetPath={false}
-                      availableOutputFormats={selectedTexture?.availableOutputFormats}
-                      currentFormat={selectedTexture?.outputFormatDefault}
-                      currentColorSpace={selectedTexture?.colorSpace}
-                      formatConversionMessage={selectedTexture?.formatConversionMessage}
+                      sharedResize={bulkApply && dialogTextures.length > 1}
+                      availableOutputFormats={
+                        bulkApply && dialogTextures.length > 1
+                          ? sharedFormats
+                          : formTexture?.availableOutputFormats
+                      }
+                      currentFormat={
+                        bulkApply && dialogTextures.length > 1
+                          ? sharedFormats[0]
+                          : formTexture?.outputFormatDefault
+                      }
+                      currentColorSpace={
+                        bulkApply && dialogTextures.length > 1
+                          ? sharedColor
+                          : formTexture?.colorSpace
+                      }
+                      formatConversionMessage={
+                        bulkApply && dialogTextures.length > 1
+                          ? sharedFormatConversionMessage(dialogTextures)
+                          : formTexture?.formatConversionMessage
+                      }
                       resizeSource={
-                        selectedTexture
+                        formTexture
                           ? {
-                              width: selectedTexture.originalWidth,
-                              height: selectedTexture.originalHeight,
+                              width: formTexture.originalWidth,
+                              height: formTexture.originalHeight,
                             }
                           : null
                       }
@@ -388,39 +662,47 @@ export function TextureResizerWorkspace({
 
           <dialogSettingsForm.Subscribe
             selector={(state) => state.values}
-            children={(dialogSettings) => (
-              <DialogFooter>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setSelectedTexture(null)}
-                  disabled={runningFilePath != null}
-                >
-                  {t("g.cancel")}
-                </Button>
-                <Button
-                  type="button"
-                  className="gap-2"
-                  disabled={
-                    !selectedTexture ||
-                    runningFilePath != null ||
-                    !canRun(dialogSettings, selectedTexture)
-                  }
-                  onClick={() =>
-                    selectedTexture && void processTexture(selectedTexture.filePath, dialogSettings)
-                  }
-                >
-                  {runningFilePath === selectedTexture?.filePath ? (
-                    <Loader2Icon className="size-4 animate-spin" />
-                  ) : (
-                    <ImageIcon className="size-4" />
-                  )}
-                  {runningFilePath === selectedTexture?.filePath
-                    ? t("page.tools.texture_resizer.running")
-                    : t("page.tools.texture_resizer.process_single")}
-                </Button>
-              </DialogFooter>
-            )}
+            children={(dialogSettings) => {
+              const canProcessAny = dialogTextures.some((texture) => {
+                const nextSettings =
+                  bulkApply || dialogTextures.length === 1
+                    ? adaptSettingsForTexture(dialogSettings, texture)
+                    : (perTextureSettings[texture.filePath] ?? dialogSettings);
+                return canRun(nextSettings, texture);
+              });
+
+              return (
+                <DialogFooter>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={closeDialog}
+                    disabled={batchProgress != null}
+                  >
+                    {t("g.cancel")}
+                  </Button>
+                  <Button
+                    type="button"
+                    className="gap-2"
+                    disabled={
+                      dialogTextures.length === 0 || batchProgress != null || !canProcessAny
+                    }
+                    onClick={() => void processSelectedTextures(dialogSettings)}
+                  >
+                    {batchProgress != null ? (
+                      <Loader2Icon className="size-4 animate-spin" />
+                    ) : (
+                      <ImageIcon className="size-4" />
+                    )}
+                    {batchProgress != null
+                      ? t("page.tools.texture_resizer.running")
+                      : dialogTextures.length > 1
+                        ? t("page.tools.texture_resizer.process_selected")
+                        : t("page.tools.texture_resizer.process_single")}
+                  </Button>
+                </DialogFooter>
+              );
+            }}
           />
         </DialogContent>
       </Dialog>
@@ -431,27 +713,43 @@ export function TextureResizerWorkspace({
 function TextureItemRow({
   texture,
   t,
+  selected,
   isRunning,
   disabled,
-  onProcess,
+  onToggle,
 }: {
   texture: TextureResizeListItem;
   t: ReturnType<typeof useTranslation>["t"];
+  selected: boolean;
   isRunning: boolean;
   disabled: boolean;
-  onProcess: () => void;
+  onToggle: (selected: boolean) => void;
 }) {
   const formatValue = `${formatTextureFormatLabel(texture.format)} / ${t(
     `page.tools.texture_resizer.color_space.${texture.colorSpace}`,
   )}`;
+  const canSelect = texture.canProcess && !disabled;
 
   return (
-    <tr className="transition-colors hover:bg-card/50">
+    <tr
+      className={cn(
+        "transition-colors hover:bg-card/50",
+        selected && "bg-card/50",
+        canSelect && "cursor-pointer",
+      )}
+      onClick={() => {
+        if (!canSelect) {
+          return;
+        }
+        onToggle(!selected);
+      }}
+    >
       <td className="w-full max-w-0 p-2 pl-3 text-left align-middle whitespace-nowrap">
         <div
           className="block w-full cursor-pointer truncate text-sm font-medium"
           title={texture.fileName}
-          onClick={() => {
+          onClick={(event) => {
+            event.stopPropagation();
             void window.api.invoke("util:openExternal", texture.filePath);
           }}
         >
@@ -468,27 +766,22 @@ function TextureItemRow({
         {texture.originalWidth}x{texture.originalHeight}
       </td>
       <td className="w-[1%] p-2 pr-6 text-right align-middle whitespace-nowrap">
-        <Button
-          size="sm"
-          className="gap-2"
-          onClick={onProcess}
-          disabled={disabled || !texture.canProcess}
-        >
-          {isRunning ? (
-            <Loader2Icon className="size-4 animate-spin" />
-          ) : (
-            <ImageIcon className="size-4" />
-          )}
-          {isRunning
-            ? t("page.tools.texture_resizer.running")
-            : t("page.tools.texture_resizer.process_single")}
-        </Button>
+        <div className="flex items-center justify-end gap-2">
+          {isRunning && <Loader2Icon className="size-4 animate-spin" />}
+          <Checkbox
+            checked={selected}
+            disabled={disabled || !texture.canProcess}
+            aria-label={texture.fileName}
+            onClick={(event) => event.stopPropagation()}
+            onCheckedChange={(checked) => onToggle(checked === true)}
+          />
+        </div>
       </td>
     </tr>
   );
 }
 
-function buildDialogSettings(
+function adaptSettingsForTexture(
   settings: TextureResizeSettings,
   texture: TextureResizeListItem,
 ): TextureResizeSettings {
@@ -497,24 +790,106 @@ function buildDialogSettings(
       ? settings.outputFormat
       : texture.outputFormatDefault;
 
-  let operation = settings.operation;
   if (
-    (operation === "resize_and_convert" || operation === "convert") &&
+    (settings.operation === "resize_and_convert" || settings.operation === "convert") &&
     !texture.canConvertFormat
   ) {
-    operation = "resize";
+    return {
+      ...settings,
+      operation: "resize",
+      outputFormat,
+    };
   }
-  if (operation === "upscale_and_convert" && !texture.canConvertFormat) {
-    operation = "upscale";
+
+  if (settings.operation === "upscale_and_convert" && !texture.canConvertFormat) {
+    return {
+      ...settings,
+      operation: "upscale",
+      outputFormat,
+    };
   }
 
   return {
     ...settings,
-    mode: "custom",
-    customWidth: texture.canResize ? texture.targetWidth : settings.customWidth,
-    customHeight: texture.canResize ? texture.targetHeight : settings.customHeight,
-    operation,
     outputFormat,
+  };
+}
+
+function buildDialogSettings(
+  settings: TextureResizeSettings,
+  texture: TextureResizeListItem,
+): TextureResizeSettings {
+  const adapted = adaptSettingsForTexture(settings, texture);
+  const preview = resolveTexturePreview(texture, adapted);
+
+  return {
+    ...adapted,
+    mode: "custom",
+    customWidth: preview?.width ?? adapted.customWidth,
+    customHeight: preview?.height ?? adapted.customHeight,
+  };
+}
+
+function buildSharedDialogSettings(
+  settings: TextureResizeSettings,
+  textures: TextureResizeListItem[],
+): TextureResizeSettings {
+  const availableOutputFormats = intersectOutputFormats(textures);
+  const outputFormat =
+    availableOutputFormats.includes(settings.outputFormat) && settings.outputFormat
+      ? settings.outputFormat
+      : (availableOutputFormats[0] ?? "");
+
+  return {
+    ...settings,
+    outputFormat,
+  };
+}
+
+function intersectOutputFormats(textures: TextureResizeListItem[]): string[] {
+  const first = textures[0];
+  if (!first) {
+    return [];
+  }
+
+  return first.availableOutputFormats.filter((format) =>
+    textures.every((texture) => texture.availableOutputFormats.includes(format)),
+  );
+}
+
+function sharedColorSpace(textures: TextureResizeListItem[]): TextureColorSpace {
+  if (textures.some((texture) => texture.colorSpace === "linear")) {
+    return "linear";
+  }
+
+  const first = textures[0]?.colorSpace;
+  if (!first) {
+    return "unknown";
+  }
+
+  return textures.every((texture) => texture.colorSpace === first) ? first : "unknown";
+}
+
+function sharedFormatConversionMessage(textures: TextureResizeListItem[]) {
+  const first = textures[0]?.formatConversionMessage ?? null;
+  if (!first) {
+    return null;
+  }
+
+  return textures.every((texture) => texture.formatConversionMessage === first) ? first : null;
+}
+
+function resolveResizeBounds(texture: TextureResizeListItem, settings: TextureResizeSettings) {
+  if (settings.mode === "percent") {
+    return {
+      width: Math.floor((texture.originalWidth * settings.percent) / 100),
+      height: Math.floor((texture.originalHeight * settings.percent) / 100),
+    };
+  }
+
+  return {
+    width: settings.customWidth,
+    height: settings.customHeight,
   };
 }
 
@@ -542,7 +917,8 @@ function resolveTexturePreview(
     return null;
   }
 
-  return pickTextureResizeCandidate(candidates, settings.customWidth, settings.customHeight);
+  const bounds = resolveResizeBounds(texture, settings);
+  return pickTextureResizeCandidate(candidates, bounds.width, bounds.height);
 }
 
 function canUpscaleWithSettings(texture: TextureResizeListItem, settings: TextureResizeSettings) {
@@ -573,6 +949,48 @@ function canRun(settings: TextureResizeSettings, texture: TextureResizeListItem)
   }
 
   return canResizeWithSettings && texture.canConvertFormat;
+}
+
+function showTextureResizeResultToast(
+  t: ReturnType<typeof useTranslation>["t"],
+  result: {
+    selectedCount: number;
+    updated: number;
+    failed: number;
+    skipped: number;
+    lastFileResult?: TextureResizeFileResult;
+  },
+) {
+  const description = t("page.tools.texture_resizer.toast.completed_description", {
+    updated: result.updated,
+    failed: result.failed,
+    skipped: result.skipped,
+  });
+
+  if (result.selectedCount === 1 && result.updated === 1) {
+    toast.success(t("page.tools.texture_resizer.toast.single_completed"), {
+      description: describeFileResult(t, result.lastFileResult),
+    });
+    return;
+  }
+
+  if (result.updated === 0 && result.failed > 0) {
+    toast.error(t("page.tools.texture_resizer.toast.failed"), {
+      description,
+    });
+    return;
+  }
+
+  if (result.updated === 0) {
+    toast.warning(t("page.tools.texture_resizer.toast.none_processed"), {
+      description,
+    });
+    return;
+  }
+
+  toast.success(t("page.tools.texture_resizer.toast.completed"), {
+    description,
+  });
 }
 
 function describeFileResult(

--- a/src/renderer/src/components/tools/texture-resizer-workspace.tsx
+++ b/src/renderer/src/components/tools/texture-resizer-workspace.tsx
@@ -312,6 +312,7 @@ export function TextureResizerWorkspace({
         }
         if (fileResult?.status === "failed" || !fileResult) {
           failed += 1;
+          errorMessage ??= fileResult?.message ?? undefined;
           continue;
         }
         skipped += 1;
@@ -978,7 +979,7 @@ function showTextureResizeResultToast(
 
   if (result.selectedCount === 1 && result.failed > 0) {
     toast.error(t("page.tools.texture_resizer.toast.failed"), {
-      description: result.errorMessage ?? description,
+      description: result.errorMessage ?? result.lastFileResult?.message ?? description,
     });
     return;
   }

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -998,6 +998,12 @@
         "ready": "Ready",
         "not_resizable": "Skipped",
         "process_single": "Process",
+        "select_all": "Select all",
+        "selected_count": "{{count}} selected",
+        "bulk_apply": "Apply to all",
+        "bulk_apply_description": "Use the same options for every selected texture.",
+        "process_selected": "Process selected",
+        "batch_progress": "{{current}} / {{total}}",
         "run": "Process textures",
         "running": "Processing",
         "result_title": "Processing result",
@@ -1021,7 +1027,8 @@
         },
         "dialog": {
           "title": "Texture processing options",
-          "description_fallback": "Selected DDS file"
+          "description_fallback": "Selected DDS file",
+          "description_multiple": "{{count}} DDS files"
         },
         "result": {
           "processed": "Processed",
@@ -1033,7 +1040,8 @@
           "save_settings_failed": "Failed to save texture processing settings",
           "load_failed": "Failed to load the texture list",
           "completed": "Texture processing completed",
-          "completed_description": "{{updated}} updated, {{failed}} failed",
+          "completed_description": "{{updated}} updated, {{failed}} failed, {{skipped}} skipped",
+          "none_processed": "No textures were processed",
           "single_completed": "Texture processing completed",
           "single_completed_fallback": "Finished processing the selected texture",
           "failed": "Texture processing failed"

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -965,6 +965,12 @@
         "ready": "変換可能",
         "not_resizable": "スキップ",
         "process_single": "変換",
+        "select_all": "すべて選択",
+        "selected_count": "{{count}} 件選択",
+        "bulk_apply": "一括適用",
+        "bulk_apply_description": "選択したすべてのテクスチャに同じオプションを適用します。",
+        "process_selected": "選択項目を変換",
+        "batch_progress": "{{current}} / {{total}}",
         "run": "テクスチャを変換",
         "running": "変換中",
         "result_title": "変換結果",
@@ -988,7 +994,8 @@
         },
         "dialog": {
           "title": "テクスチャ変換オプション",
-          "description_fallback": "選択した DDS ファイル"
+          "description_fallback": "選択した DDS ファイル",
+          "description_multiple": "{{count}} 個の DDS ファイル"
         },
         "result": {
           "processed": "処理",
@@ -1000,7 +1007,8 @@
           "save_settings_failed": "テクスチャ変換設定の保存に失敗しました",
           "load_failed": "テクスチャ一覧の読み込みに失敗しました",
           "completed": "テクスチャ変換が完了しました",
-          "completed_description": "{{updated}} 件変更、{{failed}} 件失敗",
+          "completed_description": "{{updated}} 件変更、{{failed}} 件失敗、{{skipped}} 件スキップ",
+          "none_processed": "変換されたテクスチャはありません",
           "single_completed": "テクスチャ変換が完了しました",
           "single_completed_fallback": "選択したテクスチャの処理が完了しました",
           "failed": "テクスチャ変換に失敗しました"

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -984,6 +984,12 @@
         "ready": "변환 가능",
         "not_resizable": "건너뜀",
         "process_single": "변환",
+        "select_all": "전체 선택",
+        "selected_count": "{{count}}개 선택",
+        "bulk_apply": "일괄 적용",
+        "bulk_apply_description": "선택한 모든 텍스처에 같은 옵션을 적용합니다.",
+        "process_selected": "선택 항목 변환",
+        "batch_progress": "{{current}} / {{total}}",
         "run": "텍스처 변환",
         "running": "변환 중",
         "result_title": "변환 결과",
@@ -1007,7 +1013,8 @@
         },
         "dialog": {
           "title": "텍스처 변환 옵션",
-          "description_fallback": "선택한 DDS 파일"
+          "description_fallback": "선택한 DDS 파일",
+          "description_multiple": "{{count}}개의 DDS 파일"
         },
         "result": {
           "processed": "처리",
@@ -1019,7 +1026,8 @@
           "save_settings_failed": "텍스처 변환 설정을 저장하지 못했습니다",
           "load_failed": "텍스처 목록을 불러오지 못했습니다",
           "completed": "텍스처 변환이 완료되었습니다",
-          "completed_description": "{{updated}}개 변경, {{failed}}개 실패",
+          "completed_description": "{{updated}}개 변경, {{failed}}개 실패, {{skipped}}개 건너뜀",
+          "none_processed": "변환된 텍스처가 없습니다",
           "single_completed": "텍스처 변환이 완료되었습니다",
           "single_completed_fallback": "선택한 텍스처 처리가 완료되었습니다",
           "failed": "텍스처 변환에 실패했습니다"

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -964,6 +964,12 @@
         "ready": "可转换",
         "not_resizable": "已跳过",
         "process_single": "转换",
+        "select_all": "全选",
+        "selected_count": "已选择 {{count}} 个",
+        "bulk_apply": "批量应用",
+        "bulk_apply_description": "对所选纹理使用相同选项。",
+        "process_selected": "转换所选",
+        "batch_progress": "{{current}} / {{total}}",
         "run": "处理纹理",
         "running": "处理中",
         "result_title": "处理结果",
@@ -987,7 +993,8 @@
         },
         "dialog": {
           "title": "纹理处理选项",
-          "description_fallback": "选中的 DDS 文件"
+          "description_fallback": "选中的 DDS 文件",
+          "description_multiple": "{{count}} 个 DDS 文件"
         },
         "result": {
           "processed": "已处理",
@@ -999,7 +1006,8 @@
           "save_settings_failed": "保存纹理处理设置失败",
           "load_failed": "加载纹理列表失败",
           "completed": "纹理处理已完成",
-          "completed_description": "修改 {{updated}} 个，失败 {{failed}} 个",
+          "completed_description": "修改 {{updated}} 个，失败 {{failed}} 个，跳过 {{skipped}} 个",
+          "none_processed": "没有纹理被处理",
           "single_completed": "纹理处理已完成",
           "single_completed_fallback": "选中纹理处理完成",
           "failed": "纹理处理失败"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Batch processing overwrites multiple mod DDS files sequentially with optional backups; mistakes or partial failures affect user content, though logic reuses existing resize IPC and per-file validation.
> 
> **Overview**
> Replaces per-row **Process** actions with **checkbox selection**, a **Process selected** flow, and sequential processing of each chosen DDS through the existing single-file API.
> 
> The options dialog now supports **bulk apply** (one shared settings object adapted per texture) or **per-texture** tabs when bulk is off. For multi-select bulk resize, the form adds **percent vs custom** mode with a slider or width/height inputs (1024-step snapping via `snapDimension`), instead of only the per-file resize-step slider.
> 
> **Batch progress** (current/total) and upscale progress stay visible while the dialog cannot be closed. The mod texture resize shell hides the default dialog close button. Result toasts report updated, failed, and skipped counts; new strings in EN/JA/KO/ZH.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b7089ffef9609b6504d689043022069320c74ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Select and resize multiple textures in a single batch.
  - Apply shared resize settings using percentages or custom dimensions.
  - Track batch progress and view results, including skipped items.
  - Select textures individually and apply settings in bulk.
  - Custom dimensions are validated and snapped to supported increments.

- **Bug Fixes**
  - Prevent accidental closure of the texture resize dialog during processing.

- **Localization**
  - Added bulk-processing and progress messages in English, Japanese, Korean, and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->