### PR TITLE
feat(akasha): support NTE mod bundle uploads

### DIFF
--- a/src/main/lib/cbor-response.ts
+++ b/src/main/lib/cbor-response.ts
@@ -51,8 +51,13 @@ export async function jsonResponseFromBody(
 function parseDecodedHttpResult(status: number, value: unknown) {
     if (typeof value === "string") return { status, reason: value };
     if (value && typeof value === "object") {
-        const payload = value as { status?: string; reason?: string; message?: string };
-        return { status, payload, reason: payload.reason ?? payload.message };
+        const payload = value as {
+            status?: string;
+            reason?: string;
+            message?: string;
+            code?: string;
+        };
+        return { status, payload, reason: payload.reason ?? payload.message ?? payload.code };
     }
     return { status };
 }

--- a/src/main/lib/upload-v2.test.ts
+++ b/src/main/lib/upload-v2.test.ts
@@ -9,7 +9,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NahidaDesktop } from "..";
 import type { FinalFile, UploadProgress } from "./upload";
 
-import { uploadDriveFilesV2 } from "./upload-v2";
+import { MAX_UPLOAD_FILE_SIZE, paginateUploadFiles, uploadDriveFilesV2 } from "./upload-v2";
 
 const mocks = vi.hoisted(() => ({
     networkFetch: vi.fn(),
@@ -43,6 +43,14 @@ function file(id: string): FinalFile {
     };
 }
 
+function nteFile(id: string, extension: "pak" | "utoc" | "ucas"): FinalFile {
+    return {
+        ...file(id),
+        path: `mod.${extension}`,
+        name: `mod.${extension}`,
+    };
+}
+
 function sseResponse(events: Array<{ event: string; data: unknown }>): Response {
     const lines = events.flatMap((e) => {
         const dataStr = typeof e.data === "string" ? e.data : JSON.stringify(e.data);
@@ -71,6 +79,222 @@ function sseResponseText(events: Array<{ event: string; data: string }>): Respon
 describe("uploadDriveFilesV2", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+    });
+
+    it("keeps an NTE group together across 500-file plan pages", () => {
+        const ordinary = Array.from({ length: 499 }, (_, index) => file(`ordinary-${index}`));
+        const nte = [nteFile("pak", "pak"), nteFile("utoc", "utoc"), nteFile("ucas", "ucas")];
+
+        const pages = paginateUploadFiles([...ordinary, ...nte]);
+
+        expect(pages.map((page) => page.length)).toEqual([499, 3]);
+        expect(pages[1].map((entry) => entry.FID)).toEqual(["pak", "utoc", "ucas"]);
+    });
+
+    it("rejects an NTE group that cannot fit in one plan page", () => {
+        const files = Array.from({ length: 501 }, (_, index) => ({
+            ...nteFile(`ucas-${index}`, "ucas"),
+            name: index === 0 ? "mod.ucas" : `mod_s${index}.ucas`,
+        }));
+
+        expect(() => paginateUploadFiles(files)).toThrow("nte_bundle_too_large");
+    });
+
+    it("sends the NTE capability in every plan request", async () => {
+        mocks.networkFetch.mockResolvedValue(
+            sseResponse([
+                {
+                    event: "complete",
+                    data: {
+                        items: [{ clientId: "first", status: "created", itemId: "one" }],
+                        uploads: [],
+                        nteBundles: [],
+                    },
+                },
+            ]),
+        );
+
+        await uploadDriveFilesV2({
+            desktop,
+            currentId: "current",
+            requestId: "request-id",
+            files: [file("first")],
+            queue: new PQueue({ concurrency: 1 }),
+            prepareDirectFile: async () => ({ data: Buffer.from("unused") }),
+        });
+
+        expect(
+            JSON.parse(String(mocks.networkFetch.mock.calls[0][1]?.body)) as unknown,
+        ).toMatchObject({ capabilities: ["nte-bundle-v1"] });
+    });
+
+    it("accepts exactly 1 GiB and rejects one byte more without allocating the file", async () => {
+        const exact = { ...file("exact"), size: MAX_UPLOAD_FILE_SIZE };
+        mocks.networkFetch.mockResolvedValue(
+            sseResponse([
+                {
+                    event: "complete",
+                    data: {
+                        items: [{ clientId: "exact", status: "created", itemId: "one" }],
+                        uploads: [],
+                    },
+                },
+            ]),
+        );
+
+        await expect(
+            uploadDriveFilesV2({
+                desktop,
+                currentId: "current",
+                requestId: "request-id",
+                files: [exact],
+                queue: new PQueue({ concurrency: 1 }),
+                prepareDirectFile: async () => ({ data: Buffer.from("unused") }),
+            }),
+        ).resolves.toBeUndefined();
+        await expect(
+            uploadDriveFilesV2({
+                desktop,
+                currentId: "current",
+                requestId: "request-id",
+                files: [{ ...exact, size: MAX_UPLOAD_FILE_SIZE + 1 }],
+                queue: new PQueue({ concurrency: 1 }),
+                prepareDirectFile: async () => ({ data: Buffer.from("unused") }),
+            }),
+        ).rejects.toMatchObject({ code: "upload_file_too_large" });
+        expect(mocks.networkFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("stages NTE members and marks them complete only after bundle finalization", async () => {
+        const utoc = nteFile("utoc", "utoc");
+        const ucas = nteFile("ucas", "ucas");
+        mocks.networkFetch.mockResolvedValue(
+            sseResponse([
+                {
+                    event: "complete",
+                    data: {
+                        items: [
+                            {
+                                clientId: "utoc",
+                                status: "pending",
+                                intentId: "intent-utoc",
+                                bundleId: "bundle",
+                            },
+                            {
+                                clientId: "ucas",
+                                status: "pending",
+                                intentId: "intent-ucas",
+                                bundleId: "bundle",
+                            },
+                        ],
+                        uploads: [
+                            {
+                                intentId: "intent-utoc",
+                                url: "https://api.nahida.live/uploads/intent-utoc",
+                                method: "POST",
+                                form: { token: "upload-token", sha256: "a".repeat(64) },
+                            },
+                        ],
+                        nteBundles: [
+                            {
+                                id: "bundle",
+                                memberClientIds: ["utoc", "ucas"],
+                                completeUrl:
+                                    "https://api.nahida.live/upload-bundles/bundle/complete",
+                                abortUrl: "https://api.nahida.live/upload-bundles/bundle/abort",
+                                form: { token: "bundle-token" },
+                            },
+                        ],
+                    },
+                },
+            ]),
+        );
+        const order: string[] = [];
+        mocks.request.mockImplementation(async () => {
+            order.push("upload");
+            return new Response(JSON.stringify({ status: "completed" }), { status: 200 });
+        });
+        mocks.post.mockImplementation(async () => {
+            order.push("complete");
+            return new Response(JSON.stringify({ status: "completed" }), { status: 200 });
+        });
+
+        await uploadDriveFilesV2({
+            desktop,
+            currentId: "current",
+            requestId: "request-id",
+            files: [utoc, ucas],
+            queue: new PQueue({ concurrency: 2 }),
+            prepareDirectFile: async () => ({ data: Buffer.from("payload") }),
+            onProgress: (progress) => {
+                if (progress.fileId) order.push(`ready:${progress.fileId}`);
+            },
+        });
+
+        expect(order).toEqual(["upload", "complete", "ready:utoc", "ready:ucas"]);
+    });
+
+    it("aborts only the invalid NTE bundle and preserves the structured error code", async () => {
+        const utoc = nteFile("utoc", "utoc");
+        const ucas = nteFile("ucas", "ucas");
+        mocks.networkFetch.mockResolvedValue(
+            sseResponse([
+                {
+                    event: "complete",
+                    data: {
+                        items: [
+                            {
+                                clientId: "utoc",
+                                status: "pending",
+                                intentId: "dedup-utoc",
+                                bundleId: "bundle",
+                            },
+                            {
+                                clientId: "ucas",
+                                status: "pending",
+                                intentId: "dedup-ucas",
+                                bundleId: "bundle",
+                            },
+                        ],
+                        uploads: [],
+                        nteBundles: [
+                            {
+                                id: "bundle",
+                                memberClientIds: ["utoc", "ucas"],
+                                completeUrl:
+                                    "https://api.nahida.live/upload-bundles/bundle/complete",
+                                abortUrl: "https://api.nahida.live/upload-bundles/bundle/abort",
+                                form: { token: "bundle-token" },
+                            },
+                        ],
+                    },
+                },
+            ]),
+        );
+        mocks.post
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({ code: "invalid_nte_mod_file" }), { status: 400 }),
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({ status: "cancelled" }), { status: 200 }),
+            );
+        const progress: UploadProgress[] = [];
+
+        await expect(
+            uploadDriveFilesV2({
+                desktop,
+                currentId: "current",
+                requestId: "request-id",
+                files: [utoc, ucas],
+                queue: new PQueue({ concurrency: 2 }),
+                prepareDirectFile: async () => ({ data: Buffer.from("unused") }),
+                onProgress: (event) => progress.push(event),
+            }),
+        ).rejects.toMatchObject({ code: "invalid_nte_mod_file" });
+        expect(mocks.request).not.toHaveBeenCalled();
+        expect(mocks.post).toHaveBeenCalledTimes(2);
+        expect(progress.reduce((total, event) => total + event.bytes, 0)).toBe(0);
+        expect(progress.every((event) => event.fileId === undefined)).toBe(true);
     });
 
     it("marks files materialized by the plan as server-deduplicated", async () => {

--- a/src/main/lib/upload-v2.ts
+++ b/src/main/lib/upload-v2.ts
@@ -6,8 +6,8 @@ import { parseHttpBody, readApiBody } from "@main/lib/cbor-response";
 import { BACKEND_URL } from "@shared/const";
 import type { PlanPhase } from "@shared/types";
 import { toErrorMessage } from "@shared/utils";
-import { chunk } from "es-toolkit";
 import ky from "ky";
+import pLimit from "p-limit";
 import type PQueue from "p-queue";
 import { parseServerSentEvents } from "parse-sse";
 
@@ -26,6 +26,8 @@ import {
 
 const PLAN_PAGE_SIZE = 500;
 const PART_SIZE = 25 * 1024 * 1024;
+export const MAX_UPLOAD_FILE_SIZE = 1024 ** 3;
+export const MAX_MULTIPART_CONCURRENCY = 4;
 const RETRY_LIMIT = 3;
 const COMPLETE_TIMEOUT_MS = 15 * 60 * 1000;
 const UPLOAD_STREAM_CHUNK_SIZE = 64 * 1024;
@@ -36,6 +38,7 @@ type UploadPlanItem = {
     reason?: string;
     itemId?: string;
     intentId?: string;
+    bundleId?: string;
 };
 
 type UploadPlanEntry = {
@@ -52,10 +55,18 @@ type IntentPackResult = {
     reason?: string;
 };
 
+type NteBundle = {
+    id: string;
+    memberClientIds: string[];
+    completeUrl: string;
+    abortUrl: string;
+    form: { token: string };
+};
+
 type HttpResult = {
     status: number;
     reason?: string;
-    payload?: { status?: string; results?: IntentPackResult[] };
+    payload?: { status?: string; results?: IntentPackResult[]; code?: string };
 };
 
 type PreparedUpload = {
@@ -66,6 +77,68 @@ type PreparedUpload = {
     payloadBytes: number;
     logicalSize: number;
 };
+
+export class UploadV2Error extends Error {
+    public readonly code: string;
+
+    public constructor(code: string, message = code) {
+        super(message);
+        this.name = "UploadV2Error";
+        this.code = code;
+    }
+}
+
+export function uploadErrorCode(error: unknown) {
+    if (typeof error !== "object" || error === null) return undefined;
+    const code = (error as { code?: unknown }).code;
+    return typeof code === "string" ? code : undefined;
+}
+
+export function paginateUploadFiles(files: FinalFile[], pageSize = PLAN_PAGE_SIZE) {
+    const grouped = new Map<string, FinalFile[]>();
+    const units: FinalFile[][] = [];
+
+    for (const file of files) {
+        const key = nteGroupKey(file);
+        if (!key) {
+            units.push([file]);
+            continue;
+        }
+        const group = grouped.get(key);
+        if (group) {
+            group.push(file);
+            continue;
+        }
+        const created = [file];
+        grouped.set(key, created);
+        units.push(created);
+    }
+
+    const pages: FinalFile[][] = [];
+    let page: FinalFile[] = [];
+    for (const unit of units) {
+        if (unit.length > pageSize) throw new UploadV2Error("nte_bundle_too_large");
+        if (page.length > 0 && page.length + unit.length > pageSize) {
+            pages.push(page);
+            page = [];
+        }
+        page.push(...unit);
+        if (page.length >= pageSize) {
+            pages.push(page);
+            page = [];
+        }
+    }
+    if (page.length > 0) pages.push(page);
+    return pages;
+}
+
+function nteGroupKey(file: FinalFile) {
+    const match = /^(.*)\.(pak|utoc|ucas)$/i.exec(file.name);
+    if (!match) return undefined;
+    const basename =
+        match[2].toLowerCase() === "ucas" ? match[1].replace(/_s[1-9]\d*$/i, "") : match[1];
+    return `${file.parentId}\0${basename.normalize("NFC").toLowerCase()}`;
+}
 
 export async function uploadDriveFilesV2({
     desktop,
@@ -90,12 +163,22 @@ export async function uploadDriveFilesV2({
     onPlanComplete?: () => void;
     signal?: AbortSignal;
 }) {
+    const oversized = files.find((file) => file.size > MAX_UPLOAD_FILE_SIZE);
+    if (oversized) {
+        throw new UploadV2Error(
+            "upload_file_too_large",
+            `${oversized.name}: upload_file_too_large`,
+        );
+    }
+
     const items: UploadPlanItem[] = [];
     const uploads = new Map<string, UploadPlanEntry>();
+    const nteBundles = new Map<string, NteBundle>();
 
     const url = `${BACKEND_URL}/akasha/v2/sse/drive/files:plan`;
-    const pages = chunk(files, PLAN_PAGE_SIZE);
-    for (const [pageIndex, page] of pages.entries()) {
+    const pages = paginateUploadFiles(files);
+    let plannedFiles = 0;
+    for (const page of pages) {
         signal?.throwIfAborted();
         const response = await networkFetch(url, {
             method: "POST",
@@ -106,6 +189,7 @@ export async function uploadDriveFilesV2({
             body: JSON.stringify({
                 requestId,
                 current: currentId,
+                capabilities: ["nte-bundle-v1"],
                 files: page.map((file) => ({
                     clientId: file.FID,
                     name: file.name,
@@ -119,7 +203,7 @@ export async function uploadDriveFilesV2({
         });
         if (!response.ok) {
             const body = await readApiBody(response).catch(() => response.statusText);
-            throw new Error(`[upload plan failed] ${toErrorMessage(body)}`);
+            throw apiError(body, `[upload plan failed] ${toErrorMessage(body)}`);
         }
         if (!response.body) {
             throw new Error("[upload plan failed] empty response stream");
@@ -127,7 +211,7 @@ export async function uploadDriveFilesV2({
 
         for await (const event of parseServerSentEvents(response)) {
             if (event.type === "error") {
-                throw new Error(`[upload plan failed] ${event.data}`);
+                throw apiError(parseEventData(event.data), `[upload plan failed] ${event.data}`);
             }
             if (event.type === "progress") {
                 const data = JSON.parse(event.data) as {
@@ -137,7 +221,7 @@ export async function uploadDriveFilesV2({
                 };
                 onPlanProgress?.({
                     phase: data.phase,
-                    processed: pageIndex * PLAN_PAGE_SIZE + data.processed,
+                    processed: plannedFiles + data.processed,
                     total: files.length,
                 });
             }
@@ -145,23 +229,51 @@ export async function uploadDriveFilesV2({
                 const data = JSON.parse(event.data) as {
                     items: UploadPlanItem[];
                     uploads: UploadPlanEntry[];
+                    nteBundles?: NteBundle[];
                 };
                 items.push(...data.items);
                 data.uploads.forEach((upload) => uploads.set(upload.intentId, upload));
+                data.nteBundles?.forEach((bundle) => nteBundles.set(bundle.id, bundle));
             }
         }
+        plannedFiles += page.length;
     }
 
     const filesById = new Map(files.map((file) => [file.FID, file]));
+    const bundleIdByClientId = new Map(
+        [...nteBundles.values()].flatMap((bundle) =>
+            bundle.memberClientIds.map((clientId) => [clientId, bundle.id] as const),
+        ),
+    );
+    items.forEach((item) => {
+        if (item.bundleId) bundleIdByClientId.set(item.clientId, item.bundleId);
+    });
     const pendingByIntent = new Map<string, FinalFile[]>();
     const rejected: UploadPlanItem[] = [];
     const returnedClientIds = new Set(items.map((item) => item.clientId));
+    const stagedClientIds = new Set<string>();
+    const bundleCreditedBytes = new Map<string, number>();
+    const reportFileBytes = (file: FinalFile, bytes: number, isServerDeduplicated: boolean) => {
+        const bundleId = bundleIdByClientId.get(file.FID);
+        if (bundleId) {
+            bundleCreditedBytes.set(bundleId, (bundleCreditedBytes.get(bundleId) ?? 0) + bytes);
+        }
+        onProgress?.({ bytes, isServerDeduplicated });
+    };
+    const markReady = (file: FinalFile, bytes: number, isServerDeduplicated: boolean) => {
+        if (bundleIdByClientId.has(file.FID)) {
+            stagedClientIds.add(file.FID);
+            reportFileBytes(file, bytes, isServerDeduplicated);
+            return;
+        }
+        onProgress?.({ bytes, fileId: file.FID, isServerDeduplicated });
+    };
 
     for (const item of items) {
         const file = filesById.get(item.clientId);
         if (!file) continue;
         if (item.status === "created" || item.status === "exists") {
-            onProgress?.({ bytes: file.size, fileId: file.FID, isServerDeduplicated: true });
+            markReady(file, file.size, true);
             continue;
         }
         if (item.status === "pending" && item.intentId) {
@@ -187,6 +299,76 @@ export async function uploadDriveFilesV2({
     onPlanComplete?.();
 
     const failures: Error[] = [];
+    const failedBundles = new Set<string>();
+    const bundleControllers = new Map(
+        [...nteBundles.keys()].map((bundleId) => [bundleId, new AbortController()]),
+    );
+    const abortRequests = new Map<string, Promise<void>>();
+    const abortBundle = (bundleId: string, reason: unknown) => {
+        const existing = abortRequests.get(bundleId);
+        if (existing) return existing;
+        bundleControllers.get(bundleId)?.abort(reason);
+        const bundle = nteBundles.get(bundleId);
+        if (!bundle) return Promise.resolve();
+        const request = sendJson(
+            desktop,
+            bundle.abortUrl,
+            { token: bundle.form.token },
+            AbortSignal.timeout(30_000),
+        ).then((result) => {
+            if (result.status < 200 || result.status >= 300) throw httpError(result);
+        });
+        abortRequests.set(bundleId, request);
+        return request;
+    };
+    const failTargets = (error: unknown, targets: FinalFile[], context: string) => {
+        const normalized = error instanceof Error ? error : new Error(String(error));
+        const bundleIds = new Set(
+            targets
+                .map((file) => bundleIdByClientId.get(file.FID))
+                .filter((bundleId): bundleId is string => bundleId !== undefined),
+        );
+        if (bundleIds.size === 0 || targets.some((file) => !bundleIdByClientId.has(file.FID))) {
+            failures.push(normalized);
+        }
+        for (const bundleId of bundleIds) {
+            if (failedBundles.has(bundleId)) continue;
+            failedBundles.add(bundleId);
+            failures.push(normalized);
+            void abortBundle(bundleId, normalized).catch((cleanupError) => {
+                desktop.logger.error(cleanupError, `UploadV2:bundle-abort:${bundleId}:${context}`);
+            });
+        }
+    };
+    const intentSignal = (targets: FinalFile[]) => {
+        const bundleIds = [
+            ...new Set(
+                targets
+                    .map((file) => bundleIdByClientId.get(file.FID))
+                    .filter((bundleId): bundleId is string => bundleId !== undefined),
+            ),
+        ];
+        if (bundleIds.length !== 1) return signal;
+        const bundleSignal = bundleControllers.get(bundleIds[0])?.signal;
+        if (!bundleSignal) return signal;
+        return signal ? AbortSignal.any([signal, bundleSignal]) : bundleSignal;
+    };
+    const markIntentReady = (source: FinalFile, copies: FinalFile[]) => {
+        markReady(source, 0, false);
+        copies.forEach((file) => markReady(file, file.size, true));
+    };
+    const multipartLimit = pLimit(MAX_MULTIPART_CONCURRENCY);
+    const rolledBackBundles = new Set<string>();
+    const rollbackFailedBundles = () => {
+        for (const bundleId of failedBundles) {
+            if (rolledBackBundles.has(bundleId)) continue;
+            rolledBackBundles.add(bundleId);
+            const credited = bundleCreditedBytes.get(bundleId) ?? 0;
+            if (credited > 0) {
+                onProgress?.({ bytes: -credited, isServerDeduplicated: false });
+            }
+        }
+    };
     const packed: PreparedUpload[] = [];
     const flushPacked = () => {
         const groups = partitionPackedUploads(packed.splice(0));
@@ -199,6 +381,7 @@ export async function uploadDriveFilesV2({
                             member: group.member,
                             signal,
                             onProgress,
+                            onIntentReady: markIntentReady,
                         });
                         return;
                     }
@@ -207,6 +390,7 @@ export async function uploadDriveFilesV2({
                         members: group.members,
                         signal,
                         onProgress,
+                        onIntentReady: markIntentReady,
                     });
                 } catch (error) {
                     if (!signal?.aborted) {
@@ -218,63 +402,204 @@ export async function uploadDriveFilesV2({
         }
     };
 
-    for (const [intentId, targets] of pendingByIntent.entries()) {
-        signal?.throwIfAborted();
-        const upload = uploads.get(intentId);
-        if (!upload) {
-            failures.push(new Error(`Upload intent missing for ${targets[0].name}`));
-            continue;
-        }
-        const source = targets[0];
-        if (source.size >= DIRECT_UPLOAD_THRESHOLD) {
-            void queue.add(async () => {
-                try {
-                    await uploadParts(desktop, upload, source, signal, (bytes) =>
-                        onProgress?.({ bytes, isServerDeduplicated: false }),
-                    );
-                    markIntentProgress(source, targets.slice(1), onProgress);
-                } catch (error) {
-                    if (!signal?.aborted) {
-                        desktop.logger.error(error, `UploadV2:intent:${intentId}`);
-                        failures.push(error instanceof Error ? error : new Error(String(error)));
-                    }
-                }
+    const abortAllBundles = () => {
+        nteBundles.forEach((bundle) => {
+            void abortBundle(bundle.id, signal?.reason).catch((cleanupError) => {
+                desktop.logger.error(cleanupError, `UploadV2:bundle-abort:${bundle.id}:cancel`);
             });
-            continue;
-        }
-        const prepared = await prepareDirectFile(source);
-        packed.push({
-            upload,
-            source,
-            copies: targets.slice(1),
-            prepared,
-            payloadBytes: prepared.data.byteLength,
-            logicalSize: source.size,
         });
-        const packedBytes = packed.reduce((sum, member) => sum + member.payloadBytes, 0);
-        if (packed.length >= PACK_MAX_FILES || packedBytes >= PACK_PAYLOAD_BUDGET) {
-            flushPacked();
-            await queue.onSizeLessThan(Math.max(1, queue.concurrency));
-            signal?.throwIfAborted();
-        }
-    }
-    flushPacked();
-    await queue.onIdle();
-    signal?.throwIfAborted();
-
-    if (rejected.length > 0) {
-        failures.push(
-            new Error(
-                rejected
-                    .map(
-                        (item) =>
-                            `${filesById.get(item.clientId)?.name ?? item.clientId}: ${item.reason ?? item.status}`,
-                    )
-                    .join(", "),
+    };
+    for (const item of rejected) {
+        const file = filesById.get(item.clientId);
+        if (!file || !bundleIdByClientId.has(file.FID)) continue;
+        failTargets(
+            new UploadV2Error(
+                item.reason ?? item.status,
+                `${file.name}: ${item.reason ?? item.status}`,
             ),
+            [file],
+            "plan",
         );
     }
-    if (failures.length > 0) throw new Error(failures.map((error) => error.message).join("\n"));
+    signal?.addEventListener("abort", abortAllBundles, { once: true });
+
+    try {
+        for (const [intentId, targets] of pendingByIntent.entries()) {
+            signal?.throwIfAborted();
+            const targetBundleIds = targets
+                .map((file) => bundleIdByClientId.get(file.FID))
+                .filter((bundleId): bundleId is string => bundleId !== undefined);
+            if (
+                targetBundleIds.length > 0 &&
+                targets.every((file) => bundleIdByClientId.has(file.FID)) &&
+                targetBundleIds.every((bundleId) => failedBundles.has(bundleId))
+            ) {
+                continue;
+            }
+            const upload = uploads.get(intentId);
+            if (!upload) {
+                if (targets.every((file) => bundleIdByClientId.has(file.FID))) {
+                    targets.forEach((file) => markReady(file, file.size, true));
+                    continue;
+                }
+                failures.push(new Error(`Upload intent missing for ${targets[0].name}`));
+                continue;
+            }
+            const source = targets[0];
+            const targetsSignal = intentSignal(targets);
+            if (source.size >= DIRECT_UPLOAD_THRESHOLD) {
+                void queue.add(async () => {
+                    try {
+                        await multipartLimit(() =>
+                            uploadParts(desktop, upload, source, targetsSignal, (bytes) =>
+                                reportFileBytes(source, bytes, false),
+                            ),
+                        );
+                        markIntentReady(source, targets.slice(1));
+                    } catch (error) {
+                        if (signal?.aborted) return;
+                        const targetBundleIds = targets
+                            .map((file) => bundleIdByClientId.get(file.FID))
+                            .filter((bundleId): bundleId is string => bundleId !== undefined);
+                        if (
+                            targetsSignal?.aborted &&
+                            targetBundleIds.every((id) => failedBundles.has(id))
+                        ) {
+                            return;
+                        }
+                        desktop.logger.error(error, `UploadV2:intent:${intentId}`);
+                        failTargets(error, targets, `intent:${intentId}`);
+                    }
+                });
+                continue;
+            }
+            let prepared: { data: Buffer; compAlg?: "zstd" };
+            try {
+                prepared = await prepareDirectFile(source);
+            } catch (error) {
+                failTargets(error, targets, `prepare:${intentId}`);
+                continue;
+            }
+            const member = {
+                upload,
+                source,
+                copies: targets.slice(1),
+                prepared,
+                payloadBytes: prepared.data.byteLength,
+                logicalSize: source.size,
+            };
+            if (targets.some((file) => bundleIdByClientId.has(file.FID))) {
+                void queue.add(async () => {
+                    try {
+                        await uploadPreparedIntent({
+                            desktop,
+                            member,
+                            signal: targetsSignal,
+                            onProgress: (progress) =>
+                                reportFileBytes(
+                                    source,
+                                    progress.bytes,
+                                    progress.isServerDeduplicated ?? false,
+                                ),
+                            onIntentReady: markIntentReady,
+                        });
+                    } catch (error) {
+                        if (signal?.aborted) return;
+                        const targetBundleIds = targets
+                            .map((file) => bundleIdByClientId.get(file.FID))
+                            .filter((bundleId): bundleId is string => bundleId !== undefined);
+                        if (
+                            targetsSignal?.aborted &&
+                            targetBundleIds.every((id) => failedBundles.has(id))
+                        ) {
+                            return;
+                        }
+                        desktop.logger.error(error, `UploadV2:intent:${intentId}`);
+                        failTargets(error, targets, `intent:${intentId}`);
+                    }
+                });
+                continue;
+            }
+            packed.push(member);
+            const packedBytes = packed.reduce((sum, entry) => sum + entry.payloadBytes, 0);
+            if (packed.length >= PACK_MAX_FILES || packedBytes >= PACK_PAYLOAD_BUDGET) {
+                flushPacked();
+                await queue.onSizeLessThan(Math.max(1, queue.concurrency));
+                signal?.throwIfAborted();
+            }
+        }
+        flushPacked();
+        await queue.onIdle();
+        signal?.throwIfAborted();
+        rollbackFailedBundles();
+
+        for (const bundle of nteBundles.values()) {
+            if (failedBundles.has(bundle.id)) continue;
+            const members = bundle.memberClientIds
+                .map((clientId) => filesById.get(clientId))
+                .filter((file): file is FinalFile => file !== undefined);
+            if (
+                members.length !== bundle.memberClientIds.length ||
+                members.some((file) => !stagedClientIds.has(file.FID))
+            ) {
+                const error = new UploadV2Error(
+                    "nte_bundle_incomplete",
+                    `${members[0]?.name ?? bundle.id}: nte_bundle_incomplete`,
+                );
+                failTargets(error, members, `complete:${bundle.id}`);
+                continue;
+            }
+            try {
+                await completeNteBundle(desktop, bundle, signal);
+                members.forEach((file) =>
+                    onProgress?.({ bytes: 0, fileId: file.FID, isServerDeduplicated: false }),
+                );
+            } catch (error) {
+                failTargets(error, members, `complete:${bundle.id}`);
+            }
+        }
+        rollbackFailedBundles();
+    } finally {
+        signal?.removeEventListener("abort", abortAllBundles);
+        if (signal?.aborted) {
+            abortAllBundles();
+            await Promise.allSettled(abortRequests.values());
+        }
+    }
+
+    if (rejected.length > 0) {
+        const message = rejected
+            .map(
+                (item) =>
+                    `${filesById.get(item.clientId)?.name ?? item.clientId}: ${item.reason ?? item.status}`,
+            )
+            .join(", ");
+        const code = rejected.find((item) => item.reason)?.reason;
+        failures.push(code ? new UploadV2Error(code, message) : new Error(message));
+    }
+    await Promise.allSettled(abortRequests.values());
+    if (failures.length > 0) {
+        const coded = failures.find((error) => uploadErrorCode(error));
+        if (coded) throw coded;
+        throw new Error(failures.map((error) => error.message).join("\n"));
+    }
+}
+
+async function completeNteBundle(desktop: NahidaDesktop, bundle: NteBundle, signal?: AbortSignal) {
+    const startedAt = Date.now();
+    for (let attempt = 0; Date.now() - startedAt < COMPLETE_TIMEOUT_MS; attempt++) {
+        signal?.throwIfAborted();
+        const result = await sendJson(
+            desktop,
+            bundle.completeUrl,
+            { token: bundle.form.token },
+            signal,
+        );
+        if (result.status >= 200 && result.status < 300 && result.status !== 202) return;
+        if (!isRetryable(result)) throw httpError(result);
+        await retryDelay(Math.min(attempt, 4), signal, 30_000);
+    }
+    throw new UploadV2Error("nte_bundle_incomplete");
 }
 
 async function uploadPreparedIntent({
@@ -282,17 +607,19 @@ async function uploadPreparedIntent({
     member,
     signal,
     onProgress,
+    onIntentReady,
 }: {
     desktop: NahidaDesktop;
     member: PreparedUpload;
     signal?: AbortSignal;
     onProgress?: (progress: UploadProgress) => void;
+    onIntentReady: (source: FinalFile, copies: FinalFile[]) => void;
 }) {
     signal?.throwIfAborted();
     await uploadDirect(desktop, member.upload, member.source, member.prepared, signal, (bytes) =>
         onProgress?.({ bytes, isServerDeduplicated: false }),
     );
-    markIntentProgress(member.source, member.copies, onProgress);
+    onIntentReady(member.source, member.copies);
 }
 
 async function uploadPack({
@@ -300,11 +627,13 @@ async function uploadPack({
     members,
     signal,
     onProgress,
+    onIntentReady,
 }: {
     desktop: NahidaDesktop;
     members: PreparedUpload[];
     signal?: AbortSignal;
     onProgress?: (progress: UploadProgress) => void;
+    onIntentReady: (source: FinalFile, copies: FinalFile[]) => void;
 }) {
     const pack = Buffer.concat(members.map((member) => member.prepared.data));
     const manifest = JSON.stringify({
@@ -355,7 +684,7 @@ async function uploadPack({
                             isServerDeduplicated: false,
                         });
                     }
-                    markIntentProgress(member.source, member.copies, onProgress);
+                    onIntentReady(member.source, member.copies);
                     return;
                 }
                 if (credited > 0) {
@@ -378,21 +707,6 @@ function packResultForIntent(results: IntentPackResult[], intentId: string) {
     const matches = results.filter((result) => result.intentId === intentId);
     if (matches.length !== 1) return undefined;
     return matches[0];
-}
-
-function markIntentProgress(
-    source: FinalFile,
-    copies: FinalFile[],
-    onProgress?: (progress: UploadProgress) => void,
-) {
-    onProgress?.({ bytes: 0, fileId: source.FID, isServerDeduplicated: false });
-    copies.forEach((file) =>
-        onProgress?.({
-            bytes: file.size,
-            fileId: file.FID,
-            isServerDeduplicated: true,
-        }),
-    );
 }
 
 async function uploadDirect(
@@ -449,6 +763,7 @@ async function uploadParts(
     signal?: AbortSignal,
     onProgress?: (bytes: number) => void,
 ) {
+    signal?.throwIfAborted();
     const totalParts = Math.ceil(file.size / PART_SIZE);
     let reportedBytes = 0;
     const reportProgress = (bytes: number) => {
@@ -462,6 +777,7 @@ async function uploadParts(
         const handle = await open(file.fullPath, "r");
         try {
             for (let index = 0; index < totalParts; index++) {
+                signal?.throwIfAborted();
                 const start = index * PART_SIZE;
                 const size = Math.min(PART_SIZE, file.size - start);
                 const buffer = Buffer.allocUnsafe(size);
@@ -705,7 +1021,31 @@ function isRetryable(result: HttpResult) {
 }
 
 function httpError(result: HttpResult) {
-    return new Error(result.reason ?? `http_${result.status}`);
+    const code = result.payload?.code ?? result.reason ?? `http_${result.status}`;
+    return new UploadV2Error(code);
+}
+
+function apiError(value: unknown, fallback: string) {
+    if (typeof value === "object" && value !== null) {
+        const body = value as Record<string, unknown>;
+        const code = [body.code, body.error, body.reason].find(
+            (candidate): candidate is string =>
+                typeof candidate === "string" && candidate.length > 0,
+        );
+        if (code) return new UploadV2Error(code, fallback);
+    }
+    if (typeof value === "string" && /^[a-z][a-z0-9_]+$/i.test(value)) {
+        return new UploadV2Error(value, fallback);
+    }
+    return new Error(fallback);
+}
+
+function parseEventData(value: string) {
+    try {
+        return JSON.parse(value) as unknown;
+    } catch {
+        return value;
+    }
 }
 
 function retryDelay(attempt: number, signal?: AbortSignal, cap = 8_000) {

--- a/src/main/lib/upload.test.ts
+++ b/src/main/lib/upload.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { FilesComponent } from "./upload";
 
-import { UploadLib, hasSystemFileSegment, isSystemFile } from "./upload";
+import { UploadLib, assignStableUploadFileIds, hasSystemFileSegment, isSystemFile } from "./upload";
 
 vi.mock("@native/fs", () => ({
     collectFiles: vi.fn(),
@@ -105,5 +105,52 @@ describe("UploadLib.collect", () => {
 
         expect(result.files.map((f) => f.path)).toEqual(["mods/real.png"]);
         expect(result.directories.map((d) => d.path)).toEqual(["mods"]);
+    });
+
+    it("passes case-insensitive NTE extensions to native collection", async () => {
+        vi.mocked(collectFiles).mockResolvedValue({
+            files: [file("mods/CHARACTER.UTOC", "CHARACTER.UTOC")],
+            directories: [{ path: "mods", name: "mods", parentPath: "" }],
+        });
+
+        const result = await new UploadLib({} as never).prepareUpload(["C:/folder"], []);
+
+        expect(collectFiles).toHaveBeenCalledWith(
+            ["C:/folder"],
+            expect.arrayContaining([".pak", ".utoc", ".ucas"]),
+        );
+        expect(result.files.map((entry) => entry.name)).toEqual(["CHARACTER.UTOC"]);
+    });
+
+    it("accepts an uppercase NTE extension for a directly selected file", async () => {
+        const result = await new UploadLib({} as never).prepareUpload(["C:/CHARACTER.PAK"], []);
+
+        expect(result.files).toHaveLength(1);
+        expect(result.files[0].name).toBe("CHARACTER.PAK");
+    });
+});
+
+describe("assignStableUploadFileIds", () => {
+    it("derives stable case-insensitive identities from relative paths", () => {
+        const first = assignStableUploadFileIds([
+            {
+                path: "Mods/Character.PAK",
+                name: "Character.PAK",
+                size: 10,
+                parentPath: "Mods",
+                fullPath: "C:/Mods/Character.PAK",
+            },
+        ])[0].FID;
+        const second = assignStableUploadFileIds([
+            {
+                path: "mods/character.pak",
+                name: "character.pak",
+                size: 10,
+                parentPath: "mods",
+                fullPath: "C:/mods/character.pak",
+            },
+        ])[0].FID;
+
+        expect(first).toBe(second);
     });
 });

--- a/src/main/lib/upload.ts
+++ b/src/main/lib/upload.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
 
 import sha256PiscinaWorker from "@main/worker/drive/sha256-piscina.worker?modulePath";
@@ -14,7 +14,7 @@ import Piscina from "piscina";
 
 import type { NahidaDesktop } from "..";
 
-import { uploadDriveFilesV2 } from "./upload-v2";
+import { uploadDriveFilesV2, uploadErrorCode } from "./upload-v2";
 
 const SYSTEM_FILE_PATTERNS = [
     /^\.DS_Store$/,
@@ -38,6 +38,19 @@ export function isSystemFile(name: string) {
 
 export function hasSystemFileSegment(path: string) {
     return path.split("/").some(isSystemFile);
+}
+
+export function assignStableUploadFileIds<T extends Omit<FilesComponent, "FID">>(files: T[]) {
+    const occurrences = new Map<string, number>();
+    return files.map((file) => {
+        const relativePath = file.path.replaceAll("\\", "/").toLowerCase();
+        const occurrence = occurrences.get(relativePath) ?? 0;
+        occurrences.set(relativePath, occurrence + 1);
+        return {
+            ...file,
+            FID: createHash("sha256").update(`${relativePath}\0${occurrence}`).digest("hex"),
+        };
+    });
 }
 
 export type FilesComponent = {
@@ -126,6 +139,9 @@ export class UploadLib {
             ".blend",
             ".pck",
             ".bin",
+            ".pak",
+            ".utoc",
+            ".ucas",
         ];
         const allowedExt = [...defaultAllowedExt, ...additionalExt].map((ext) =>
             ext.startsWith(".") ? ext.toLowerCase() : `.${ext.toLowerCase()}`,
@@ -183,15 +199,12 @@ export class UploadLib {
         const filteredDirectories = collected?.directories.filter(
             (dir) => !hasSystemFileSegment(dir.path),
         );
-        const files: FilesComponent[] = [...(filteredFiles ?? []), ...rootFiles].map((f) => ({
-            ...f,
-            FID: nanoid(),
-        }));
+        const files = assignStableUploadFileIds([...(filteredFiles ?? []), ...rootFiles]);
 
         return { files, directories: filteredDirectories ?? [] };
     }
 
-    private async isMediaByMagicNumbers(file: Buffer) {
+    private isMediaByMagicNumbers(file: Buffer) {
         const slicedBuffer = file.subarray(0, 8);
 
         const startsWith = (signature: number[]) => {
@@ -227,20 +240,11 @@ export class UploadLib {
 
         const fileSlice = file.subarray(0, 4100);
 
-        try {
-            const fileType = await fileTypeFromBuffer(fileSlice);
-            if (fileType) {
-                return fileType.mime.startsWith("image/") || fileType.mime.startsWith("video/");
-            }
-        } catch {}
-
-        if (await this.isMediaByMagicNumbers(fileSlice)) {
-            return true;
-        }
-
-        const fileType = await fileTypeFromBuffer(fileSlice);
-        const isByMimeType =
-            fileType && (fileType.mime.startsWith("image/") || fileType.mime.startsWith("video/"));
+        const fileType = await fileTypeFromBuffer(fileSlice).catch(() => undefined);
+        const isByMimeType = Boolean(
+            fileType && (fileType.mime.startsWith("image/") || fileType.mime.startsWith("video/")),
+        );
+        if (isByMimeType || this.isMediaByMagicNumbers(fileSlice)) return true;
 
         let isByName = false;
         if (name) {
@@ -249,7 +253,7 @@ export class UploadLib {
                 /\.(mp4|webm|ogg|mov|avi|flv|mkv)$/i.test(name);
         }
 
-        return isByMimeType || isByName;
+        return isByName;
     }
 
     public async calculateHashes(
@@ -270,6 +274,7 @@ export class UploadLib {
             return piscina
                 .run({ path: file.fullPath }, { signal })
                 .then((hash: string) => {
+                    signal?.throwIfAborted();
                     processedCount++;
                     const now = Date.now();
 
@@ -281,6 +286,7 @@ export class UploadLib {
                     return { ...file, sha256: hash };
                 })
                 .catch((err) => {
+                    if (signal?.aborted) throw signal.reason;
                     throw new Error(`Failed to hash ${file.name}: ${err}`);
                 });
         });
@@ -458,7 +464,12 @@ export class UploadLib {
                     return { ...f, sha256: hash };
                 });
             } else if (processedFiles && processedFiles.length === parentIdProcessedFiles.length) {
-                finalFiles = processedFiles;
+                const hashes = new Map(processedFiles.map((file) => [file.FID, file.sha256]));
+                finalFiles = parentIdProcessedFiles.map((file) => {
+                    const hash = hashes.get(file.FID);
+                    if (!hash) throw new Error(`Hash missing for file ${file.name}`);
+                    return { ...file, sha256: hash };
+                });
             } else {
                 finalFiles = await this.calculateHashes(
                     parentIdProcessedFiles,
@@ -512,6 +523,7 @@ export class UploadLib {
                     files: finalFiles,
                     totalSize,
                     onProgress: (progress: UploadProgress) => {
+                        if (abortController.signal.aborted) return;
                         if (progress.fileId) {
                             this.desktop.service.transfer.markFileCompleted(pid, progress.fileId);
                             currentUploadedCount++;
@@ -519,6 +531,7 @@ export class UploadLib {
                         currentUploadedBytes += progress.bytes;
                     },
                     onPlanProgress: (progress) => {
+                        if (abortController.signal.aborted) return;
                         void this.desktop.service.transfer.updateTransfer(pid, {
                             planPhase: progress.phase,
                             planProgress:
@@ -528,6 +541,7 @@ export class UploadLib {
                         });
                     },
                     onPlanComplete: () => {
+                        if (abortController.signal.aborted) return;
                         void this.desktop.service.transfer.updateTransfer(pid, {
                             status: "progress",
                             transferedSize: currentUploadedBytes,
@@ -563,6 +577,7 @@ export class UploadLib {
             void this.desktop.service.transfer.updateTransfer(pid, {
                 status: "error",
                 error: toErrorMessage(err),
+                errorCode: uploadErrorCode(err),
             });
             throw err;
         }

--- a/src/main/services/drive-upload.test.ts
+++ b/src/main/services/drive-upload.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { NahidaDesktop } from "..";
+
+import { DriveService } from "./drive";
+
+vi.mock("@main/client", () => ({
+    eden: {
+        akasha: {
+            content: vi.fn(() => ({ get: vi.fn() })),
+        },
+    },
+}));
+
+vi.mock("electron", () => ({
+    dialog: { showOpenDialog: vi.fn() },
+}));
+
+vi.mock("./util", () => ({
+    processChunked: vi.fn(),
+}));
+
+vi.mock("@native/fs", () => ({
+    collectFiles: vi.fn(),
+}));
+
+vi.mock("@main/worker/drive/sha256-piscina.worker?modulePath", () => ({
+    default: "mock-worker",
+}));
+
+describe("DriveService upload source validation", () => {
+    it("requires source paths to be readable without requiring write access", async () => {
+        const isPathReadable = vi.fn().mockResolvedValue(false);
+        const service = new DriveService({
+            window: { main: { window: {} } },
+            lib: { fs: { isPathReadable } },
+        } as unknown as NahidaDesktop);
+
+        await expect(
+            service.fn.startUpload({ destId: "destination", paths: ["C:/Mods"] }),
+        ).rejects.toThrow("Path is not readable");
+        expect(isPathReadable).toHaveBeenCalledWith("C:/Mods");
+    });
+});

--- a/src/main/services/drive.ts
+++ b/src/main/services/drive.ts
@@ -16,6 +16,7 @@ import Upload, {
     type UploadConflictStrategy,
     type UploadParams,
 } from "@main/lib/upload";
+import { uploadErrorCode } from "@main/lib/upload-v2";
 import type { LinkData } from "@main/server";
 import { BACKEND_URL } from "@shared/const";
 import type { DownloadSource } from "@shared/mod";
@@ -318,10 +319,12 @@ export class DriveService {
                 preparation,
                 abortController,
             }).catch((err) => {
+                if (abortController.signal.aborted) return;
                 this.desktop.logger.error(err, "Drive:Upload:Preprocessing");
                 void this.desktop.service.transfer.updateTransfer(pid, {
                     status: "error",
                     error: toErrorMessage(err),
+                    errorCode: uploadErrorCode(err),
                 });
             });
         },
@@ -1679,9 +1682,9 @@ export class DriveService {
             selectedPaths = dialogResult.filePaths;
         }
 
-        const isWritable = this.desktop.lib.fs.isPathWritable(selectedPaths[0]);
-        if (!isWritable) {
-            throw new Error("Path is not writable");
+        const isReadable = await this.desktop.lib.fs.isPathReadable(selectedPaths[0]);
+        if (!isReadable) {
+            throw new Error("Path is not readable");
         }
 
         return selectedPaths;
@@ -1745,6 +1748,7 @@ export class DriveService {
         pid,
         restartParams,
         preparation,
+        abortController,
     }: {
         currentId: string;
         pid: string;
@@ -1768,11 +1772,17 @@ export class DriveService {
             })),
         );
 
-        const hashedFiles = await this.upload.calculateHashes(dummyFiles, (count) => {
-            void this.desktop.service.transfer.updateTransfer(pid, {
-                transferedFiles: count,
-            });
-        });
+        const hashedFiles = await this.upload.calculateHashes(
+            dummyFiles,
+            (count) => {
+                if (abortController.signal.aborted) return;
+                void this.desktop.service.transfer.updateTransfer(pid, {
+                    transferedFiles: count,
+                });
+            },
+            abortController.signal,
+        );
+        abortController.signal.throwIfAborted();
         const fileHashes: Record<string, string> = {};
         hashedFiles.forEach((f) => {
             fileHashes[f.FID] = f.sha256;

--- a/src/main/services/transfer.ts
+++ b/src/main/services/transfer.ts
@@ -20,6 +20,7 @@ export interface LocalTransfer extends Transfer {
     sessionStartBytes: number;
     speedSamples: Array<{ timestamp: number; bytes: number }>;
     error?: string;
+    errorCode?: string;
 }
 
 const MIB = 1024 * 1024;
@@ -379,6 +380,7 @@ export class TransferService {
 
         transfer.failedFiles = 0;
         transfer.error = undefined;
+        transfer.errorCode = undefined;
         this.emitUpdate();
         void this.processQueue();
     }
@@ -537,6 +539,7 @@ export class TransferService {
             transfer.transferedFiles = 0;
             transfer.failedFiles = 0;
             transfer.error = undefined;
+            transfer.errorCode = undefined;
             this.emitUpdate();
         }
     }

--- a/src/renderer/src/components/transfer/transfer-item.tsx
+++ b/src/renderer/src/components/transfer/transfer-item.tsx
@@ -35,6 +35,7 @@ const TransferItemActions = memo(
     onCancel,
     onRetry,
     failedFiles,
+    errorCode,
   }: Pick<
     TransferItemProps,
     | "id"
@@ -46,6 +47,7 @@ const TransferItemActions = memo(
     | "onCancel"
     | "onRetry"
     | "failedFiles"
+    | "errorCode"
   >) => {
     const { t } = useTranslation();
 
@@ -55,6 +57,9 @@ const TransferItemActions = memo(
     const isFailed = status === "failed";
     const isCompleted = status === "completed";
     const hasFailedFiles = (failedFiles || 0) > 0;
+    const canRetry = !["invalid_nte_mod_file", "nte_client_upgrade_required"].includes(
+      errorCode ?? "",
+    );
 
     return (
       <div className="flex shrink-0 items-center gap-1">
@@ -69,7 +74,7 @@ const TransferItemActions = memo(
           </Button>
         )}
 
-        {isFailed && (
+        {isFailed && canRetry && (
           <Button
             variant="ghost"
             size="icon"
@@ -111,12 +116,12 @@ const TransferItemActions = memo(
                 {t("page.transfer.item.dropdown_menu.cancel")}
               </DropdownMenuItem>
             )}
-            {isFailed && (
+            {isFailed && canRetry && (
               <DropdownMenuItem onClick={() => onRetry?.(id)}>
                 {t("page.transfer.item.dropdown_menu.retry")}
               </DropdownMenuItem>
             )}
-            {!isFailed && hasFailedFiles && (
+            {!isFailed && hasFailedFiles && canRetry && (
               <DropdownMenuItem onClick={() => onRetry?.(id)}>
                 {t("page.transfer.item.dropdown_menu.retry_failed_files")}
               </DropdownMenuItem>
@@ -160,6 +165,7 @@ export const TransferItem = memo((props: TransferItemProps) => {
     processedFiles,
     failedFiles,
     error,
+    errorCode,
     planPhase,
     planProgress,
   } = props;
@@ -170,6 +176,9 @@ export const TransferItem = memo((props: TransferItemProps) => {
   const isCompleted = status === "completed";
   const isFailed = status === "failed";
   const isPlanning = status === "uploading" && planPhase != null;
+  const translatedError = errorCode
+    ? t(`page.transfer.item.error.${errorCode}`, { defaultValue: error ?? errorCode })
+    : error;
 
   return (
     <div className="group grid w-full max-w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-4 overflow-hidden rounded-lg border bg-card p-4 transition-all hover:border-accent">
@@ -215,7 +224,7 @@ export const TransferItem = memo((props: TransferItemProps) => {
                       {t(`page.transfer.item.${status}`)}
                     </span>
                   </DialogTrigger>
-                  <DialogContent>{error}</DialogContent>
+                  <DialogContent>{translatedError}</DialogContent>
                 </Dialog>
               );
             } else {
@@ -281,6 +290,7 @@ export const TransferItem = memo((props: TransferItemProps) => {
         onCancel={onCancel}
         onRetry={onRetry}
         failedFiles={failedFiles}
+        errorCode={errorCode}
       />
     </div>
   );

--- a/src/renderer/src/components/transfer/transfer-item.tsx
+++ b/src/renderer/src/components/transfer/transfer-item.tsx
@@ -57,9 +57,12 @@ const TransferItemActions = memo(
     const isFailed = status === "failed";
     const isCompleted = status === "completed";
     const hasFailedFiles = (failedFiles || 0) > 0;
-    const canRetry = !["invalid_nte_mod_file", "nte_client_upgrade_required"].includes(
-      errorCode ?? "",
-    );
+    const canRetry = ![
+      "invalid_nte_mod_file",
+      "nte_client_upgrade_required",
+      "upload_file_too_large",
+      "nte_bundle_too_large",
+    ].includes(errorCode ?? "");
 
     return (
       <div className="flex shrink-0 items-center gap-1">

--- a/src/renderer/src/components/transfer/types.ts
+++ b/src/renderer/src/components/transfer/types.ts
@@ -30,6 +30,7 @@ export interface TransferItemProps {
     processedFiles?: number;
     failedFiles?: number;
     error?: string;
+    errorCode?: string;
     planPhase?: PlanPhase;
     planProgress?: number | null;
 }

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -80,7 +80,8 @@
           "nte_client_upgrade_required": "Update the desktop app to upload NTE mods.",
           "nte_bundle_incomplete": "Not all required NTE mod files were uploaded.",
           "bundle_cleanup_failed": "Failed to clean up temporary NTE mod uploads.",
-          "upload_file_too_large": "A single file cannot exceed 1 GiB."
+          "upload_file_too_large": "A single file cannot exceed 1 GiB.",
+          "nte_bundle_too_large": "This NTE mod has too many files to upload as one group."
         },
         "time_remaining": "{{time}} remaining",
         "time_elapsed": "{{time}} elapsed",

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -75,6 +75,13 @@
           "dedup_lookup": "Checking duplicates",
           "processing": "Processing files"
         },
+        "error": {
+          "invalid_nte_mod_file": "This is not a valid NTE mod file.",
+          "nte_client_upgrade_required": "Update the desktop app to upload NTE mods.",
+          "nte_bundle_incomplete": "Not all required NTE mod files were uploaded.",
+          "bundle_cleanup_failed": "Failed to clean up temporary NTE mod uploads.",
+          "upload_file_too_large": "A single file cannot exceed 1 GiB."
+        },
         "time_remaining": "{{time}} remaining",
         "time_elapsed": "{{time}} elapsed",
         "failed_files": "{{count}} failed",

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -75,6 +75,13 @@
           "dedup_lookup": "重複を確認中",
           "processing": "ファイルを処理中"
         },
+        "error": {
+          "invalid_nte_mod_file": "有効なNTE Modファイルではありません。",
+          "nte_client_upgrade_required": "NTE Modをアップロードするにはデスクトップアプリを更新してください。",
+          "nte_bundle_incomplete": "NTE Modに必要なファイルがすべてアップロードされていません。",
+          "bundle_cleanup_failed": "NTE Modの一時アップロードファイルを削除できませんでした。",
+          "upload_file_too_large": "1つのファイルは1 GiBを超えることができません。"
+        },
         "time_remaining": "残り {{time}}",
         "time_elapsed": "経過 {{time}}",
         "failed_files": "{{count}}個 失敗",

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -80,7 +80,8 @@
           "nte_client_upgrade_required": "NTE Modをアップロードするにはデスクトップアプリを更新してください。",
           "nte_bundle_incomplete": "NTE Modに必要なファイルがすべてアップロードされていません。",
           "bundle_cleanup_failed": "NTE Modの一時アップロードファイルを削除できませんでした。",
-          "upload_file_too_large": "1つのファイルは1 GiBを超えることができません。"
+          "upload_file_too_large": "1つのファイルは1 GiBを超えることができません。",
+          "nte_bundle_too_large": "このNTE Modはファイル数が多すぎて1つのグループとしてアップロードできません。"
         },
         "time_remaining": "残り {{time}}",
         "time_elapsed": "経過 {{time}}",

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -75,6 +75,13 @@
           "dedup_lookup": "중복 확인 중",
           "processing": "파일 처리 중"
         },
+        "error": {
+          "invalid_nte_mod_file": "유효한 NTE 모드 파일이 아닙니다.",
+          "nte_client_upgrade_required": "NTE 모드 업로드를 사용하려면 데스크톱 앱을 업데이트해야 합니다.",
+          "nte_bundle_incomplete": "NTE 모드에 필요한 파일이 모두 업로드되지 않았습니다.",
+          "bundle_cleanup_failed": "NTE 모드 임시 업로드 파일을 정리하지 못했습니다.",
+          "upload_file_too_large": "단일 파일은 1GiB를 초과할 수 없습니다."
+        },
         "time_remaining": "{{time}} 남음",
         "time_elapsed": "{{time}} 경과",
         "failed_files": "{{count}}개 실패",

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -80,7 +80,8 @@
           "nte_client_upgrade_required": "NTE 모드 업로드를 사용하려면 데스크톱 앱을 업데이트해야 합니다.",
           "nte_bundle_incomplete": "NTE 모드에 필요한 파일이 모두 업로드되지 않았습니다.",
           "bundle_cleanup_failed": "NTE 모드 임시 업로드 파일을 정리하지 못했습니다.",
-          "upload_file_too_large": "단일 파일은 1GiB를 초과할 수 없습니다."
+          "upload_file_too_large": "단일 파일은 1GiB를 초과할 수 없습니다.",
+          "nte_bundle_too_large": "이 NTE 모드는 파일이 너무 많아 한 그룹으로 업로드할 수 없습니다."
         },
         "time_remaining": "{{time}} 남음",
         "time_elapsed": "{{time}} 경과",

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -80,7 +80,8 @@
           "nte_client_upgrade_required": "请更新桌面应用后再上传 NTE 模组。",
           "nte_bundle_incomplete": "NTE 模组所需文件尚未全部上传。",
           "bundle_cleanup_failed": "无法清理 NTE 模组的临时上传文件。",
-          "upload_file_too_large": "单个文件不能超过 1 GiB。"
+          "upload_file_too_large": "单个文件不能超过 1 GiB。",
+          "nte_bundle_too_large": "此 NTE 模组文件过多，无法作为一组上传。"
         },
         "time_remaining": "剩余 {{time}}",
         "time_elapsed": "经过 {{time}}",

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -75,6 +75,13 @@
           "dedup_lookup": "正在检查重复",
           "processing": "正在处理文件"
         },
+        "error": {
+          "invalid_nte_mod_file": "这不是有效的 NTE 模组文件。",
+          "nte_client_upgrade_required": "请更新桌面应用后再上传 NTE 模组。",
+          "nte_bundle_incomplete": "NTE 模组所需文件尚未全部上传。",
+          "bundle_cleanup_failed": "无法清理 NTE 模组的临时上传文件。",
+          "upload_file_too_large": "单个文件不能超过 1 GiB。"
+        },
         "time_remaining": "剩余 {{time}}",
         "time_elapsed": "经过 {{time}}",
         "failed_files": "{{count}} 个失败",

--- a/src/renderer/src/routes/transfer.tsx
+++ b/src/renderer/src/routes/transfer.tsx
@@ -86,6 +86,7 @@ function RouteComponent() {
       processedFiles: t.transferedFiles,
       failedFiles: t.failedFiles,
       error: t.error,
+      errorCode: t.errorCode,
       planPhase: t.planPhase,
       planProgress: t.planProgress,
     };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -532,6 +532,7 @@ export interface Transfer {
     failedFiles: number;
     path?: string;
     error?: string;
+    errorCode?: string;
     planPhase?: PlanPhase;
     planProgress?: number | null;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the core upload pipeline (planning, progress, abort, and error reporting). Bundle complete/abort and progress rollback are easy to get wrong, but this is not auth or payment logic.
> 
> **Overview**
> Enables **NTE mod uploads** (`.pak` / `.utoc` / `.ucas`) as server-side bundles. Plan requests advertise `nte-bundle-v1`, keep related files on the same 500-file page, stage members without marking them complete, then finalize (or abort and roll back progress) as a group.
> 
> Adds a **1 GiB per-file cap**, caps multipart concurrency at 4, and uses stable case-insensitive file IDs instead of random `nanoid`s. Failures now carry structured `errorCode`s (localized in the transfer UI); retry is hidden for codes that cannot succeed on retry.
> 
> Also checks upload sources for **read** access instead of write, and is more careful about aborting hashing/progress updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9d740b1f8b87a8b835286235de79c10f45e5b56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for NTE bundle uploads, including pagination, completion tracking, cancellation, and rollback.
  * Added deterministic file identification and support for `.pak`, `.utoc`, and `.ucas` files.
  * Added upload size limits, bounded multipart concurrency, and structured error reporting.
* **Bug Fixes**
  * Improved cancellation, restart handling, progress reporting, media detection, and path validation.
  * Added validation for invalid, incomplete, oversized, or over-limit bundles.
* **User Experience**
  * Added localized transfer error messages in English, Japanese, Korean, and Chinese.
  * Retry controls are hidden when retrying cannot resolve the reported error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->