### PR TITLE
fix(nte): list wrapped pak folders in the parent mod grid

### DIFF
--- a/src/main/services/mod-manager/mod-actions.ts
+++ b/src/main/services/mod-manager/mod-actions.ts
@@ -300,8 +300,9 @@ export class ModActionsService {
     }
 
     private async exclusiveToggleNte(modPath: string, game: GameConfig) {
+        const roots = getNteRoots(game);
         if (!(await isNteModEnabled(modPath))) {
-            await this.setAllNte(await getNteListingGroupPath(modPath), game, false);
+            await this.setAllNte(await getNteListingGroupPath(roots, modPath), game, false);
             return await setNteModEnabled(this.desktop, modPath, true);
         }
 
@@ -315,7 +316,7 @@ export class ModActionsService {
         if (!(await this.desktop.lib.fs.pathExists(groupDir))) return;
 
         await Promise.all(
-            (await listNteModPaths(groupDir)).map(async (modPath) => {
+            (await listNteModPaths(roots, groupDir)).map(async (modPath) => {
                 try {
                     const currentlyEnabled = await isNteModEnabled(modPath);
                     if (currentlyEnabled === enabled) return;

--- a/src/main/services/mod-manager/mod-actions.ts
+++ b/src/main/services/mod-manager/mod-actions.ts
@@ -11,9 +11,10 @@ import type { ShaderFixesProcessedFile } from "./shader-fixes";
 import {
     findNteGameByPath,
     getNteGroupRelativePath,
+    getNteListingGroupPath,
     getNteRoots,
-    hasNteDirectPak,
     isNteModEnabled,
+    listNteModPaths,
     setNteModEnabled,
 } from "./nte";
 import {
@@ -299,14 +300,8 @@ export class ModActionsService {
     }
 
     private async exclusiveToggleNte(modPath: string, game: GameConfig) {
-        const roots = getNteRoots(game);
-
         if (!(await isNteModEnabled(modPath))) {
-            await this.setAllNte(
-                path.dirname(path.join(roots.modRoot, getNteGroupRelativePath(roots, modPath))),
-                game,
-                false,
-            );
+            await this.setAllNte(await getNteListingGroupPath(modPath), game, false);
             return await setNteModEnabled(this.desktop, modPath, true);
         }
 
@@ -320,11 +315,8 @@ export class ModActionsService {
         if (!(await this.desktop.lib.fs.pathExists(groupDir))) return;
 
         await Promise.all(
-            (await this.desktop.lib.fs.listDirectories(groupDir)).map(async (folderName) => {
-                const modPath = path.join(groupDir, folderName);
+            (await listNteModPaths(groupDir)).map(async (modPath) => {
                 try {
-                    if (!(await hasNteDirectPak(modPath))) return;
-
                     const currentlyEnabled = await isNteModEnabled(modPath);
                     if (currentlyEnabled === enabled) return;
 

--- a/src/main/services/mod-manager/nte.test.ts
+++ b/src/main/services/mod-manager/nte.test.ts
@@ -67,9 +67,9 @@ describe("NTE wrapped pak folders", () => {
             group.mods.find((mod) => mod.name === "Shinku Natsu Sparkle 1.3 / shinku")?.preview,
             path.join(sparkle, "preview.png"),
         );
-        assert.deepEqual(await listNteModPaths(shinku), [disabledShinku, inner, burst]);
-        assert.equal(await getNteListingGroupPath(inner), shinku);
-        assert.equal(await getNteListingGroupPath(disabledShinku), shinku);
+        assert.deepEqual(await listNteModPaths(roots, shinku), [disabledShinku, inner, burst]);
+        assert.equal(await getNteListingGroupPath(roots, inner), shinku);
+        assert.equal(await getNteListingGroupPath(roots, disabledShinku), shinku);
     });
 
     it("does not list a pak wrapper as a subgroup", async () => {
@@ -118,10 +118,15 @@ describe("NTE wrapped pak folders", () => {
         const npc = path.join(modRoot, "NPC");
         const shopGirl = path.join(npc, "NPC_Shop Girl");
         await writePak(shopGirl, "NPC_023_NSFW_P.pak");
+        await writePak(
+            path.join(modRoot, "Character", "Shinku", "DISABLED Shinku"),
+            "mod_P.pak.disabled",
+        );
 
         const roots = { modRoot, linkedRoot: null };
         const group = await getNteMods(desktopStub(), roots, npc);
         const npcGroups = await getNteSubGroups(desktopStub(), roots, npc);
+        const rootGroups = await getNteSubGroups(desktopStub(), roots, modRoot);
 
         assert.deepEqual(
             group.mods.map((mod) => ({ name: mod.name, isEnabled: mod.isEnabled })),
@@ -131,6 +136,33 @@ describe("NTE wrapped pak folders", () => {
             npcGroups.map((entry) => entry.name),
             [],
         );
+        assert.deepEqual(
+            rootGroups.map((entry) => entry.name),
+            ["Character", "NPC"],
+        );
+        assert.equal(await getNteListingGroupPath(roots, shopGirl), npc);
+    });
+
+    it("keeps a character folder as a group when every child is a direct pak mod", async () => {
+        const modRoot = await makeModRoot();
+        const character = path.join(modRoot, "Character");
+        const shinku = path.join(character, "Shinku");
+        await writePak(path.join(shinku, "DISABLED Shinku"), "mod_P.pak.disabled");
+        await writePak(path.join(shinku, "DISABLED ShinkuSwim"), "mod_P.pak.disabled");
+
+        const roots = { modRoot, linkedRoot: null };
+        const characterMods = await getNteMods(desktopStub(), roots, character);
+        const characterGroups = await getNteSubGroups(desktopStub(), roots, character);
+
+        assert.deepEqual(
+            characterMods.mods.map((mod) => mod.name),
+            [],
+        );
+        assert.deepEqual(
+            characterGroups.map((group) => group.name),
+            ["Shinku"],
+        );
+        assert.equal(characterGroups[0]?.modCount, 2);
     });
 
     it("flattens variant wrappers like longhairdaff without collapsing them into one toggle", async () => {

--- a/src/main/services/mod-manager/nte.test.ts
+++ b/src/main/services/mod-manager/nte.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+
+import fse from "fs-extra";
+import { afterEach, describe, it } from "vitest";
+
+import type { NahidaDesktop } from "../..";
+
+import { getNteListingGroupPath, getNteMods, getNteSubGroups, listNteModPaths } from "./nte.ts";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+    await Promise.all(tempRoots.splice(0).map((root) => fse.remove(root)));
+});
+
+async function makeModRoot() {
+    const root = await fse.mkdtemp(path.join(os.tmpdir(), "nhd-nte-"));
+    tempRoots.push(root);
+    return root;
+}
+
+async function writePak(dirPath: string, fileName: string) {
+    await fse.ensureDir(dirPath);
+    await fse.writeFile(path.join(dirPath, fileName), "pak");
+}
+
+function desktopStub() {
+    return {
+        lib: {
+            fs: {
+                getFolderSize: async () => 1,
+            },
+        },
+    } as unknown as NahidaDesktop;
+}
+
+describe("NTE wrapped pak folders", () => {
+    it("flattens a wrapper with inner pak folders into the parent mod list", async () => {
+        const modRoot = await makeModRoot();
+        const shinku = path.join(modRoot, "Character", "Shinku");
+        const sparkle = path.join(shinku, "Shinku Natsu Sparkle 1.3");
+        const disabledShinku = path.join(shinku, "DISABLED Shinku");
+        const inner = path.join(sparkle, "shinku");
+        const burst = path.join(sparkle, "shinku burst");
+
+        await writePak(disabledShinku, "mod_P.pak.disabled");
+        await writePak(inner, "Shinku Natsu Sparkle_P.pak");
+        await writePak(burst, "Shinku Natsu Sparkle burst_P.pak");
+        await fse.writeFile(path.join(sparkle, "preview.png"), "preview");
+
+        const roots = { modRoot, linkedRoot: null };
+        const group = await getNteMods(desktopStub(), roots, shinku);
+
+        assert.deepEqual(
+            group.mods.map((mod) => ({ name: mod.name, isEnabled: mod.isEnabled })),
+            [
+                { name: "DISABLED Shinku", isEnabled: false },
+                { name: "Shinku Natsu Sparkle 1.3 / shinku", isEnabled: true },
+                { name: "Shinku Natsu Sparkle 1.3 / shinku burst", isEnabled: true },
+            ],
+        );
+        assert.equal(group.modCount, 3);
+        assert.equal(group.enabledModCount, 2);
+        assert.equal(
+            group.mods.find((mod) => mod.name === "Shinku Natsu Sparkle 1.3 / shinku")?.preview,
+            path.join(sparkle, "preview.png"),
+        );
+        assert.deepEqual(await listNteModPaths(shinku), [disabledShinku, inner, burst]);
+        assert.equal(await getNteListingGroupPath(inner), shinku);
+        assert.equal(await getNteListingGroupPath(disabledShinku), shinku);
+    });
+
+    it("does not list a pak wrapper as a subgroup", async () => {
+        const modRoot = await makeModRoot();
+        const shinku = path.join(modRoot, "Character", "Shinku");
+        await writePak(path.join(shinku, "DISABLED Shinku"), "mod_P.pak.disabled");
+        await writePak(
+            path.join(shinku, "Shinku Natsu Sparkle 1.3", "shinku"),
+            "Shinku Natsu Sparkle_P.pak",
+        );
+
+        const groups = await getNteSubGroups(desktopStub(), { modRoot, linkedRoot: null }, shinku);
+
+        assert.deepEqual(
+            groups.map((group) => group.name),
+            [],
+        );
+    });
+
+    it("keeps a character folder as a group when it contains both mods and wrappers", async () => {
+        const modRoot = await makeModRoot();
+        const character = path.join(modRoot, "Character");
+        const shinku = path.join(character, "Shinku");
+        await writePak(path.join(shinku, "DISABLED Shinku"), "mod_P.pak.disabled");
+        await writePak(
+            path.join(shinku, "Shinku Natsu Sparkle 1.3", "shinku"),
+            "Shinku Natsu Sparkle_P.pak",
+        );
+
+        const roots = { modRoot, linkedRoot: null };
+        const characterMods = await getNteMods(desktopStub(), roots, character);
+        const characterGroups = await getNteSubGroups(desktopStub(), roots, character);
+        const shinkuGroup = characterGroups.find((group) => group.name === "Shinku");
+
+        assert.deepEqual(
+            characterMods.mods.map((mod) => mod.name),
+            [],
+        );
+        assert.equal(shinkuGroup?.modCount, 2);
+        assert.equal(shinkuGroup?.enabledModCount, 1);
+        assert.equal(shinkuGroup?.hasSubGroups, false);
+    });
+
+    it("still lists NPC mods that have a pak in the folder itself", async () => {
+        const modRoot = await makeModRoot();
+        const npc = path.join(modRoot, "NPC");
+        const shopGirl = path.join(npc, "NPC_Shop Girl");
+        await writePak(shopGirl, "NPC_023_NSFW_P.pak");
+
+        const roots = { modRoot, linkedRoot: null };
+        const group = await getNteMods(desktopStub(), roots, npc);
+        const npcGroups = await getNteSubGroups(desktopStub(), roots, npc);
+
+        assert.deepEqual(
+            group.mods.map((mod) => ({ name: mod.name, isEnabled: mod.isEnabled })),
+            [{ name: "NPC_Shop Girl", isEnabled: true }],
+        );
+        assert.deepEqual(
+            npcGroups.map((entry) => entry.name),
+            [],
+        );
+    });
+
+    it("flattens variant wrappers like longhairdaff without collapsing them into one toggle", async () => {
+        const modRoot = await makeModRoot();
+        const daffodil = path.join(modRoot, "Character", "Daffodil");
+        await writePak(path.join(daffodil, "longhairdaff", "Alt Skin"), "mod_P.pak");
+        await writePak(path.join(daffodil, "longhairdaff", "Default Skin"), "mod_P.pak");
+
+        const group = await getNteMods(desktopStub(), { modRoot, linkedRoot: null }, daffodil);
+
+        assert.deepEqual(
+            group.mods.map((mod) => mod.name),
+            ["longhairdaff / Alt Skin", "longhairdaff / Default Skin"],
+        );
+        assert.equal(
+            group.mods.every((mod) => mod.isEnabled),
+            true,
+        );
+    });
+});

--- a/src/main/services/mod-manager/nte.ts
+++ b/src/main/services/mod-manager/nte.ts
@@ -175,6 +175,7 @@ export async function getNteSubGroups(
             const nextPath = path.join(groupDir, groupName);
 
             if (await hasDirectPak(nextPath)) return null;
+            if (await isNtePakWrapper(nextPath)) return null;
 
             const preview = await findPreview(nextPath);
             const modCounts = await countDirectMods(nextPath);
@@ -201,19 +202,16 @@ export async function getNteMods(
 ): Promise<FolderGroup> {
     const relativePath = getNteRelativePath(roots, groupPath);
     const groupDir = path.join(roots.modRoot, relativePath);
-    const modNames = await listDirectoryNames(groupDir);
     const mods = (
         await Promise.all(
-            modNames.map(async (modName) => {
-                const modPath = path.join(groupDir, modName);
-                if (!(await hasDirectPak(modPath))) return null;
-
-                return await createNteModInfo(desktop, modPath, await isNteModEnabled(modPath));
-            }),
+            (await collectNteModEntries(groupDir)).map(async (entry) =>
+                createNteModInfo(desktop, entry.modPath, await isNteModEnabled(entry.modPath), {
+                    name: entry.name,
+                    previewFallbackDir: entry.previewFallbackDir,
+                }),
+            ),
         )
-    )
-        .filter((mod) => mod !== null)
-        .sort((a, b) => a.name.localeCompare(b.name));
+    ).sort((a, b) => a.name.localeCompare(b.name));
 
     const preview = await findPreview(groupDir);
     return {
@@ -310,6 +308,16 @@ export async function setNteModEnabled(
 
 export async function hasNteDirectPak(dirPath: string) {
     return await hasDirectPak(dirPath);
+}
+
+export async function listNteModPaths(groupDir: string) {
+    return (await collectNteModEntries(groupDir)).map((entry) => entry.modPath);
+}
+
+export async function getNteListingGroupPath(modPath: string) {
+    const parentPath = path.dirname(modPath);
+    if (await isNtePakWrapper(parentPath)) return path.dirname(parentPath);
+    return parentPath;
 }
 
 export function getNteGroupRelativePath(roots: NteGameRoots, groupPath: string) {
@@ -879,11 +887,68 @@ async function listDirectoryNames(dirPath: string) {
 async function hasNteSubGroups(groupDir: string) {
     return (
         await Promise.all(
-            (
-                await listDirectoryNames(groupDir)
-            ).map(async (name) => !(await hasDirectPak(path.join(groupDir, name)))),
+            (await listDirectoryNames(groupDir)).map(async (name) => {
+                const childPath = path.join(groupDir, name);
+                if (await hasDirectPak(childPath)) return false;
+                return !(await isNtePakWrapper(childPath));
+            }),
         )
     ).some(Boolean);
+}
+
+type NteModEntry = {
+    modPath: string;
+    name: string;
+    previewFallbackDir?: string;
+};
+
+async function collectNteModEntries(groupDir: string): Promise<NteModEntry[]> {
+    const entries = await Promise.all(
+        (await listDirectoryNames(groupDir)).map(async (name) => {
+            const childPath = path.join(groupDir, name);
+            if (await hasDirectPak(childPath)) {
+                return [{ modPath: childPath, name }];
+            }
+
+            if (!(await isNtePakWrapper(childPath))) return [];
+
+            return (
+                await Promise.all(
+                    (await listDirectoryNames(childPath)).map(async (innerName) => {
+                        const innerPath = path.join(childPath, innerName);
+                        if (!(await hasDirectPak(innerPath))) return null;
+                        return {
+                            modPath: innerPath,
+                            name: `${name} / ${innerName}`,
+                            previewFallbackDir: childPath,
+                        } satisfies NteModEntry;
+                    }),
+                )
+            ).filter((entry) => entry !== null);
+        }),
+    );
+
+    return entries.flat();
+}
+
+async function isNtePakWrapper(dirPath: string) {
+    if (await hasDirectPak(dirPath)) return false;
+
+    const childNames = await listDirectoryNames(dirPath);
+    if (childNames.length === 0) return false;
+
+    const childInfos = await Promise.all(
+        childNames.map(async (name) => {
+            const childPath = path.join(dirPath, name);
+            return {
+                hasPak: await hasDirectPak(childPath),
+                hasSubdirs: (await listDirectoryNames(childPath)).length > 0,
+            };
+        }),
+    );
+
+    if (!childInfos.some((child) => child.hasPak)) return false;
+    return childInfos.every((child) => child.hasPak || !child.hasSubdirs);
 }
 
 function isDisabledFile(fileName: string) {
@@ -907,17 +972,9 @@ async function hasDirectPak(dirPath: string) {
 }
 
 async function countDirectMods(groupDir: string) {
-    const mods = (
-        await Promise.all(
-            (
-                await listDirectoryNames(groupDir)
-            ).map(async (name) => {
-                const modPath = path.join(groupDir, name);
-                if (!(await hasDirectPak(modPath))) return null;
-                return await isNteModEnabled(modPath);
-            }),
-        )
-    ).filter((enabled): enabled is boolean => enabled !== null);
+    const mods = await Promise.all(
+        (await collectNteModEntries(groupDir)).map((entry) => isNteModEnabled(entry.modPath)),
+    );
 
     return {
         total: mods.length,
@@ -936,13 +993,20 @@ async function findPreview(dirPath: string) {
     return preview ? path.join(dirPath, preview) : undefined;
 }
 
-async function createNteModInfo(desktop: NahidaDesktop, modPath: string, isEnabled: boolean) {
+async function createNteModInfo(
+    desktop: NahidaDesktop,
+    modPath: string,
+    isEnabled: boolean,
+    options?: { name?: string; previewFallbackDir?: string },
+) {
     const stat = await fse.stat(modPath);
-    const preview = await findPreview(modPath);
+    const preview =
+        (await findPreview(modPath)) ??
+        (options?.previewFallbackDir ? await findPreview(options.previewFallbackDir) : undefined);
 
     return {
         id: modPath,
-        name: path.basename(modPath),
+        name: options?.name ?? path.basename(modPath),
         path: modPath,
         isEnabled,
         ...(preview ? { preview } : {}),

--- a/src/main/services/mod-manager/nte.ts
+++ b/src/main/services/mod-manager/nte.ts
@@ -175,10 +175,10 @@ export async function getNteSubGroups(
             const nextPath = path.join(groupDir, groupName);
 
             if (await hasDirectPak(nextPath)) return null;
-            if (await isNtePakWrapper(nextPath)) return null;
+            if (await isNtePakWrapper(roots, nextPath)) return null;
 
             const preview = await findPreview(nextPath);
-            const modCounts = await countDirectMods(nextPath);
+            const modCounts = await countDirectMods(roots, nextPath);
             return {
                 name: groupName,
                 path: nextPath,
@@ -186,7 +186,7 @@ export async function getNteSubGroups(
                 ...(preview ? { preview } : {}),
                 modCount: modCounts.total,
                 enabledModCount: modCounts.enabled,
-                hasSubGroups: await hasNteSubGroups(nextPath),
+                hasSubGroups: await hasNteSubGroups(roots, nextPath),
                 hasManualSubGroups: false,
             } satisfies FolderGroup;
         }),
@@ -204,7 +204,7 @@ export async function getNteMods(
     const groupDir = path.join(roots.modRoot, relativePath);
     const mods = (
         await Promise.all(
-            (await collectNteModEntries(groupDir)).map(async (entry) =>
+            (await collectNteModEntries(roots, groupDir)).map(async (entry) =>
                 createNteModInfo(desktop, entry.modPath, await isNteModEnabled(entry.modPath), {
                     name: entry.name,
                     previewFallbackDir: entry.previewFallbackDir,
@@ -310,13 +310,13 @@ export async function hasNteDirectPak(dirPath: string) {
     return await hasDirectPak(dirPath);
 }
 
-export async function listNteModPaths(groupDir: string) {
-    return (await collectNteModEntries(groupDir)).map((entry) => entry.modPath);
+export async function listNteModPaths(roots: NteGameRoots, groupDir: string) {
+    return (await collectNteModEntries(roots, groupDir)).map((entry) => entry.modPath);
 }
 
-export async function getNteListingGroupPath(modPath: string) {
+export async function getNteListingGroupPath(roots: NteGameRoots, modPath: string) {
     const parentPath = path.dirname(modPath);
-    if (await isNtePakWrapper(parentPath)) return path.dirname(parentPath);
+    if (await isNtePakWrapper(roots, parentPath)) return path.dirname(parentPath);
     return parentPath;
 }
 
@@ -884,13 +884,13 @@ async function listDirectoryNames(dirPath: string) {
         .sort((a, b) => a.localeCompare(b));
 }
 
-async function hasNteSubGroups(groupDir: string) {
+async function hasNteSubGroups(roots: NteGameRoots, groupDir: string) {
     return (
         await Promise.all(
             (await listDirectoryNames(groupDir)).map(async (name) => {
                 const childPath = path.join(groupDir, name);
                 if (await hasDirectPak(childPath)) return false;
-                return !(await isNtePakWrapper(childPath));
+                return !(await isNtePakWrapper(roots, childPath));
             }),
         )
     ).some(Boolean);
@@ -902,7 +902,7 @@ type NteModEntry = {
     previewFallbackDir?: string;
 };
 
-async function collectNteModEntries(groupDir: string): Promise<NteModEntry[]> {
+async function collectNteModEntries(roots: NteGameRoots, groupDir: string): Promise<NteModEntry[]> {
     const entries = await Promise.all(
         (await listDirectoryNames(groupDir)).map(async (name) => {
             const childPath = path.join(groupDir, name);
@@ -910,7 +910,7 @@ async function collectNteModEntries(groupDir: string): Promise<NteModEntry[]> {
                 return [{ modPath: childPath, name }];
             }
 
-            if (!(await isNtePakWrapper(childPath))) return [];
+            if (!(await isNtePakWrapper(roots, childPath))) return [];
 
             return (
                 await Promise.all(
@@ -931,7 +931,18 @@ async function collectNteModEntries(groupDir: string): Promise<NteModEntry[]> {
     return entries.flat();
 }
 
-async function isNtePakWrapper(dirPath: string) {
+function isNteNavigableGroup(roots: NteGameRoots, dirPath: string) {
+    const relativePath = getNteRelativePath(roots, dirPath);
+    if (!relativePath) return false;
+
+    const segments = relativePath.split(path.sep).filter((segment) => segment.length > 0);
+    if (segments.length === 1) return true;
+    if (segments.length !== 2) return false;
+    return segments[0].toLowerCase() === "character";
+}
+
+async function isNtePakWrapper(roots: NteGameRoots, dirPath: string) {
+    if (isNteNavigableGroup(roots, dirPath)) return false;
     if (await hasDirectPak(dirPath)) return false;
 
     const childNames = await listDirectoryNames(dirPath);
@@ -971,9 +982,11 @@ async function hasDirectPak(dirPath: string) {
     );
 }
 
-async function countDirectMods(groupDir: string) {
+async function countDirectMods(roots: NteGameRoots, groupDir: string) {
     const mods = await Promise.all(
-        (await collectNteModEntries(groupDir)).map((entry) => isNteModEnabled(entry.modPath)),
+        (await collectNteModEntries(roots, groupDir)).map((entry) =>
+            isNteModEnabled(entry.modPath),
+        ),
     );
 
     return {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes NTE mod discovery, grouping, and exclusive/bulk toggle targeting. Misclassification of wrappers vs groups could hide mods or enable/disable the wrong set.
> 
> **Overview**
> NTE now treats nested “pak wrapper” folders as mods in the parent grid instead of extra subgroups. Inner pak folders show as `wrapper / variant` entries with independent toggles, and previews can fall back to the wrapper folder.
> 
> Character/NPC navigable folders stay groups. Exclusive and bulk enable/disable use the listing group and flattened mod paths so wrapped variants are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e927e42f04e9eeb0dc9b5ecf4a649514115282b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved NTE mod discovery across nested PAK-wrapper folders.
  * Flattened wrapped mods into clearer listings while preserving correct grouping.
  * Added separate enabled toggles for mod variants.
  * Improved grouping and counts for mixed character and NPC mods.

* **Bug Fixes**
  * Prevented wrapper folders from appearing as mod subgroups.
  * Improved bulk and exclusive NTE mod toggling for more reliable updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->