### PR TITLE
feat(transfer): show finalizing status when upload bytes complete

### DIFF
--- a/src/renderer/src/components/transfer/transfer-item.tsx
+++ b/src/renderer/src/components/transfer/transfer-item.tsx
@@ -179,6 +179,7 @@ export const TransferItem = memo((props: TransferItemProps) => {
   const isCompleted = status === "completed";
   const isFailed = status === "failed";
   const isPlanning = status === "uploading" && planPhase != null;
+  const isFinalizing = isActive && progress >= 100;
   const translatedError = errorCode
     ? t(`page.transfer.item.error.${errorCode}`, { defaultValue: error ?? errorCode })
     : error;
@@ -205,6 +206,12 @@ export const TransferItem = memo((props: TransferItemProps) => {
               return (
                 <span className={cn("shrink-0 text-xs font-medium", getStatusColor(status))}>
                   {t(`page.transfer.item.planning.${planPhase}`)}
+                </span>
+              );
+            } else if (isFinalizing) {
+              return (
+                <span className={cn("shrink-0 text-xs font-medium", getStatusColor(status))}>
+                  {t("page.transfer.item.finalizing")}
                 </span>
               );
             } else if (
@@ -251,10 +258,10 @@ export const TransferItem = memo((props: TransferItemProps) => {
                   {t(`page.transfer.item.planning.${planPhase}`)}
                 </span>
               )}
-              {!isPlanning && (isActive || isPaused) && speed && (
+              {!isPlanning && !isFinalizing && (isActive || isPaused) && speed && (
                 <span className="shrink-0 whitespace-nowrap">{speed}</span>
               )}
-              {!isPlanning && (isActive || isPaused) && timeRemaining && (
+              {!isPlanning && !isFinalizing && (isActive || isPaused) && timeRemaining && (
                 <span className="hidden truncate whitespace-nowrap sm:inline">
                   {t("page.transfer.item.time_remaining", { time: timeRemaining })}
                 </span>

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -62,6 +62,7 @@
       },
       "item": {
         "uploading": "Uploading",
+        "finalizing": "Finalizing",
         "downloading": "Downloading",
         "completed": "Completed",
         "failed": "Failed",

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -62,6 +62,7 @@
       },
       "item": {
         "uploading": "アップロード中",
+        "finalizing": "仕上げ中",
         "downloading": "ダウンロード中",
         "completed": "完了",
         "failed": "失敗",

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -62,6 +62,7 @@
       },
       "item": {
         "uploading": "업로드 중",
+        "finalizing": "마무리 중",
         "downloading": "다운로드 중",
         "completed": "완료",
         "failed": "실패",

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -62,6 +62,7 @@
       },
       "item": {
         "uploading": "上传中",
+        "finalizing": "收尾中",
         "downloading": "下载中",
         "completed": "已完成",
         "failed": "失败",

--- a/src/renderer/src/routes/transfer.tsx
+++ b/src/renderer/src/routes/transfer.tsx
@@ -103,7 +103,7 @@ function RouteComponent() {
   ).length;
 
   const totalUploadSpeed = transfers
-    .filter((t) => t.type === "upload" && t.status === "progress")
+    .filter((t) => t.type === "upload" && t.status === "progress" && t.progress < 100)
     .reduce((acc, curr) => acc + curr.speed, 0);
 
   const totalDownloadSpeed = transfers


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only status and speed display; no transfer, auth, or data-handling logic changes.
> 
> **Overview**
> Shows a **Finalizing** status on active transfers once progress hits 100%, so the UI no longer looks stuck on “Uploading/Downloading” while post-byte work finishes.
> 
> Speed and time-remaining are hidden in that state. Aggregate upload speed on the transfer page also ignores uploads at 100% so the header does not keep counting a finished byte stream. Strings added for en/ja/ko/zh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9827df830322ac3c09b1800bf3f45ba0e5c8c595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Finalizing” status for transfers that have reached 100% but are still completing.
  - Finalizing transfers now hide speed and remaining-time indicators.
  - Added localized status text in English, Japanese, Korean, and Chinese.

- **Bug Fixes**
  - Improved upload speed totals by excluding transfers that have reached 100% progress but are still finalizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->