### PR TITLE
fix(download): add presigned url fallback after CDN error retries

### DIFF
--- a/src/main/lib/download.test.ts
+++ b/src/main/lib/download.test.ts
@@ -731,6 +731,75 @@ describe("FileDownloadTask executeWithSlowRetry progress correction", () => {
         expect(onComplete).toHaveBeenCalledOnce();
         performDownload.mockRestore();
     });
+
+    it("resets errorRetries when slow-chunk fallback switches to a presigned url", async () => {
+        const filePath = path.join(tempDir, "file.bin");
+        const targetPath = `${filePath}.ntmp`;
+        await writeFile(targetPath, "hello");
+        const cdnFile = {
+            ...file,
+            size: 11,
+            url: "https://n1.nahida.live/fil/file.bin",
+        };
+        const desktop = createDesktop();
+        const task = (new DownloadLib(desktop) as unknown as { task: DownloadTask }).task;
+        const registered: Array<{ abortSlow: () => void }> = [];
+        const register = vi.spyOn(slowChunkMonitor, "register").mockImplementation((input) => {
+            const transfer = {
+                key: `transfer-${registered.length}`,
+                abortReason: null as "slow-chunk" | null,
+                detect: null as "stall" | null,
+                chunkSpeedBps: 0,
+                peerMedianBps: 0,
+            };
+            registered.push({
+                abortSlow: () => {
+                    transfer.abortReason = "slow-chunk";
+                    transfer.detect = "stall";
+                    input.attemptController.abort();
+                },
+            });
+            return transfer as never;
+        });
+        const performDownload = vi.spyOn(task, "performDownload");
+        performDownload
+            .mockRejectedValueOnce(new Error("net::ERR_CONNECTION_RESET"))
+            .mockImplementationOnce(async (_currentFile, _target, signal) => {
+                await waitForSlowAbort(signal);
+            })
+            .mockImplementationOnce(async (_currentFile, _target, signal) => {
+                await waitForSlowAbort(signal);
+            })
+            .mockRejectedValueOnce(new Error("net::ERR_CONNECTION_RESET"))
+            .mockImplementationOnce(async (currentFile, currentTarget, _signal, options) => {
+                expect(currentFile.url).toBe("https://r2.test/signed");
+                expect(currentFile.urlOrigin).toBe("presign");
+                expect(options?.resumeFrom).toBe(5);
+                await writeFile(currentTarget, "hello world");
+            });
+
+        const onComplete = vi.fn();
+        const run = task.executeWithSlowRetry({
+            file: cdnFile,
+            filePath,
+            signal: new AbortController().signal,
+            onComplete,
+        });
+
+        await vi.waitFor(() => expect(performDownload).toHaveBeenCalledTimes(2));
+        registered[1]?.abortSlow();
+        await vi.waitFor(() => expect(performDownload).toHaveBeenCalledTimes(3));
+        registered[2]?.abortSlow();
+        await run;
+
+        expect(cdnFile.url).toBe("https://r2.test/signed");
+        expect(cdnFile.urlOrigin).toBe("presign");
+        expect(mocks.fetchPresignedUrl).toHaveBeenCalledTimes(1);
+        expect(performDownload).toHaveBeenCalledTimes(5);
+        expect(onComplete).toHaveBeenCalledOnce();
+        register.mockRestore();
+        performDownload.mockRestore();
+    });
 });
 
 describe("DownloadLib existing file handling", () => {

--- a/src/main/lib/download.test.ts
+++ b/src/main/lib/download.test.ts
@@ -691,6 +691,46 @@ describe("FileDownloadTask executeWithSlowRetry progress correction", () => {
         expect(performDownload).toHaveBeenCalledTimes(3);
         performDownload.mockRestore();
     });
+
+    it("falls back to a presigned url after CDN error retries are exhausted", async () => {
+        const filePath = path.join(tempDir, "file.bin");
+        const targetPath = `${filePath}.ntmp`;
+        await writeFile(targetPath, "hello");
+        const cdnFile = {
+            ...file,
+            size: 11,
+            url: "https://n1.nahida.live/fil/file.bin",
+        };
+        const desktop = createDesktop();
+        const task = (new DownloadLib(desktop) as unknown as { task: DownloadTask }).task;
+        const performDownload = vi.spyOn(task, "performDownload");
+        performDownload
+            .mockRejectedValueOnce(new Error("net::ERR_CONNECTION_RESET"))
+            .mockRejectedValueOnce(new Error("net::ERR_CONNECTION_RESET"))
+            .mockRejectedValueOnce(new Error("net::ERR_CONNECTION_RESET"))
+            .mockRejectedValueOnce(new Error("net::ERR_CONNECTION_RESET"))
+            .mockImplementationOnce(async (currentFile, currentTarget, _signal, options) => {
+                expect(currentFile.url).toBe("https://r2.test/signed");
+                expect(currentFile.urlOrigin).toBe("presign");
+                expect(options?.resumeFrom).toBe(5);
+                await writeFile(currentTarget, "hello world");
+            });
+
+        const onComplete = vi.fn();
+        await task.executeWithSlowRetry({
+            file: cdnFile,
+            filePath,
+            signal: new AbortController().signal,
+            onComplete,
+        });
+
+        expect(cdnFile.url).toBe("https://r2.test/signed");
+        expect(cdnFile.urlOrigin).toBe("presign");
+        expect(mocks.fetchPresignedUrl).toHaveBeenCalledTimes(1);
+        expect(performDownload).toHaveBeenCalledTimes(5);
+        expect(onComplete).toHaveBeenCalledOnce();
+        performDownload.mockRestore();
+    });
 });
 
 describe("DownloadLib existing file handling", () => {

--- a/src/main/lib/download.ts
+++ b/src/main/lib/download.ts
@@ -761,6 +761,7 @@ class FileDownloadTask {
                                 file.urlOrigin = "presign";
                                 urlOrigin = "presign";
                                 slowReconnects = 0;
+                                errorRetries = 0;
                                 this.desktop.logger.warn(
                                     {
                                         fileId: file.id,

--- a/src/main/lib/download.ts
+++ b/src/main/lib/download.ts
@@ -659,7 +659,8 @@ class FileDownloadTask {
         }
 
         const targetPath = `${filePath}.ntmp`;
-        const MAX_ERROR_RETRIES = 3;
+        const MAX_ERROR_RETRIES = 2;
+        const MAX_PRESIGN_RETRIES = 1;
         const monitor = this.desktop.service.transfer.slowChunkMonitor;
 
         let slowReconnects = 0;
@@ -830,15 +831,46 @@ class FileDownloadTask {
                         }
                     }
 
-                    if (!isAbortError(err) && errorRetries < MAX_ERROR_RETRIES) {
+                    const maxRetries =
+                        urlOrigin === "cdn" ? MAX_ERROR_RETRIES : MAX_PRESIGN_RETRIES;
+                    if (!isAbortError(err) && errorRetries < maxRetries) {
                         errorRetries += 1;
-                        const retryDelayMs = 2 ** errorRetries * 1000;
+                        const retryDelayMs = 2 ** errorRetries * 100;
                         this.desktop.logger.warn(
-                            `Retrying download for ${file.name} (${errorRetries}/${MAX_ERROR_RETRIES}) after ${toErrorMessage(err)}; waiting ${retryDelayMs}ms`,
+                            `Retrying download for ${file.name} (${errorRetries}/${maxRetries}) after ${toErrorMessage(err)}; waiting ${retryDelayMs}ms`,
                             "FileDownloadTask:retry",
                         );
                         await sleepWithAbort(retryDelayMs, signal);
                         continue;
+                    }
+
+                    if (urlOrigin === "cdn") {
+                        const freshUrl = await this.fetchPresignedDownloadUrl({
+                            fileId: file.id,
+                            link,
+                            signal,
+                        }).catch((presignErr: unknown) => {
+                            err = presignErr;
+                            return null;
+                        });
+                        if (freshUrl) {
+                            file.url = freshUrl;
+                            file.urlOrigin = "presign";
+                            urlOrigin = "presign";
+                            errorRetries = 0;
+                            this.desktop.logger.warn(
+                                {
+                                    fileId: file.id,
+                                    fileName: file.name,
+                                    remainingBytes: Math.max(0, file.size - reportedResumeBytes),
+                                    resumeFrom: reportedResumeBytes,
+                                    url: getSafeUrlResource(freshUrl),
+                                },
+                                "FileDownloadTask:presignFallback",
+                            );
+                            await resetAndWait(0);
+                            continue;
+                        }
                     }
 
                     throw err;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes download retry and origin-fallback behavior, which can affect transfer reliability and extra presign API usage, but stays within existing download recovery paths.
> 
> **Overview**
> CDN downloads that keep failing with network errors now switch to a presigned URL instead of giving up after retries.
> 
> `executeWithSlowRetry` uses **2** CDN error retries and **1** presign retry, with retry delays cut from seconds to hundreds of milliseconds. After CDN retries are exhausted, it fetches a presigned URL, resets `errorRetries`, and resumes from the existing partial file. Switching to presign on a slow-chunk fallback also resets `errorRetries` so the new origin still gets a retry budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb806b26d1fc5e3035142acabfa64ebc6f2ed28b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download reliability when CDN connections reset or become slow.
  * Added automatic fallback to a presigned URL after CDN retries are exhausted.
  * Downloads now resume from existing partial files during recovery.
  * Retry handling is reset correctly when switching connection methods.
  * Reduced retry delays for faster recovery.
  * Prevented duplicate completion notifications after successful recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->