### PR TITLE
feat(tools): add Real-CUGAN upscale engine

### DIFF
--- a/src/main/services/mod-tools/ncnn-vulkan-runtime.ts
+++ b/src/main/services/mod-tools/ncnn-vulkan-runtime.ts
@@ -1,0 +1,293 @@
+import { createHash } from "node:crypto";
+import { createReadStream, createWriteStream } from "node:fs";
+import path from "node:path";
+import { pipeline } from "node:stream/promises";
+
+import type { TextureUpscaleRuntimeStatus } from "@shared/types";
+import { app } from "electron";
+import fse from "fs-extra";
+import ky from "ky";
+
+import type { NahidaDesktop } from "@/main";
+
+import { drainWebStream, webStreamToNodeReadable } from "@/main/lib/web-stream-to-readable";
+
+export interface NcnnVulkanRuntimeConfig {
+    dirName: string;
+    binaryName: string;
+    version: string;
+    downloadUrl: string;
+    archiveSha256: string;
+    settingKeyPrefix: string;
+    displayName: string;
+    modelDirNames: readonly string[];
+    isInstalled: (binaryPath: string, modelsPath: string) => Promise<boolean>;
+    resolveModelsPath: (runtimeRoot: string) => string;
+}
+
+const DOWNLOAD_STALL_TIMEOUT_MS = 30_000;
+
+export class NcnnVulkanRuntime {
+    private installPromise: Promise<TextureUpscaleRuntimeStatus> | null = null;
+
+    constructor(
+        private readonly desktop: NahidaDesktop,
+        private readonly config: NcnnVulkanRuntimeConfig,
+    ) {}
+
+    public getToolDir() {
+        return path.join(app.getPath("userData"), "tools", this.config.dirName);
+    }
+
+    public async getStatus(): Promise<TextureUpscaleRuntimeStatus> {
+        const binaryPath = await this.resolveBinaryPath();
+        const modelsPath = await this.resolveModelsPath(binaryPath);
+        const installed = await this.isInstalled(binaryPath, modelsPath);
+
+        return {
+            installed,
+            version: installed
+                ? ((await this.getSettingValue(
+                      `${this.config.settingKeyPrefix}:installed-version`,
+                  )) ?? this.config.version)
+                : null,
+            binaryPath: installed ? binaryPath : null,
+            modelsPath: installed ? modelsPath : null,
+            needsInstall: !installed,
+        };
+    }
+
+    public async ensureInstalled(
+        onProgress?: (phase: "download" | "extract", percent: number | null) => void,
+    ) {
+        const current = await this.getStatus();
+        if (current.installed) {
+            return current;
+        }
+
+        if (!this.installPromise) {
+            this.installPromise = this.install(onProgress).finally(() => {
+                this.installPromise = null;
+            });
+        }
+
+        return await this.installPromise;
+    }
+
+    private async install(
+        onProgress?: (phase: "download" | "extract", percent: number | null) => void,
+    ) {
+        const targetDir = this.getToolDir();
+        const zipPath = path.join(targetDir, `${this.config.dirName}.zip.download`);
+        const extractDir = path.join(targetDir, "extract");
+
+        await fse.ensureDir(targetDir);
+        await fse.remove(zipPath);
+        await fse.remove(extractDir);
+
+        try {
+            onProgress?.("download", 0);
+            await this.downloadArchive(zipPath, (percent) => onProgress?.("download", percent));
+            const digest = createHash("sha256");
+            for await (const chunk of createReadStream(zipPath)) {
+                digest.update(chunk);
+            }
+            if (digest.digest("hex") !== this.config.archiveSha256) {
+                throw new Error(`Downloaded ${this.config.displayName} archive checksum mismatch.`);
+            }
+            onProgress?.("extract", null);
+            await this.desktop.service.archive.extract(zipPath, extractDir);
+            const layout = await this.resolveExtractedLayout(extractDir);
+            await this.promoteExtractedLayout(layout, targetDir);
+            await this.saveSettingValue(
+                `${this.config.settingKeyPrefix}:installed-version`,
+                this.config.version,
+            );
+            await this.saveSettingValue(
+                `${this.config.settingKeyPrefix}:binary-path`,
+                path.join(targetDir, this.config.binaryName),
+            );
+            await this.saveSettingValue(
+                `${this.config.settingKeyPrefix}:models-path`,
+                this.config.resolveModelsPath(targetDir),
+            );
+        } catch (error) {
+            await fse.remove(zipPath).catch(() => {});
+            await fse.remove(extractDir).catch(() => {});
+            throw error;
+        }
+
+        await fse.remove(zipPath).catch(() => {});
+        await fse.remove(extractDir).catch(() => {});
+
+        const status = await this.getStatus();
+        if (!status.installed) {
+            throw new Error(`${this.config.displayName} runtime installation is incomplete.`);
+        }
+
+        return status;
+    }
+
+    private async downloadArchive(zipPath: string, onPercent: (percent: number | null) => void) {
+        const abortController = new AbortController();
+        const response = await ky.get(this.config.downloadUrl, {
+            timeout: 10 * 60 * 1000,
+            signal: abortController.signal,
+            throwHttpErrors: false,
+            headers: {
+                "User-Agent": "Nahida Desktop",
+            },
+        });
+
+        if (!response.ok) {
+            await drainWebStream(response.body).catch(() => {});
+            throw new Error(
+                `Failed to download ${this.config.displayName} runtime: HTTP ${response.status}`,
+            );
+        }
+        if (!response.body) {
+            throw new Error(
+                `Failed to download ${this.config.displayName} runtime: empty response body.`,
+            );
+        }
+
+        const contentLength = Number.parseInt(response.headers.get("content-length") ?? "", 10);
+        const hasLength = Number.isFinite(contentLength) && contentLength > 0;
+        let received = 0;
+        const source = webStreamToNodeReadable(response.body);
+        let stallTimer: ReturnType<typeof setTimeout> | undefined;
+        const resetStallTimer = () => {
+            clearTimeout(stallTimer);
+            stallTimer = setTimeout(() => {
+                abortController.abort();
+                source.destroy(
+                    new Error(`Failed to download ${this.config.displayName} runtime: stalled.`),
+                );
+            }, DOWNLOAD_STALL_TIMEOUT_MS);
+        };
+
+        source.on("data", (chunk: Buffer) => {
+            resetStallTimer();
+            received += chunk.byteLength;
+            onPercent(hasLength ? Math.min(100, (received / contentLength) * 100) : null);
+        });
+        resetStallTimer();
+
+        await pipeline(source, createWriteStream(zipPath)).finally(() => {
+            clearTimeout(stallTimer);
+        });
+        onPercent(100);
+    }
+
+    private async resolveExtractedLayout(extractDir: string) {
+        const binaryPath = await findFileByName(extractDir, this.config.binaryName);
+        if (!binaryPath) {
+            throw new Error(
+                `Extracted ${this.config.displayName} archive is missing the executable.`,
+            );
+        }
+
+        const layoutRoot = path.dirname(binaryPath);
+        for (const dirName of this.config.modelDirNames) {
+            const modelDir = await findDirectoryByName(layoutRoot, dirName);
+            if (!modelDir) {
+                throw new Error(
+                    `Extracted ${this.config.displayName} archive is missing the ${dirName} directory.`,
+                );
+            }
+        }
+
+        return {
+            binaryPath,
+            layoutRoot,
+        };
+    }
+
+    private async promoteExtractedLayout(
+        layout: { binaryPath: string; layoutRoot: string },
+        targetDir: string,
+    ) {
+        const finalBinaryPath = path.join(targetDir, this.config.binaryName);
+        const sidecarNames = await fse.readdir(layout.layoutRoot);
+
+        await fse.remove(finalBinaryPath);
+        await fse.move(layout.binaryPath, finalBinaryPath, { overwrite: true });
+        for (const dirName of this.config.modelDirNames) {
+            const sourcePath = path.join(layout.layoutRoot, dirName);
+            const finalPath = path.join(targetDir, dirName);
+            await fse.remove(finalPath);
+            await fse.move(sourcePath, finalPath, { overwrite: true });
+        }
+
+        await Promise.all(
+            sidecarNames
+                .filter((name) => name.toLowerCase().endsWith(".dll"))
+                .map(async (name) => {
+                    const sourcePath = path.join(layout.layoutRoot, name);
+                    if (!(await fse.pathExists(sourcePath))) {
+                        return;
+                    }
+
+                    await fse.move(sourcePath, path.join(targetDir, name), { overwrite: true });
+                }),
+        );
+    }
+
+    private async resolveBinaryPath() {
+        const stored = await this.getSettingValue(`${this.config.settingKeyPrefix}:binary-path`);
+        if (stored && (await fse.pathExists(stored))) {
+            return stored;
+        }
+
+        return path.join(this.getToolDir(), this.config.binaryName);
+    }
+
+    private async resolveModelsPath(binaryPath: string) {
+        const stored = await this.getSettingValue(`${this.config.settingKeyPrefix}:models-path`);
+        if (stored && (await fse.pathExists(stored))) {
+            return stored;
+        }
+
+        return this.config.resolveModelsPath(path.dirname(binaryPath));
+    }
+
+    private async isInstalled(binaryPath: string, modelsPath: string) {
+        return await this.config.isInstalled(binaryPath, modelsPath);
+    }
+
+    private async getSettingValue(key: string) {
+        return await this.desktop.lib.db.settings.getValue(key);
+    }
+
+    private async saveSettingValue(key: string, value: string) {
+        await this.desktop.lib.db.settings.upsert(key, value);
+    }
+}
+
+export async function findFileByName(root: string, fileName: string): Promise<string | null> {
+    const entries = await fse.readdir(root, { withFileTypes: true });
+    const files = entries.filter(
+        (entry) => entry.isFile() && entry.name.toLowerCase() === fileName.toLowerCase(),
+    );
+    if (files[0]) {
+        return path.join(root, files[0].name);
+    }
+
+    const nested = await Promise.all(
+        entries
+            .filter((entry) => entry.isDirectory())
+            .map((entry) => findFileByName(path.join(root, entry.name), fileName)),
+    );
+    return nested.find((value): value is string => value != null) ?? null;
+}
+
+export async function findDirectoryByName(
+    root: string,
+    directoryName: string,
+): Promise<string | null> {
+    const entries = await fse.readdir(root, { withFileTypes: true });
+    const match = entries.find(
+        (entry) => entry.isDirectory() && entry.name.toLowerCase() === directoryName.toLowerCase(),
+    );
+    return match ? path.join(root, match.name) : null;
+}

--- a/src/main/services/mod-tools/realcugan-runtime-status.test.ts
+++ b/src/main/services/mod-tools/realcugan-runtime-status.test.ts
@@ -1,0 +1,36 @@
+import os from "node:os";
+import path from "node:path";
+
+import fse from "fs-extra";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+    isRealcuganRuntimeInstalled,
+    REALCUGAN_BINARY_NAME,
+    REQUIRED_REALCUGAN_MODEL_FILES,
+} from "./realcugan-runtime-status";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+    await Promise.all(temporaryDirectories.splice(0).map((dirPath) => fse.remove(dirPath)));
+});
+
+describe("realcugan runtime install check", () => {
+    it("requires the executable and all bundled model files", async () => {
+        const root = await fse.mkdtemp(path.join(os.tmpdir(), "realcugan-runtime-"));
+        temporaryDirectories.push(root);
+        const binaryPath = path.join(root, REALCUGAN_BINARY_NAME);
+        await fse.outputFile(binaryPath, "");
+
+        expect(await isRealcuganRuntimeInstalled(binaryPath, root)).toBe(false);
+
+        for (const model of REQUIRED_REALCUGAN_MODEL_FILES) {
+            await fse.outputFile(path.join(root, `${model}.param`), "");
+            await fse.outputFile(path.join(root, `${model}.bin`), "");
+        }
+
+        expect(await isRealcuganRuntimeInstalled(binaryPath, root)).toBe(true);
+        expect(await isRealcuganRuntimeInstalled(path.join(root, "missing.exe"), root)).toBe(false);
+    });
+});

--- a/src/main/services/mod-tools/realcugan-runtime-status.ts
+++ b/src/main/services/mod-tools/realcugan-runtime-status.ts
@@ -1,0 +1,33 @@
+import path from "node:path";
+
+import fse from "fs-extra";
+
+export const REALCUGAN_BINARY_NAME = "realcugan-ncnn-vulkan.exe";
+
+// Model files the app can use with the fixed no-denoise (-n -1) setting,
+// relative to the runtime root. models-pro has no up4x and models-nose only
+// ships up2x-no-denoise, so the exposed scale options are limited accordingly.
+export const REQUIRED_REALCUGAN_MODEL_FILES = [
+    "models-pro/up2x-no-denoise",
+    "models-pro/up3x-no-denoise",
+    "models-se/up2x-no-denoise",
+    "models-se/up3x-no-denoise",
+    "models-se/up4x-no-denoise",
+    "models-nose/up2x-no-denoise",
+] as const;
+
+export async function isRealcuganRuntimeInstalled(binaryPath: string, runtimeRoot: string) {
+    if (!(await fse.pathExists(binaryPath)) || !(await fse.pathExists(runtimeRoot))) {
+        return false;
+    }
+
+    const modelReady = await Promise.all(
+        REQUIRED_REALCUGAN_MODEL_FILES.map(async (model) => {
+            const paramPath = path.join(runtimeRoot, `${model}.param`);
+            const binPath = path.join(runtimeRoot, `${model}.bin`);
+            return (await fse.pathExists(paramPath)) && (await fse.pathExists(binPath));
+        }),
+    );
+
+    return modelReady.every(Boolean);
+}

--- a/src/main/services/mod-tools/realcugan-runtime-status.ts
+++ b/src/main/services/mod-tools/realcugan-runtime-status.ts
@@ -4,7 +4,7 @@ import fse from "fs-extra";
 
 export const REALCUGAN_BINARY_NAME = "realcugan-ncnn-vulkan.exe";
 
-// Model files the app can use with the fixed no-denoise (-n -1) setting,
+// Model files the app can use with the fixed no-denoise (-n 0) setting,
 // relative to the runtime root. models-pro has no up4x and models-nose only
 // ships up2x-no-denoise, so the exposed scale options are limited accordingly.
 export const REQUIRED_REALCUGAN_MODEL_FILES = [

--- a/src/main/services/mod-tools/realcugan-runtime.ts
+++ b/src/main/services/mod-tools/realcugan-runtime.ts
@@ -1,0 +1,31 @@
+import type { NahidaDesktop } from "@/main";
+
+import { NcnnVulkanRuntime, type NcnnVulkanRuntimeConfig } from "./ncnn-vulkan-runtime";
+import { isRealcuganRuntimeInstalled, REALCUGAN_BINARY_NAME } from "./realcugan-runtime-status";
+
+export const REALCUGAN_RUNTIME_VERSION = "20220728";
+export const REALCUGAN_RUNTIME_DIR_NAME = "realcugan-ncnn-vulkan";
+export { REALCUGAN_BINARY_NAME };
+export const REALCUGAN_DOWNLOAD_URL =
+    "https://github.com/nihui/realcugan-ncnn-vulkan/releases/download/20220728/realcugan-ncnn-vulkan-20220728-windows.zip";
+export const REALCUGAN_ARCHIVE_SHA256 =
+    "c6e08d46c11704b1e3a1ada9ddd591cb5005f52f132136c8633ba25def400e01";
+
+export const REALCUGAN_RUNTIME_CONFIG: NcnnVulkanRuntimeConfig = {
+    dirName: REALCUGAN_RUNTIME_DIR_NAME,
+    binaryName: REALCUGAN_BINARY_NAME,
+    version: REALCUGAN_RUNTIME_VERSION,
+    downloadUrl: REALCUGAN_DOWNLOAD_URL,
+    archiveSha256: REALCUGAN_ARCHIVE_SHA256,
+    settingKeyPrefix: "mod_tools:realcugan-ncnn-vulkan",
+    displayName: "Real-CUGAN",
+    modelDirNames: ["models-pro", "models-se", "models-nose"],
+    isInstalled: isRealcuganRuntimeInstalled,
+    resolveModelsPath: (runtimeRoot) => runtimeRoot,
+};
+
+export class RealcuganRuntime extends NcnnVulkanRuntime {
+    constructor(desktop: NahidaDesktop) {
+        super(desktop, REALCUGAN_RUNTIME_CONFIG);
+    }
+}

--- a/src/main/services/mod-tools/realesrgan-runtime.ts
+++ b/src/main/services/mod-tools/realesrgan-runtime.ts
@@ -1,17 +1,8 @@
-import { createHash } from "node:crypto";
-import { createReadStream, createWriteStream } from "node:fs";
 import path from "node:path";
-import { pipeline } from "node:stream/promises";
-
-import type { TextureUpscaleRuntimeStatus } from "@shared/types";
-import { app } from "electron";
-import fse from "fs-extra";
-import ky from "ky";
 
 import type { NahidaDesktop } from "@/main";
 
-import { drainWebStream, webStreamToNodeReadable } from "@/main/lib/web-stream-to-readable";
-
+import { NcnnVulkanRuntime, type NcnnVulkanRuntimeConfig } from "./ncnn-vulkan-runtime";
 import { isRealesrganRuntimeInstalled, REALESRGAN_BINARY_NAME } from "./realesrgan-runtime-status";
 
 export const REALESRGAN_RUNTIME_VERSION = "20220424";
@@ -22,244 +13,21 @@ export const REALESRGAN_DOWNLOAD_URL =
 export const REALESRGAN_ARCHIVE_SHA256 =
     "abc02804e17982a3be33675e4d471e91ea374e65b70167abc09e31acb412802d";
 
-const INSTALLED_VERSION_KEY = "mod_tools:realesrgan-ncnn-vulkan:installed-version";
-const BINARY_PATH_KEY = "mod_tools:realesrgan-ncnn-vulkan:binary-path";
-const MODELS_PATH_KEY = "mod_tools:realesrgan-ncnn-vulkan:models-path";
-const DOWNLOAD_STALL_TIMEOUT_MS = 30_000;
+export const REALESRGAN_RUNTIME_CONFIG: NcnnVulkanRuntimeConfig = {
+    dirName: REALESRGAN_RUNTIME_DIR_NAME,
+    binaryName: REALESRGAN_BINARY_NAME,
+    version: REALESRGAN_RUNTIME_VERSION,
+    downloadUrl: REALESRGAN_DOWNLOAD_URL,
+    archiveSha256: REALESRGAN_ARCHIVE_SHA256,
+    settingKeyPrefix: "mod_tools:realesrgan-ncnn-vulkan",
+    displayName: "Real-ESRGAN",
+    modelDirNames: ["models"],
+    isInstalled: isRealesrganRuntimeInstalled,
+    resolveModelsPath: (runtimeRoot) => path.join(runtimeRoot, "models"),
+};
 
-export class RealesrganRuntime {
-    private installPromise: Promise<TextureUpscaleRuntimeStatus> | null = null;
-
-    constructor(private readonly desktop: NahidaDesktop) {}
-
-    public getToolDir() {
-        return path.join(app.getPath("userData"), "tools", REALESRGAN_RUNTIME_DIR_NAME);
+export class RealesrganRuntime extends NcnnVulkanRuntime {
+    constructor(desktop: NahidaDesktop) {
+        super(desktop, REALESRGAN_RUNTIME_CONFIG);
     }
-
-    public async getStatus(): Promise<TextureUpscaleRuntimeStatus> {
-        const binaryPath = await this.resolveBinaryPath();
-        const modelsPath = await this.resolveModelsPath(binaryPath);
-        const installed = await this.isInstalled(binaryPath, modelsPath);
-
-        return {
-            installed,
-            version: installed
-                ? ((await this.getSettingValue(INSTALLED_VERSION_KEY)) ??
-                  REALESRGAN_RUNTIME_VERSION)
-                : null,
-            binaryPath: installed ? binaryPath : null,
-            modelsPath: installed ? modelsPath : null,
-            needsInstall: !installed,
-        };
-    }
-
-    public async ensureInstalled(
-        onProgress?: (phase: "download" | "extract", percent: number | null) => void,
-    ) {
-        const current = await this.getStatus();
-        if (current.installed) {
-            return current;
-        }
-
-        if (!this.installPromise) {
-            this.installPromise = this.install(onProgress).finally(() => {
-                this.installPromise = null;
-            });
-        }
-
-        return await this.installPromise;
-    }
-
-    private async install(
-        onProgress?: (phase: "download" | "extract", percent: number | null) => void,
-    ) {
-        const targetDir = this.getToolDir();
-        const zipPath = path.join(targetDir, `${REALESRGAN_RUNTIME_DIR_NAME}.zip.download`);
-        const extractDir = path.join(targetDir, "extract");
-
-        await fse.ensureDir(targetDir);
-        await fse.remove(zipPath);
-        await fse.remove(extractDir);
-
-        try {
-            onProgress?.("download", 0);
-            await this.downloadArchive(zipPath, (percent) => onProgress?.("download", percent));
-            const digest = createHash("sha256");
-            for await (const chunk of createReadStream(zipPath)) {
-                digest.update(chunk);
-            }
-            if (digest.digest("hex") !== REALESRGAN_ARCHIVE_SHA256) {
-                throw new Error("Downloaded Real-ESRGAN archive checksum mismatch.");
-            }
-            onProgress?.("extract", null);
-            await this.desktop.service.archive.extract(zipPath, extractDir);
-            const layout = await this.resolveExtractedLayout(extractDir);
-            await this.promoteExtractedLayout(layout, targetDir);
-            await this.saveSettingValue(INSTALLED_VERSION_KEY, REALESRGAN_RUNTIME_VERSION);
-            await this.saveSettingValue(
-                BINARY_PATH_KEY,
-                path.join(targetDir, REALESRGAN_BINARY_NAME),
-            );
-            await this.saveSettingValue(MODELS_PATH_KEY, path.join(targetDir, "models"));
-        } catch (error) {
-            await fse.remove(zipPath).catch(() => {});
-            await fse.remove(extractDir).catch(() => {});
-            throw error;
-        }
-
-        await fse.remove(zipPath).catch(() => {});
-        await fse.remove(extractDir).catch(() => {});
-
-        const status = await this.getStatus();
-        if (!status.installed) {
-            throw new Error("Real-ESRGAN runtime installation is incomplete.");
-        }
-
-        return status;
-    }
-
-    private async downloadArchive(zipPath: string, onPercent: (percent: number | null) => void) {
-        const abortController = new AbortController();
-        const response = await ky.get(REALESRGAN_DOWNLOAD_URL, {
-            timeout: 10 * 60 * 1000,
-            signal: abortController.signal,
-            throwHttpErrors: false,
-            headers: {
-                "User-Agent": "Nahida Desktop",
-            },
-        });
-
-        if (!response.ok) {
-            await drainWebStream(response.body).catch(() => {});
-            throw new Error(`Failed to download Real-ESRGAN runtime: HTTP ${response.status}`);
-        }
-        if (!response.body) {
-            throw new Error("Failed to download Real-ESRGAN runtime: empty response body.");
-        }
-
-        const contentLength = Number.parseInt(response.headers.get("content-length") ?? "", 10);
-        const hasLength = Number.isFinite(contentLength) && contentLength > 0;
-        let received = 0;
-        const source = webStreamToNodeReadable(response.body);
-        let stallTimer: ReturnType<typeof setTimeout> | undefined;
-        const resetStallTimer = () => {
-            clearTimeout(stallTimer);
-            stallTimer = setTimeout(() => {
-                abortController.abort();
-                source.destroy(new Error("Failed to download Real-ESRGAN runtime: stalled."));
-            }, DOWNLOAD_STALL_TIMEOUT_MS);
-        };
-
-        source.on("data", (chunk: Buffer) => {
-            resetStallTimer();
-            received += chunk.byteLength;
-            onPercent(hasLength ? Math.min(100, (received / contentLength) * 100) : null);
-        });
-        resetStallTimer();
-
-        await pipeline(source, createWriteStream(zipPath)).finally(() => {
-            clearTimeout(stallTimer);
-        });
-        onPercent(100);
-    }
-
-    private async resolveExtractedLayout(extractDir: string) {
-        const binaryPath = await findFileByName(extractDir, REALESRGAN_BINARY_NAME);
-        if (!binaryPath) {
-            throw new Error("Extracted Real-ESRGAN archive is missing the executable.");
-        }
-
-        const modelsPath = await findDirectoryByName(path.dirname(binaryPath), "models");
-        if (!modelsPath) {
-            throw new Error("Extracted Real-ESRGAN archive is missing the models directory.");
-        }
-
-        return {
-            binaryPath,
-            modelsPath,
-            rootDir: path.dirname(binaryPath),
-        };
-    }
-
-    private async promoteExtractedLayout(
-        layout: { binaryPath: string; modelsPath: string; rootDir: string },
-        targetDir: string,
-    ) {
-        const finalBinaryPath = path.join(targetDir, REALESRGAN_BINARY_NAME);
-        const finalModelsPath = path.join(targetDir, "models");
-        const sidecarNames = await fse.readdir(layout.rootDir);
-
-        await fse.remove(finalBinaryPath);
-        await fse.move(layout.binaryPath, finalBinaryPath, { overwrite: true });
-        await fse.remove(finalModelsPath);
-        await fse.move(layout.modelsPath, finalModelsPath, { overwrite: true });
-
-        await Promise.all(
-            sidecarNames
-                .filter((name) => name.toLowerCase().endsWith(".dll"))
-                .map(async (name) => {
-                    const sourcePath = path.join(layout.rootDir, name);
-                    if (!(await fse.pathExists(sourcePath))) {
-                        return;
-                    }
-
-                    await fse.move(sourcePath, path.join(targetDir, name), { overwrite: true });
-                }),
-        );
-    }
-
-    private async resolveBinaryPath() {
-        const stored = await this.getSettingValue(BINARY_PATH_KEY);
-        if (stored && (await fse.pathExists(stored))) {
-            return stored;
-        }
-
-        return path.join(this.getToolDir(), REALESRGAN_BINARY_NAME);
-    }
-
-    private async resolveModelsPath(binaryPath: string) {
-        const stored = await this.getSettingValue(MODELS_PATH_KEY);
-        if (stored && (await fse.pathExists(stored))) {
-            return stored;
-        }
-
-        return path.join(path.dirname(binaryPath), "models");
-    }
-
-    private async isInstalled(binaryPath: string, modelsPath: string) {
-        return await isRealesrganRuntimeInstalled(binaryPath, modelsPath);
-    }
-
-    private async getSettingValue(key: string) {
-        return await this.desktop.lib.db.settings.getValue(key);
-    }
-
-    private async saveSettingValue(key: string, value: string) {
-        await this.desktop.lib.db.settings.upsert(key, value);
-    }
-}
-
-async function findFileByName(root: string, fileName: string): Promise<string | null> {
-    const entries = await fse.readdir(root, { withFileTypes: true });
-    const files = entries.filter(
-        (entry) => entry.isFile() && entry.name.toLowerCase() === fileName.toLowerCase(),
-    );
-    if (files[0]) {
-        return path.join(root, files[0].name);
-    }
-
-    const nested = await Promise.all(
-        entries
-            .filter((entry) => entry.isDirectory())
-            .map((entry) => findFileByName(path.join(root, entry.name), fileName)),
-    );
-    return nested.find((value): value is string => value != null) ?? null;
-}
-
-async function findDirectoryByName(root: string, directoryName: string): Promise<string | null> {
-    const entries = await fse.readdir(root, { withFileTypes: true });
-    const match = entries.find(
-        (entry) => entry.isDirectory() && entry.name.toLowerCase() === directoryName.toLowerCase(),
-    );
-    return match ? path.join(root, match.name) : null;
 }

--- a/src/main/services/mod-tools/texture-resizer.test.ts
+++ b/src/main/services/mod-tools/texture-resizer.test.ts
@@ -9,7 +9,27 @@ vi.mock("@native/mod-tools", () => ({
 }));
 
 vi.mock("./realesrgan-runtime", () => ({
-    RealesrganRuntime: class {},
+    RealesrganRuntime: class {
+        getStatus = vi.fn(async () => ({
+            installed: false,
+            version: null,
+            binaryPath: null,
+            modelsPath: null,
+            needsInstall: true,
+        }));
+    },
+}));
+
+vi.mock("./realcugan-runtime", () => ({
+    RealcuganRuntime: class {
+        getStatus = vi.fn(async () => ({
+            installed: false,
+            version: null,
+            binaryPath: null,
+            modelsPath: null,
+            needsInstall: true,
+        }));
+    },
 }));
 
 import type { NahidaDesktop } from "@main/index";
@@ -76,6 +96,26 @@ function createResizer() {
 }
 
 describe("texture resizer settings", () => {
+    it("reports runtime status for both upscale engines", async () => {
+        const { resizer } = createResizer();
+        await expect(resizer.getUpscaleRuntimeStatus()).resolves.toEqual({
+            realesrgan: {
+                installed: false,
+                version: null,
+                binaryPath: null,
+                modelsPath: null,
+                needsInstall: true,
+            },
+            realcugan: {
+                installed: false,
+                version: null,
+                binaryPath: null,
+                modelsPath: null,
+                needsInstall: true,
+            },
+        });
+    });
+
     it("merges upscale settings and clamps x4plus models to 4x", () => {
         const merged = mergeTextureResizeSettings(
             {

--- a/src/main/services/mod-tools/texture-resizer.ts
+++ b/src/main/services/mod-tools/texture-resizer.ts
@@ -1334,7 +1334,8 @@ function runUpscaleProcess({
                   "-o",
                   outputPath,
                   "-n",
-                  "-1",
+                  // realcugan-ncnn-vulkan maps 0 to up{scale}x-no-denoise; -1 is conservative.
+                  "0",
                   "-s",
                   String(scale),
                   "-t",

--- a/src/main/services/mod-tools/texture-resizer.ts
+++ b/src/main/services/mod-tools/texture-resizer.ts
@@ -14,12 +14,15 @@ import type {
     TextureResizeResult,
     TextureResizeRunInput,
     TextureResizeSettings,
+    TextureUpscaleEngine,
     TextureUpscaleModel,
     TextureUpscaleProgressEvent,
+    TextureUpscaleRuntimeStatuses,
     TextureUpscaleScale,
 } from "@shared/types";
 import {
     getTextureResizeCandidates,
+    getTextureUpscaleEngine,
     getTextureUpscaleTarget,
     isTextureUpscaleOperation,
     isUnsupportedTextureUpscaleFormat,
@@ -35,6 +38,7 @@ import { nanoid } from "nanoid";
 import pLimit from "p-limit";
 import sharp from "sharp";
 
+import { RealcuganRuntime } from "./realcugan-runtime";
 import { RealesrganRuntime } from "./realesrgan-runtime";
 
 const MODE_KEY = "texture_resize_mode";
@@ -77,7 +81,12 @@ const DDPF_FOURCC = 0x4;
 const DDPF_RGB = 0x40;
 const DDSCAPS2_CUBEMAP = 0x200;
 const DDSD_MIPMAPCOUNT = 0x00020000;
-const REALESRGAN_PROCESS_TIMEOUT_MS = 10 * 60 * 1000;
+const UPSCALE_PROCESS_TIMEOUT_MS = 10 * 60 * 1000;
+
+const UPSCALE_ENGINE_DISPLAY_NAMES: Record<TextureUpscaleEngine, string> = {
+    realesrgan: "Real-ESRGAN",
+    realcugan: "Real-CUGAN",
+};
 
 type TextureOutputFormat = (typeof ALL_OUTPUT_FORMATS)[number];
 
@@ -223,9 +232,11 @@ export class TextureResizer {
     private nextJobId = 0;
     private readonly inFlightJobs = new Map<number, TextureResizeProgressEvent>();
     private readonly realesrganRuntime: RealesrganRuntime;
+    private readonly realcuganRuntime: RealcuganRuntime;
 
     constructor(private readonly desktop: NahidaDesktop) {
         this.realesrganRuntime = new RealesrganRuntime(desktop);
+        this.realcuganRuntime = new RealcuganRuntime(desktop);
     }
 
     public getState(): TextureResizeProgressEvent {
@@ -349,8 +360,12 @@ export class TextureResizer {
         return merged;
     }
 
-    public async getUpscaleRuntimeStatus() {
-        return await this.realesrganRuntime.getStatus();
+    public async getUpscaleRuntimeStatus(): Promise<TextureUpscaleRuntimeStatuses> {
+        const [realesrgan, realcugan] = await Promise.all([
+            this.realesrganRuntime.getStatus(),
+            this.realcuganRuntime.getStatus(),
+        ]);
+        return { realesrgan, realcugan };
     }
 
     public async listFolderTextures(targetPath: string, settings?: Partial<TextureResizeSettings>) {
@@ -494,26 +509,30 @@ export class TextureResizer {
         const inputPngPath = path.join(workDir, `${nanoid(8)}-in.png`);
         const outputPngPath = path.join(workDir, `${nanoid(8)}-out.png`);
 
+        const engine = getTextureUpscaleEngine(settings.upscaleModel);
+        const engineDisplayName = UPSCALE_ENGINE_DISPLAY_NAMES[engine];
+        const runtime = engine === "realcugan" ? this.realcuganRuntime : this.realesrganRuntime;
+
         try {
             this.emitUpscaleProgress({
                 phase: "download",
                 percent: 0,
                 filePath,
-                message: "Preparing Real-ESRGAN runtime",
+                message: `Preparing ${engineDisplayName} runtime`,
             });
-            const runtime = await this.realesrganRuntime.ensureInstalled((phase, percent) => {
+            const installedRuntime = await runtime.ensureInstalled((phase, percent) => {
                 this.emitUpscaleProgress({
                     phase,
                     percent,
                     filePath,
                     message:
                         phase === "download"
-                            ? "Downloading Real-ESRGAN runtime"
-                            : "Extracting Real-ESRGAN runtime",
+                            ? `Downloading ${engineDisplayName} runtime`
+                            : `Extracting ${engineDisplayName} runtime`,
                 });
             });
-            if (!runtime.binaryPath || !runtime.modelsPath) {
-                throw new Error("Real-ESRGAN runtime is not installed.");
+            if (!installedRuntime.binaryPath || !installedRuntime.modelsPath) {
+                throw new Error(`${engineDisplayName} runtime is not installed.`);
             }
 
             this.emitUpscaleProgress({
@@ -579,11 +598,12 @@ export class TextureResizer {
                 phase: "upscale",
                 percent: null,
                 filePath,
-                message: "Running Real-ESRGAN",
+                message: `Running ${engineDisplayName}`,
             });
-            await runRealesrganProcess({
-                binaryPath: runtime.binaryPath,
-                modelsPath: runtime.modelsPath,
+            await runUpscaleProcess({
+                engine,
+                binaryPath: installedRuntime.binaryPath,
+                modelsPath: installedRuntime.modelsPath,
                 inputPath: inputPngPath,
                 outputPath: outputPngPath,
                 model: settings.upscaleModel,
@@ -603,7 +623,7 @@ export class TextureResizer {
             );
             if (expected && (outputWidth !== expected.width || outputHeight !== expected.height)) {
                 this.desktop.logger.warn(
-                    `Real-ESRGAN output size ${outputWidth}x${outputHeight} did not match expected ${expected.width}x${expected.height}`,
+                    `${engineDisplayName} output size ${outputWidth}x${outputHeight} did not match expected ${expected.width}x${expected.height}`,
                     "TextureResizer:upscale",
                 );
             }
@@ -1286,7 +1306,8 @@ function buildSkippedFileResult(
     };
 }
 
-function runRealesrganProcess({
+function runUpscaleProcess({
+    engine,
     binaryPath,
     modelsPath,
     inputPath,
@@ -1295,6 +1316,7 @@ function runRealesrganProcess({
     scale,
     logger,
 }: {
+    engine: TextureUpscaleEngine;
     binaryPath: string;
     modelsPath: string;
     inputPath: string;
@@ -1303,41 +1325,60 @@ function runRealesrganProcess({
     scale: TextureUpscaleScale;
     logger: (message: string) => void;
 }) {
+    const displayName = UPSCALE_ENGINE_DISPLAY_NAMES[engine];
+    const args =
+        engine === "realcugan"
+            ? [
+                  "-i",
+                  inputPath,
+                  "-o",
+                  outputPath,
+                  "-n",
+                  "-1",
+                  "-s",
+                  String(scale),
+                  "-t",
+                  "0",
+                  "-c",
+                  "3",
+                  "-f",
+                  "png",
+                  "-m",
+                  path.join(modelsPath, resolveRealcuganModelDir(model)),
+              ]
+            : [
+                  "-i",
+                  inputPath,
+                  "-o",
+                  outputPath,
+                  "-n",
+                  model,
+                  "-s",
+                  String(scale),
+                  "-t",
+                  "0",
+                  "-f",
+                  "png",
+                  "-m",
+                  modelsPath,
+              ];
+
     return new Promise<void>((resolve, reject) => {
-        const child = spawn(
-            binaryPath,
-            [
-                "-i",
-                inputPath,
-                "-o",
-                outputPath,
-                "-n",
-                model,
-                "-s",
-                String(scale),
-                "-t",
-                "0",
-                "-f",
-                "png",
-                "-m",
-                modelsPath,
-            ],
-            {
-                windowsHide: true,
-                cwd: path.dirname(binaryPath),
-                shell: false,
-            },
-        );
+        const child = spawn(binaryPath, args, {
+            windowsHide: true,
+            cwd: path.dirname(binaryPath),
+            shell: false,
+        });
 
         let stderr = "";
         const timeout = setTimeout(() => {
             child.kill();
             reject(
                 new Error(
-                    `Real-ESRGAN timed out after ${REALESRGAN_PROCESS_TIMEOUT_MS}ms${stderr.trim() ? `: ${stderr.trim()}` : ""}`,
+                    `${displayName} timed out after ${UPSCALE_PROCESS_TIMEOUT_MS}ms${stderr.trim() ? `: ${stderr.trim()}` : ""}`,
                 ),
             );
-        }, REALESRGAN_PROCESS_TIMEOUT_MS);
+        }, UPSCALE_PROCESS_TIMEOUT_MS);
         child.stderr?.on("data", (chunk: Buffer) => {
             const text = chunk.toString();
             stderr += text;
@@ -1362,9 +1403,13 @@ function runRealesrganProcess({
 
             reject(
                 new Error(
-                    `Real-ESRGAN exited with code ${code ?? "unknown"}${stderr.trim() ? `: ${stderr.trim()}` : ""}`,
+                    `${displayName} exited with code ${code ?? "unknown"}${stderr.trim() ? `: ${stderr.trim()}` : ""}`,
                 ),
             );
         });
     });
+}
+
+function resolveRealcuganModelDir(model: TextureUpscaleModel) {
+    return `models-${model.slice("realcugan-".length)}`;
 }

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -956,19 +956,25 @@
           "resize": "Only change the texture size. The DDS format stays the same.",
           "resize_and_convert": "Resize the texture and re-encode it to a different DDS format while preserving color space.",
           "convert": "Keep the original texture size and only change the DDS output format.",
-          "upscale": "Enlarge the texture with Real-ESRGAN. The DDS format stays the same.",
-          "upscale_and_convert": "Enlarge the texture with Real-ESRGAN and re-encode it to a different DDS format."
+          "upscale": "Enlarge the texture with an AI upscaler. The DDS format stays the same.",
+          "upscale_and_convert": "Enlarge the texture with an AI upscaler and re-encode it to a different DDS format."
         },
         "upscale_model": "Upscale model",
         "upscale_model_options": {
           "realesr-animevideov3": "Anime / game (default)",
           "realesrgan-x4plus-anime": "Anime x4+",
-          "realesrgan-x4plus": "Photo x4+"
+          "realesrgan-x4plus": "Photo x4+",
+          "realcugan-pro": "Real-CUGAN Pro",
+          "realcugan-se": "Real-CUGAN SE",
+          "realcugan-nose": "Real-CUGAN Nose"
         },
         "upscale_model_descriptions": {
           "realesr-animevideov3": "Best default for game and anime textures. Supports 2x, 3x, and 4x.",
           "realesrgan-x4plus-anime": "Higher-quality anime model. Fixed 4x scale.",
-          "realesrgan-x4plus": "Photo / realistic model. Fixed 4x scale."
+          "realesrgan-x4plus": "Photo / realistic model. Fixed 4x scale.",
+          "realcugan-pro": "High-quality anime model. Supports 2x and 3x.",
+          "realcugan-se": "Balanced anime model. Supports 2x, 3x, and 4x.",
+          "realcugan-nose": "Lightest and fastest model. Fixed 2x scale."
         },
         "upscale_scale": "Scale",
         "upscale_scale_option": "{{scale}}x",

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -921,19 +921,25 @@
           "resize": "テクスチャサイズのみ変更します。DDS 形式は維持されます。",
           "resize_and_convert": "色空間を維持したまま、リサイズして別の DDS 形式へ再エンコードします。",
           "convert": "元のサイズを維持し、DDS 出力形式のみ変更します。",
-          "upscale": "Real-ESRGAN でテクスチャを拡大します。DDS 形式は維持されます。",
-          "upscale_and_convert": "Real-ESRGAN で拡大したあと、別の DDS 形式へ再エンコードします。"
+          "upscale": "AI アップスケーラーでテクスチャを拡大します。DDS 形式は維持されます。",
+          "upscale_and_convert": "AI アップスケーラーで拡大したあと、別の DDS 形式へ再エンコードします。"
         },
         "upscale_model": "アップスケールモデル",
         "upscale_model_options": {
           "realesr-animevideov3": "アニメ / ゲーム（既定）",
           "realesrgan-x4plus-anime": "アニメ x4+",
-          "realesrgan-x4plus": "写真 x4+"
+          "realesrgan-x4plus": "写真 x4+",
+          "realcugan-pro": "Real-CUGAN Pro",
+          "realcugan-se": "Real-CUGAN SE",
+          "realcugan-nose": "Real-CUGAN Nose"
         },
         "upscale_model_descriptions": {
           "realesr-animevideov3": "ゲーム・アニメテクスチャ向けの標準モデルです。2x、3x、4x に対応します。",
           "realesrgan-x4plus-anime": "高品質なアニメ向けモデルです。倍率は 4x 固定です。",
-          "realesrgan-x4plus": "写真・実写向けモデルです。倍率は 4x 固定です。"
+          "realesrgan-x4plus": "写真・実写向けモデルです。倍率は 4x 固定です。",
+          "realcugan-pro": "アニメ向け高品質モデルです。2x、3x をサポートします。",
+          "realcugan-se": "バランスの良いアニメモデルです。2x、3x、4x をサポートします。",
+          "realcugan-nose": "最も軽量で高速なモデルです。倍率は 2x に固定されます。"
         },
         "upscale_scale": "倍率",
         "upscale_scale_option": "{{scale}}倍",

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -940,19 +940,25 @@
           "resize": "텍스처 크기만 변경합니다. DDS 포맷은 유지됩니다.",
           "resize_and_convert": "텍스처를 리사이즈한 뒤 색공간은 유지하면서 다른 DDS 포맷으로 다시 인코딩합니다.",
           "convert": "원본 크기는 유지하고 DDS 출력 포맷만 변경합니다.",
-          "upscale": "Real-ESRGAN으로 텍스처를 확대합니다. DDS 포맷은 유지됩니다.",
-          "upscale_and_convert": "Real-ESRGAN으로 확대한 뒤 다른 DDS 포맷으로 다시 인코딩합니다."
+          "upscale": "AI 업스케일러로 텍스처를 확대합니다. DDS 포맷은 유지됩니다.",
+          "upscale_and_convert": "AI 업스케일러로 확대한 뒤 다른 DDS 포맷으로 다시 인코딩합니다."
         },
         "upscale_model": "업스케일 모델",
         "upscale_model_options": {
           "realesr-animevideov3": "애니 / 게임 (기본)",
           "realesrgan-x4plus-anime": "애니 x4+",
-          "realesrgan-x4plus": "실사 x4+"
+          "realesrgan-x4plus": "실사 x4+",
+          "realcugan-pro": "Real-CUGAN Pro",
+          "realcugan-se": "Real-CUGAN SE",
+          "realcugan-nose": "Real-CUGAN Nose"
         },
         "upscale_model_descriptions": {
           "realesr-animevideov3": "게임·애니 텍스처에 가장 무난한 기본 모델입니다. 2x, 3x, 4x를 지원합니다.",
           "realesrgan-x4plus-anime": "품질이 더 높은 애니 모델입니다. 배율은 4x로 고정됩니다.",
-          "realesrgan-x4plus": "실사·사진용 모델입니다. 배율은 4x로 고정됩니다."
+          "realesrgan-x4plus": "실사·사진용 모델입니다. 배율은 4x로 고정됩니다.",
+          "realcugan-pro": "애니 특화 고품질 모델입니다. 2x, 3x를 지원합니다.",
+          "realcugan-se": "균형 잡힌 애니 모델입니다. 2x, 3x, 4x를 지원합니다.",
+          "realcugan-nose": "가장 가볍고 빠른 모델입니다. 배율은 2x로 고정됩니다."
         },
         "upscale_scale": "배율",
         "upscale_scale_option": "{{scale}}배",

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -920,19 +920,25 @@
           "resize": "只修改纹理尺寸，DDS 格式保持不变。",
           "resize_and_convert": "在保持颜色空间不变的前提下缩放并重新编码为其他 DDS 格式。",
           "convert": "保持原始尺寸，只修改 DDS 输出格式。",
-          "upscale": "使用 Real-ESRGAN 放大纹理，DDS 格式保持不变。",
-          "upscale_and_convert": "使用 Real-ESRGAN 放大后再重新编码为其他 DDS 格式。"
+          "upscale": "使用 AI 放大工具放大纹理，DDS 格式保持不变。",
+          "upscale_and_convert": "使用 AI 放大工具放大后再重新编码为其他 DDS 格式。"
         },
         "upscale_model": "放大模型",
         "upscale_model_options": {
           "realesr-animevideov3": "二次元 / 游戏（默认）",
           "realesrgan-x4plus-anime": "二次元 x4+",
-          "realesrgan-x4plus": "写实 x4+"
+          "realesrgan-x4plus": "写实 x4+",
+          "realcugan-pro": "Real-CUGAN Pro",
+          "realcugan-se": "Real-CUGAN SE",
+          "realcugan-nose": "Real-CUGAN Nose"
         },
         "upscale_model_descriptions": {
           "realesr-animevideov3": "适合游戏和二次元纹理的默认模型，支持 2x、3x、4x。",
           "realesrgan-x4plus-anime": "更高质量的二次元模型，倍率固定为 4x。",
-          "realesrgan-x4plus": "适合照片和写实纹理的模型，倍率固定为 4x。"
+          "realesrgan-x4plus": "适合照片和写实纹理的模型，倍率固定为 4x。",
+          "realcugan-pro": "面向二次元的高质量模型，支持 2x、3x。",
+          "realcugan-se": "均衡的二次元模型，支持 2x、3x、4x。",
+          "realcugan-nose": "最轻量、最快的模型，倍率固定为 2x。"
         },
         "upscale_scale": "倍率",
         "upscale_scale_option": "{{scale}}x",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -117,10 +117,14 @@ export type TextureResizeOperation =
     | "upscale_and_convert";
 export type TextureColorSpace = "srgb" | "linear" | "unknown";
 export type TextureUpscaleScale = 2 | 3 | 4;
+export type TextureUpscaleEngine = "realesrgan" | "realcugan";
 export type TextureUpscaleModel =
     | "realesr-animevideov3"
     | "realesrgan-x4plus-anime"
-    | "realesrgan-x4plus";
+    | "realesrgan-x4plus"
+    | "realcugan-pro"
+    | "realcugan-se"
+    | "realcugan-nose";
 
 export interface TextureResizeSettings {
     mode: TextureResizeMode;
@@ -140,6 +144,11 @@ export interface TextureUpscaleRuntimeStatus {
     binaryPath: string | null;
     modelsPath: string | null;
     needsInstall: boolean;
+}
+
+export interface TextureUpscaleRuntimeStatuses {
+    realesrgan: TextureUpscaleRuntimeStatus;
+    realcugan: TextureUpscaleRuntimeStatus;
 }
 
 export interface TextureUpscaleProgressEvent {

--- a/src/shared/utils.texture-upscale.test.ts
+++ b/src/shared/utils.texture-upscale.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
     getAvailableTextureUpscaleScales,
+    getTextureUpscaleEngine,
     getTextureUpscaleTarget,
     isTextureUpscaleOperation,
     isUnsupportedTextureUpscaleFormat,
@@ -33,5 +34,22 @@ describe("texture upscale helpers", () => {
         expect(getAvailableTextureUpscaleScales("realesrgan-x4plus-anime")).toEqual([4]);
         expect(resolveTextureUpscaleScale("realesrgan-x4plus", 2)).toBe(4);
         expect(resolveTextureUpscaleScale("realesr-animevideov3", 3)).toBe(3);
+    });
+
+    it("limits realcugan models to their shipped scales", () => {
+        expect(getAvailableTextureUpscaleScales("realcugan-pro")).toEqual([2, 3]);
+        expect(getAvailableTextureUpscaleScales("realcugan-se")).toEqual([2, 3, 4]);
+        expect(getAvailableTextureUpscaleScales("realcugan-nose")).toEqual([2]);
+        expect(resolveTextureUpscaleScale("realcugan-pro", 4)).toBe(3);
+        expect(resolveTextureUpscaleScale("realcugan-nose", 3)).toBe(2);
+        expect(resolveTextureUpscaleScale("realcugan-se", 4)).toBe(4);
+    });
+
+    it("maps models to their upscale engine", () => {
+        expect(getTextureUpscaleEngine("realcugan-pro")).toBe("realcugan");
+        expect(getTextureUpscaleEngine("realcugan-se")).toBe("realcugan");
+        expect(getTextureUpscaleEngine("realcugan-nose")).toBe("realcugan");
+        expect(getTextureUpscaleEngine("realesr-animevideov3")).toBe("realesrgan");
+        expect(getTextureUpscaleEngine("realesrgan-x4plus")).toBe("realesrgan");
     });
 });

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -3,7 +3,7 @@ import { enUS, ko, zhCN } from "date-fns/locale";
 import { isNil } from "es-toolkit";
 import { type FilesizeOptions, filesize } from "filesize";
 
-import type { TextureUpscaleScale } from "./types";
+import type { TextureUpscaleEngine, TextureUpscaleScale } from "./types";
 
 export interface TextureResizeCandidate {
     width: number;
@@ -148,6 +148,9 @@ export const TEXTURE_UPSCALE_MODELS = [
     "realesr-animevideov3",
     "realesrgan-x4plus-anime",
     "realesrgan-x4plus",
+    "realcugan-pro",
+    "realcugan-se",
+    "realcugan-nose",
 ] as const;
 
 const UNSUPPORTED_UPSCALE_FORMAT_MARKERS = ["BC4", "BC5", "BC6H"] as const;
@@ -162,9 +165,21 @@ export function isUnsupportedTextureUpscaleFormat(format: string) {
     return UNSUPPORTED_UPSCALE_FORMAT_MARKERS.some((marker) => format.includes(marker));
 }
 
+export function getTextureUpscaleEngine(model: string): TextureUpscaleEngine {
+    return model.startsWith("realcugan") ? "realcugan" : "realesrgan";
+}
+
 export function getAvailableTextureUpscaleScales(model: string): readonly TextureUpscaleScale[] {
-    if (model === "realesr-animevideov3") {
+    if (model === "realesr-animevideov3" || model === "realcugan-se") {
         return TEXTURE_UPSCALE_SCALES;
+    }
+
+    if (model === "realcugan-pro") {
+        return [2, 3];
+    }
+
+    if (model === "realcugan-nose") {
+        return [2];
     }
 
     return [4];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Downloads and runs a new third-party Windows binary from GitHub (checksum-verified) and changes the upscale runtime status API shape. Existing Real-ESRGAN install flow is refactored but should behave the same.
> 
> **Overview**
> Adds **Real-CUGAN** as a second AI upscaler for texture tools, with Pro / SE / Nose models and per-model scale limits (2–3x, 2–4x, and 2x).
> 
> Extracts the Real-ESRGAN installer into a shared `NcnnVulkanRuntime` and wires Real-CUGAN through the same download, SHA-256 check, extract, and install-status path. Upscale jobs pick the engine from the selected model and spawn engine-specific CLI args (fixed no-denoise for CUGAN).
> 
> `getUpscaleRuntimeStatus` now returns **both** engines. UI copy is generalized to “AI upscaler” and lists the new models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a8b013593b8fd439a8e62e2e48c26337b33fd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Real-CUGAN as an AI upscaling engine alongside Real-ESRGAN.
  * Added Pro, SE, and Nose model options with model-specific scaling limits.
  * Added runtime installation, verification, progress reporting, and status tracking.
  * Upscaling now selects the appropriate engine and model settings automatically.
  * Added localized labels and descriptions for the new options.

* **Bug Fixes**
  * Improved checks for required runtime files and models.

* **Tests**
  * Added coverage for runtime validation, engine selection, model limits, and status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->