### PR TITLE
model viewer ineffective toggle values

### DIFF
--- a/native/static-glb/src/lib.rs
+++ b/native/static-glb/src/lib.rs
@@ -144,8 +144,7 @@ impl Task for PrepareViewerTextureTask {
 
         let (final_width, final_height) = resized.dimensions();
         let analysis = analyze_rgba(resized.as_raw(), final_width, final_height)?;
-        let uses_alpha = analysis.has_alpha
-            && (analysis.partial_ratio > 0.0 || analysis.low_ratio >= 0.005);
+        let uses_alpha = analysis.has_alpha;
         let mime_type = if uses_alpha { "image/png" } else { "image/jpeg" };
         let bytes = encode_viewer_image(&resized, mime_type, 85)?;
         Ok(PrepareViewerTextureResult {

--- a/native/static-glb/src/lib.rs
+++ b/native/static-glb/src/lib.rs
@@ -12,6 +12,20 @@ use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
 #[napi(object)]
+pub struct PrepareViewerTextureInput {
+    pub texture_path: String,
+    pub max_pixels: u32,
+}
+
+#[napi(object)]
+pub struct PrepareViewerTextureResult {
+    pub bytes: Buffer,
+    pub mime_type: String,
+    pub width: u32,
+    pub height: u32,
+}
+
+#[napi(object)]
 pub struct PngAnalysis {
     pub has_alpha: bool,
     pub low_ratio: f64,
@@ -83,6 +97,111 @@ pub fn prepare_texture_for_material(
     input: PrepareTextureForMaterialInput,
 ) -> AsyncTask<PrepareTextureForMaterialTask> {
     AsyncTask::new(PrepareTextureForMaterialTask { input })
+}
+
+#[napi(ts_return_type = "Promise<PrepareViewerTextureResult>")]
+pub fn prepare_viewer_texture(
+    input: PrepareViewerTextureInput,
+) -> AsyncTask<PrepareViewerTextureTask> {
+    AsyncTask::new(PrepareViewerTextureTask { input })
+}
+
+pub struct PrepareViewerTextureTask {
+    input: PrepareViewerTextureInput,
+}
+
+impl Task for PrepareViewerTextureTask {
+    type Output = PrepareViewerTextureResult;
+    type JsValue = PrepareViewerTextureResult;
+
+    fn compute(&mut self) -> napi::Result<Self::Output> {
+        let input = &self.input;
+        let texture_path = Path::new(&input.texture_path);
+        let extension = texture_path
+            .extension()
+            .and_then(|value| value.to_str())
+            .map(|value| value.to_ascii_lowercase())
+            .unwrap_or_default();
+
+        let rgba = if extension == "dds" {
+            load_dds_rgba(texture_path)?.0
+        } else if extension == "png" || extension == "jpg" || extension == "jpeg" {
+            load_png_rgba(texture_path)?.0
+        } else {
+            return Err(napi::Error::from_reason(format!(
+                "Unsupported texture type for viewer: {}",
+                input.texture_path
+            )));
+        };
+
+        let (width, height) = rgba.dimensions();
+        let target = viewer_texture_target_size(width, height, input.max_pixels);
+        let resized = if target.0 != width || target.1 != height {
+            image::imageops::resize(&rgba, target.0, target.1, image::imageops::FilterType::Triangle)
+        } else {
+            rgba
+        };
+
+        let (final_width, final_height) = resized.dimensions();
+        let analysis = analyze_rgba(resized.as_raw(), final_width, final_height)?;
+        let uses_alpha = analysis.has_alpha
+            && (analysis.partial_ratio > 0.0 || analysis.low_ratio >= 0.005);
+        let mime_type = if uses_alpha { "image/png" } else { "image/jpeg" };
+        let bytes = encode_viewer_image(&resized, mime_type, 85)?;
+        Ok(PrepareViewerTextureResult {
+            bytes: bytes.into(),
+            mime_type: mime_type.to_string(),
+            width: final_width,
+            height: final_height,
+        })
+    }
+
+    fn resolve(&mut self, _: napi::Env, output: Self::Output) -> napi::Result<Self::JsValue> {
+        Ok(output)
+    }
+}
+
+fn viewer_texture_target_size(width: u32, height: u32, max_pixels: u32) -> (u32, u32) {
+    if width == 0 || height == 0 {
+        return (width, height);
+    }
+    let mut next_width = width;
+    let mut next_height = height;
+    while (next_width as u64) * (next_height as u64) > max_pixels as u64
+        && (next_width > 1 || next_height > 1)
+    {
+        next_width = std::cmp::max(1, next_width / 2);
+        next_height = std::cmp::max(1, next_height / 2);
+    }
+    (next_width, next_height)
+}
+
+fn encode_viewer_image(
+    rgba: &RgbaImage,
+    mime_type: &str,
+    jpeg_quality: u32,
+) -> napi::Result<Vec<u8>> {
+    let mut output = Vec::new();
+    if mime_type == "image/png" {
+        let encoder = PngEncoder::new(&mut output);
+        encoder
+            .write_image(
+                rgba.as_raw(),
+                rgba.width(),
+                rgba.height(),
+                ColorType::Rgba8.into(),
+            )
+            .map_err(|error| {
+                napi::Error::from_reason(format!("Failed to encode viewer PNG: {error}"))
+            })?;
+        return Ok(output);
+    }
+
+    let mut encoder = JpegEncoder::new_with_quality(&mut output, jpeg_quality.clamp(1, 100) as u8);
+    encoder.encode_image(rgba).map_err(|error| {
+        napi::Error::from_reason(format!("Failed to encode viewer JPEG: {error}"))
+    })?;
+    Ok(output)
 }
 
 impl Task for PrepareTextureForMaterialTask {

--- a/src/main/lib/mod-viewer/load.test.ts
+++ b/src/main/lib/mod-viewer/load.test.ts
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
 
-import { applyVariableSelection, evaluateViewerState } from "@shared/mod-viewer/eval";
+import {
+    applyVariableSelection,
+    computeIneffectiveValues,
+    evaluateViewerState,
+} from "@shared/mod-viewer/eval";
 import fse from "fs-extra";
 import { PNG } from "pngjs";
 import { afterEach, describe, it } from "vitest";
@@ -539,6 +543,117 @@ format = DXGI_FORMAT_R32_UINT
         const withEffects = evaluateViewerState(payload, selected);
         assert.equal(withEffects.meshes[0].visible, false);
         assert.equal(withEffects.meshes[1].visible, true);
+    });
+
+    it("applies toggle side effects but hides single-value vars from the panel", async () => {
+        const root = await makeMod({
+            ini: `[Constants]
+global persist $top = 1
+global persist $onepiece = 1
+[KeyTop]
+condition = $active == 1
+key = no_modifiers UP
+type = cycle
+$top = 0,1,2,3
+$onepiece = 0
+[KeyOnePiece]
+condition = $active == 1
+key = no_modifiers DOWN
+type = cycle
+$onepiece = 0,1
+[TextureOverrideBody]
+ib = ResourceBodyIB
+vb0 = ResourcePos
+vb1 = ResourceTc
+if $top == 1 && $onepiece == 0
+drawindexed = 3, 0, 0
+endif
+if $onepiece == 1
+drawindexed = 3, 3, 0
+endif
+[ResourcePos]
+filename = pos.buf
+stride = 40
+[ResourceTc]
+filename = tc.buf
+stride = 20
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+`,
+            ib: Buffer.from(new Uint32Array([0, 1, 2, 3, 4, 5]).buffer),
+            vertexCount: 8,
+        });
+
+        const payload = await loadModViewerPayload(root);
+        const top = payload.variables.find((variable) => variable.id === "top");
+        assert.ok(top);
+        assert.ok(top.effects?.some((effect) => effect.var === "onepiece"));
+        assert.ok(
+            !payload.variables.some(
+                (variable) => variable.id === "onepiece" && variable.label === "Top",
+            ),
+        );
+
+        const selected = applyVariableSelection(payload.defaultState, top, "2");
+        assert.equal(String(selected.top), "2");
+        assert.equal(String(selected.onepiece), "0");
+        const evaluated = evaluateViewerState(payload, selected);
+        assert.equal(evaluated.meshes[0].visible, false);
+        assert.equal(evaluated.meshes[1].visible, false);
+    });
+
+    it("disables toggle values that produce no visible mesh change", async () => {
+        const root = await makeMod({
+            ini: `[Constants]
+global persist $skirt = 0
+global persist $bottom = 0
+global persist $futa = 0
+[KeySkirt]
+type = cycle
+$skirt = 0,1
+[KeyBottom]
+type = cycle
+$bottom = 0,1
+[KeyFutanari]
+type = cycle
+$futa = 0,1,2,3,4
+$bottom = 0
+[TextureOverrideBody]
+ib = ResourceBodyIB
+vb0 = ResourcePos
+vb1 = ResourceTc
+if $skirt == 1 && ($bottom != 0 || ($bottom == 0 && $futa != 4))
+drawindexed = 3, 0, 0
+endif
+[ResourcePos]
+filename = pos.buf
+stride = 40
+[ResourceTc]
+filename = tc.buf
+stride = 20
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+`,
+            ib: Buffer.from(new Uint32Array([0, 1, 2, 3, 4, 5]).buffer),
+            vertexCount: 8,
+        });
+
+        const payload = await loadModViewerPayload(root);
+
+        // futa=4, bottom=0 → skirt=1 is ineffective (condition excludes futa==4)
+        const dead = computeIneffectiveValues(payload, { futa: "4", bottom: "0", skirt: "0" });
+        const skirtIneffective = dead.get("skirt");
+        assert.ok(skirtIneffective);
+        const skirt1Entry = skirtIneffective.get("1");
+        assert.ok(skirt1Entry);
+        assert.ok(skirt1Entry.blockingVars.some((v) => v.includes("Futanari")));
+        assert.ok(!skirtIneffective.has("0"));
+
+        // futa=0, bottom=0 → skirt=1 is effective
+        const live = computeIneffectiveValues(payload, { futa: "0", bottom: "0", skirt: "0" });
+        assert.ok(!live.has("skirt") || !live.get("skirt")!.has("1"));
     });
 
     it("evaluates a second toggle without rebuilding geometry or converting GLB", async () => {

--- a/src/main/lib/mod-viewer/load.test.ts
+++ b/src/main/lib/mod-viewer/load.test.ts
@@ -715,6 +715,74 @@ format = DXGI_FORMAT_R32_UINT
         assert.ok(!live.has("skirt") || !live.get("skirt")!.has("1"));
     });
 
+    it("resolves hidden single-value effect targets as blocking variables", async () => {
+        const root = await makeMod({
+            ini: `[Constants]
+global persist $skirt = 0
+global persist $outfit = 0
+global persist $body = 0
+global $clickedSlot
+[CommandListClickedSlot]
+if $clickedSlot == 1
+    $outfit = 1 - $outfit
+    if $outfit == 1
+        $body = 1
+    endif
+elif $clickedSlot == 2
+    $skirt = 1 - $skirt
+endif
+[TextureOverrideBody]
+ib = ResourceBodyIB
+vb0 = ResourcePos
+vb1 = ResourceTc
+if $skirt == 1 && $body != 0
+drawindexed = 3, 0, 0
+endif
+[ResourcePos]
+filename = pos.buf
+stride = 40
+[ResourceTc]
+filename = tc.buf
+stride = 20
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+`,
+            ib: Buffer.from(new Uint32Array([0, 1, 2, 3, 4, 5]).buffer),
+            vertexCount: 8,
+        });
+
+        const payload = await loadModViewerPayload(root);
+        const outfit = payload.variables.find((variable) => variable.id === "outfit");
+        assert.ok(outfit);
+        // body is a hidden single-value effect target, not a panel variable
+        assert.ok(!payload.variables.some((variable) => variable.id === "body"));
+        assert.ok(outfit.effects?.some((effect) => effect.var === "body"));
+
+        // outfit=0 → body stays 0 → skirt=1 is ineffective (condition needs body != 0)
+        const dead = computeIneffectiveValues(payload, {
+            outfit: "0",
+            skirt: "0",
+            body: "0",
+        });
+        const skirtIneffective = dead.get("skirt");
+        assert.ok(skirtIneffective);
+        const skirt1Entry = skirtIneffective.get("1");
+        assert.ok(skirt1Entry);
+        // outfit should be reported as the blocking variable even though only
+        // its hidden effect target body co-occurs in the mesh condition
+        assert.ok(skirt1Entry.blockingVars.some((v) => v.id === "outfit"));
+        assert.ok(!skirt1Entry.blockingVars.some((v) => v.id === "body"));
+
+        // outfit=1 → body=1 → skirt=1 is effective
+        const live = computeIneffectiveValues(payload, {
+            outfit: "1",
+            skirt: "0",
+            body: "1",
+        });
+        assert.ok(!live.has("skirt") || !live.get("skirt")!.has("1"));
+    });
+
     it("evaluates a second toggle without rebuilding geometry or converting GLB", async () => {
         const loadSource = await fse.readFile(new URL("./load.ts", import.meta.url), "utf8");
         const evalSource = await fse.readFile(

--- a/src/main/lib/mod-viewer/load.test.ts
+++ b/src/main/lib/mod-viewer/load.test.ts
@@ -607,6 +607,61 @@ format = DXGI_FORMAT_R32_UINT
         assert.equal(evaluated.meshes[1].visible, false);
     });
 
+    it("tracks toggle effect variables as gating vars for draw conditions", async () => {
+        const root = await makeMod({
+            ini: `[Constants]
+global persist $top = 0
+global persist $resetvar = 0
+[KeyTop]
+condition = $active == 1
+key = no_modifiers UP
+type = cycle
+$top = 0,1,2,3
+$resetvar = 0
+[TextureOverrideBody]
+ib = ResourceBodyIB
+vb0 = ResourcePos
+vb1 = ResourceTc
+if $top == 1
+if $resetvar == 0
+drawindexed = 3, 0, 0
+endif
+endif
+if $resetvar == 1
+drawindexed = 3, 3, 0
+endif
+[ResourcePos]
+filename = pos.buf
+stride = 40
+[ResourceTc]
+filename = tc.buf
+stride = 20
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+`,
+            ib: Buffer.from(new Uint32Array([0, 1, 2, 3, 4, 5]).buffer),
+            vertexCount: 8,
+        });
+
+        const payload = await loadModViewerPayload(root);
+
+        // With resetvar=0 (default), top=0 should hide both draws.
+        const baseline = evaluateViewerState(payload, { top: "0", resetvar: "0" });
+        assert.equal(baseline.meshes[0].visible, false);
+        assert.equal(baseline.meshes[1].visible, false);
+
+        // With resetvar=1, the second draw should appear regardless of top.
+        const reset = evaluateViewerState(payload, { top: "0", resetvar: "1" });
+        assert.equal(reset.meshes[0].visible, false);
+        assert.equal(reset.meshes[1].visible, true);
+
+        // With top=1 and resetvar=0, the first draw should appear.
+        const active = evaluateViewerState(payload, { top: "1", resetvar: "0" });
+        assert.equal(active.meshes[0].visible, true);
+        assert.equal(active.meshes[1].visible, false);
+    });
+
     it("disables toggle values that produce no visible mesh change", async () => {
         const root = await makeMod({
             ini: `[Constants]
@@ -652,7 +707,7 @@ format = DXGI_FORMAT_R32_UINT
         assert.ok(skirtIneffective);
         const skirt1Entry = skirtIneffective.get("1");
         assert.ok(skirt1Entry);
-        assert.ok(skirt1Entry.blockingVars.some((v) => v.includes("Futanari")));
+        assert.ok(skirt1Entry.blockingVars.some((v) => v.label.includes("Futanari")));
         assert.ok(!skirtIneffective.has("0"));
 
         // futa=0, bottom=0 → skirt=1 is effective

--- a/src/main/lib/mod-viewer/load.test.ts
+++ b/src/main/lib/mod-viewer/load.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@shared/mod-viewer/eval";
 import fse from "fs-extra";
 import { PNG } from "pngjs";
+import sharp from "sharp";
 import { afterEach, describe, it } from "vitest";
 
 import { DNF_FALSE, isUnconstrained, sameDnf } from "./dnf";
@@ -40,14 +41,17 @@ function makeColorPng(width = 16, height = 16) {
     return PNG.sync.write(png);
 }
 
-function makePngIhdr(width: number, height: number) {
-    const header = Buffer.alloc(24);
-    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(header);
-    header.writeUInt32BE(13, 8);
-    header.write("IHDR", 12);
-    header.writeUInt32BE(width, 16);
-    header.writeUInt32BE(height, 20);
-    return header;
+function makeOversizedPng(width: number, height: number) {
+    return sharp({
+        create: {
+            width,
+            height,
+            channels: 4,
+            background: { r: 32, g: 64, b: 96, alpha: 1 },
+        },
+    })
+        .png()
+        .toBuffer();
 }
 
 function makeDdsHeader(width: number, height: number) {
@@ -2119,7 +2123,7 @@ filename = Textures/Components-3 t=f58624fb.png
                 await fse.ensureDir(path.join(dir, "Textures"));
                 await fse.writeFile(
                     path.join(dir, "Textures", "Components-3 t=7d8d1ae0.png"),
-                    makePngIhdr(8192, 8192),
+                    await makeOversizedPng(8192, 8192),
                 );
                 await fse.writeFile(
                     path.join(dir, "Textures", "Components-3 t=f58624fb.png"),

--- a/src/main/lib/mod-viewer/load.ts
+++ b/src/main/lib/mod-viewer/load.ts
@@ -248,6 +248,7 @@ function buildVariables(
                 values: values.map((value) => ({ value, label: value })),
                 order,
                 controlType: "buttons",
+                effects: info.effects.map((effect) => ({ when: null, ...effect })),
             });
         }
     }

--- a/src/main/lib/mod-viewer/load.ts
+++ b/src/main/lib/mod-viewer/load.ts
@@ -2,6 +2,8 @@ import path from "node:path";
 
 import type { ViewerStateValue, ViewerVariable, ModViewerPayload } from "@shared/mod-viewer/types";
 
+import type { Logger } from "../../internal/logger";
+
 import { animationFrameValues, extractPresentAnimations } from "./animations";
 import {
     attachShapeSliders,
@@ -23,7 +25,10 @@ import { extractShapeSliders } from "./shapes";
 import { extractStateRules } from "./state-rules";
 import { extractToggleKeys, extractVariableDefaults } from "./toggles";
 
-export async function loadModViewerPayload(modPath: string): Promise<ModViewerPayload> {
+export async function loadModViewerPayload(
+    modPath: string,
+    logger?: Logger,
+): Promise<ModViewerPayload> {
     const folderPath = path.resolve(modPath);
     const iniPaths = await discoverIniPaths(folderPath);
     if (iniPaths.length === 0) {
@@ -79,6 +84,7 @@ export async function loadModViewerPayload(modPath: string): Promise<ModViewerPa
 
         const gatingVars = new Set<string>([
             ...Object.values(toggles).flatMap((info) => Object.keys(info.vars)),
+            ...Object.values(toggles).flatMap((info) => info.effects.map((effect) => effect.var)),
             ...Object.values(menu).map((info) => info.var),
             ...Object.values(menu).flatMap((info) => info.effects.map((effect) => effect.var)),
             ...rules.map((rule) => rule.var),
@@ -124,7 +130,7 @@ export async function loadModViewerPayload(modPath: string): Promise<ModViewerPa
         throw new Error(`No mesh geometry found across ${iniPaths.length} ini file(s).`);
     }
 
-    const built = await buildMeshResult(groups, folderPath);
+    const built = await buildMeshResult(groups, folderPath, logger);
     if (built.meshes.length === 0) {
         throw new Error("No mesh data could be extracted (buffer files missing?).");
     }

--- a/src/main/lib/mod-viewer/mesh-builder.test.ts
+++ b/src/main/lib/mod-viewer/mesh-builder.test.ts
@@ -69,10 +69,10 @@ describe("buildMeshResult", () => {
             ],
             root,
         );
-        assert.equal(result.textures["diffuse::diffuse.png"]?.mimeType, "image/png");
-        assert.deepEqual(result.textures["diffuse::diffuse.png"]?.bytes, png);
+        assert.equal(result.textures["diffuse::diffuse.png"]?.mimeType, "image/jpeg");
+        assert.ok(result.textures["diffuse::diffuse.png"]?.bytes.length);
         assert.equal(result.textures["diffuse::alt.jpg"]?.mimeType, "image/jpeg");
-        assert.deepEqual(result.textures["diffuse::alt.jpg"]?.bytes, jpeg);
+        assert.ok(result.textures["diffuse::alt.jpg"]?.bytes.length);
     });
 
     it("omits unreadable png and jpeg textures instead of keeping original bytes", async () => {
@@ -132,7 +132,6 @@ describe("buildMeshResult", () => {
             root,
         );
         const encoded = result.textures["diffuse::diffuse.png"];
-        assert.equal(encoded?.mimeType, "image/png");
         assert.ok(encoded);
         const metadata = await sharp(encoded.bytes).metadata();
         assert.equal(metadata.width, 2048);

--- a/src/main/lib/mod-viewer/mesh-builder.ts
+++ b/src/main/lib/mod-viewer/mesh-builder.ts
@@ -1,15 +1,15 @@
+import os from "node:os";
 import path from "node:path";
 
-import { prepareTextureForMaterial } from "@native/static-glb";
+import { prepareViewerTexture } from "@native/static-glb";
 import type {
-    TextureVariant,
     ViewerMesh,
     ViewerShapeTarget,
     ViewerTexture,
     ViewerTextureRole,
 } from "@shared/mod-viewer/types";
 import fse from "fs-extra";
-import sharp from "sharp";
+import pLimit from "p-limit";
 
 import type { Logger } from "../../internal/logger";
 import type { DrawGroup, DrawRecord } from "./draw-groups";
@@ -44,6 +44,11 @@ export async function buildMeshResult(
     const rawBufCache = new Map<string, Buffer>();
     let textureEncodeMs = 0;
     let textureCount = 0;
+    let textureEncodeStartedAt = 0;
+    let textureEncodeEndedAt = 0;
+    const texturePromises = new Map<string, Promise<string | null>>();
+    const textureConcurrency = Math.max(1, Math.min(os.availableParallelism(), 8));
+    const limitTextureEncode = pLimit(textureConcurrency);
     const bufCache = new Map<
         string,
         {
@@ -101,6 +106,79 @@ export async function buildMeshResult(
         return entry;
     };
 
+    const scheduleTextureEncode = (
+        relative: string | undefined,
+        role: ViewerTextureRole = "diffuse",
+    ): Promise<string | null> => {
+        if (!relative) {
+            return Promise.resolve(null);
+        }
+        const resolved = safeResourcePath(modDir, relative);
+        if (!resolved) {
+            return Promise.resolve(null);
+        }
+        const key = textureKey(path.relative(modDir, resolved).replaceAll("\\", "/"), role);
+        const existing = texturePromises.get(key);
+        if (existing) {
+            return existing;
+        }
+        const promise = limitTextureEncode(async () => {
+            if (textures[key]) {
+                return key;
+            }
+            if (!(await fse.pathExists(resolved))) {
+                return null;
+            }
+            if (!textureEncodeStartedAt) {
+                textureEncodeStartedAt = Date.now();
+            }
+            const encoded = await encodeTexture(resolved);
+            textureEncodeEndedAt = Date.now();
+            textureCount += 1;
+            if (!encoded) {
+                return null;
+            }
+            textures[key] = {
+                texKey: key,
+                role,
+                bytes: encoded.bytes,
+                mimeType: encoded.mimeType,
+                relativePath: path.relative(modDir, resolved).replaceAll("\\", "/"),
+            };
+            return key;
+        });
+        texturePromises.set(key, promise);
+        return promise;
+    };
+
+    const resolveTextureVariants = async (rules: DrawRecord["textureVariants"]) => {
+        const keys = await Promise.all(
+            (rules ?? []).map((variant) => scheduleTextureEncode(variant.file)),
+        );
+        return keys.flatMap((key, index) =>
+            key ? [{ conditions: rules![index].conditions, texKey: key }] : [],
+        );
+    };
+
+    const resolveChannel = async (
+        channel: ViewerTextureRole,
+        defaultFile: string | undefined,
+        variants: DrawRecord["normalMapVariants"],
+    ) => {
+        const [key, variantKeys] = await Promise.all([
+            scheduleTextureEncode(defaultFile, channel),
+            Promise.all(
+                (variants ?? []).map((variant) => scheduleTextureEncode(variant.file, channel)),
+            ),
+        ]);
+        return {
+            key,
+            variants: variantKeys.flatMap((variantKey, index) =>
+                variantKey ? [{ conditions: variants![index].conditions, texKey: variantKey }] : [],
+            ),
+        };
+    };
+
     for (const group of groups) {
         const posPath = safeResourcePath(modDir, group.positionFile);
         const tcPath = safeResourcePath(modDir, group.texcoordFile);
@@ -121,34 +199,6 @@ export async function buildMeshResult(
             ibCache.set(ibPath, await readBuffer(ibPath));
         }
         const unique = deduplicateDraws(group);
-
-        const ensureTexture = async (
-            relative: string | undefined,
-            role: ViewerTextureRole = "diffuse",
-        ) => {
-            const resolved = safeResourcePath(modDir, relative);
-            if (!resolved || !(await fse.pathExists(resolved))) {
-                return null;
-            }
-            const key = textureKey(path.relative(modDir, resolved).replaceAll("\\", "/"), role);
-            if (!textures[key]) {
-                const encodeStartedAt = Date.now();
-                const encoded = await encodeTexture(resolved, role, readBuffer);
-                textureEncodeMs += Date.now() - encodeStartedAt;
-                textureCount += 1;
-                if (!encoded) {
-                    return null;
-                }
-                textures[key] = {
-                    texKey: key,
-                    role,
-                    bytes: encoded.bytes,
-                    mimeType: encoded.mimeType,
-                    relativePath: path.relative(modDir, resolved).replaceAll("\\", "/"),
-                };
-            }
-            return key;
-        };
 
         for (const draw of unique) {
             let drawIbPath = ibPath;
@@ -287,7 +337,20 @@ export async function buildMeshResult(
             }
 
             const indices = Uint32Array.from(shifted, (value) => remap.get(value) ?? 0);
-            const texKey = await ensureTexture(draw.textureDefaultFile);
+
+            const textureRules = draw.textureAssignments ?? draw.textureVariants ?? [];
+            const [texKey, textureVariants, normal, light, material] = await Promise.all([
+                scheduleTextureEncode(draw.textureDefaultFile),
+                resolveTextureVariants(textureRules),
+                resolveChannel("normal_map", draw.normalMapDefaultFile, draw.normalMapVariants),
+                resolveChannel("light_map", draw.lightMapDefaultFile, draw.lightMapVariants),
+                resolveChannel(
+                    "material_map",
+                    draw.materialMapDefaultFile,
+                    draw.materialMapVariants,
+                ),
+            ]);
+
             const shapeTargets: ViewerShapeTarget[] = shapeBuffers.map((shape) => ({
                 var: shape.slider.var,
                 positions: shape.positions,
@@ -334,42 +397,6 @@ export async function buildMeshResult(
                 });
             }
 
-            const textureRules = draw.textureAssignments ?? draw.textureVariants ?? [];
-            const textureVariants: TextureVariant[] = [];
-            for (const variant of textureRules) {
-                const key = await ensureTexture(variant.file);
-                if (key) {
-                    textureVariants.push({ conditions: variant.conditions, texKey: key });
-                }
-            }
-
-            const aux = async (
-                channel: ViewerTextureRole,
-                defaultFile?: string,
-                variants?: DrawRecord["normalMapVariants"],
-            ) => {
-                const key = await ensureTexture(defaultFile, channel);
-                const resolved: TextureVariant[] = [];
-                for (const variant of variants ?? []) {
-                    const variantKey = await ensureTexture(variant.file, channel);
-                    if (variantKey) {
-                        resolved.push({ conditions: variant.conditions, texKey: variantKey });
-                    }
-                }
-                return { key, variants: resolved };
-            };
-            const normal = await aux(
-                "normal_map",
-                draw.normalMapDefaultFile,
-                draw.normalMapVariants,
-            );
-            const light = await aux("light_map", draw.lightMapDefaultFile, draw.lightMapVariants);
-            const material = await aux(
-                "material_map",
-                draw.materialMapDefaultFile,
-                draw.materialMapVariants,
-            );
-
             meshes.push({
                 id: draw.label,
                 component: group.displayName || group.name,
@@ -391,6 +418,9 @@ export async function buildMeshResult(
         }
     }
 
+    if (textureCount > 0) {
+        textureEncodeMs = textureEncodeEndedAt - textureEncodeStartedAt;
+    }
     logger?.info(
         `Texture encoding completed in ${textureEncodeMs}ms (textures=${textureCount})`,
         "StaticGlb.loadForViewer",
@@ -689,59 +719,20 @@ export function viewerPreviewTextureSize(
 
 async function encodeTexture(
     filePath: string,
-    role: ViewerTextureRole,
-    readBuffer: (filePath: string) => Promise<Buffer>,
 ): Promise<{ bytes: Buffer; mimeType: "image/png" | "image/jpeg" } | null> {
     const ext = path.extname(filePath).toLowerCase();
-    if (ext === ".png") {
-        return downscaleViewerTexture({ bytes: await readBuffer(filePath), mimeType: "image/png" });
-    }
-    if (ext === ".jpg" || ext === ".jpeg") {
-        return downscaleViewerTexture({
-            bytes: await readBuffer(filePath),
-            mimeType: "image/jpeg",
-        });
-    }
-    if (ext !== ".dds") {
+    if (ext !== ".dds" && ext !== ".png" && ext !== ".jpg" && ext !== ".jpeg") {
         return null;
     }
-
-    const prepared = await prepareTextureForMaterial({
-        texturePath: filePath,
-        resourceName: role,
-        textureFormat: "png",
-        jpegQuality: 85,
-        allowCacheReuse: false,
-        cacheDir: "",
-    }).catch(() => null);
-    if (!prepared?.image) {
-        return null;
-    }
-    return downscaleViewerTexture({
-        bytes: prepared.image,
-        mimeType: prepared.mimeType === "image/jpeg" ? "image/jpeg" : "image/png",
-    });
-}
-
-async function downscaleViewerTexture(encoded: {
-    bytes: Buffer;
-    mimeType: "image/png" | "image/jpeg";
-}): Promise<{ bytes: Buffer; mimeType: "image/png" | "image/jpeg" } | null> {
     try {
-        const metadata = await sharp(encoded.bytes).metadata();
-        if (!metadata.width || !metadata.height) {
-            return null;
-        }
-        const target = viewerPreviewTextureSize(metadata.width, metadata.height);
-        if (target.width === metadata.width && target.height === metadata.height) {
-            return encoded;
-        }
-        const resized = sharp(encoded.bytes).resize(target.width, target.height);
-        const bytes =
-            encoded.mimeType === "image/jpeg"
-                ? await resized.jpeg({ quality: 85 }).toBuffer()
-                : await resized.png().toBuffer();
-        return { bytes, mimeType: encoded.mimeType };
+        const result = await prepareViewerTexture({
+            texturePath: filePath,
+            maxPixels: VIEWER_TEXTURE_MAX_PIXELS,
+        });
+        return {
+            bytes: result.bytes,
+            mimeType: result.mimeType === "image/jpeg" ? "image/jpeg" : "image/png",
+        };
     } catch {
         return null;
     }

--- a/src/main/lib/mod-viewer/mesh-builder.ts
+++ b/src/main/lib/mod-viewer/mesh-builder.ts
@@ -11,6 +11,7 @@ import type {
 import fse from "fs-extra";
 import sharp from "sharp";
 
+import type { Logger } from "../../internal/logger";
 import type { DrawGroup, DrawRecord } from "./draw-groups";
 import type { ShapeSlider } from "./shapes";
 
@@ -35,11 +36,14 @@ export type MeshBuildResult = {
 export async function buildMeshResult(
     groups: DrawGroup[],
     modDir: string,
+    logger?: Logger,
 ): Promise<MeshBuildResult> {
     const meshes: ViewerMesh[] = [];
     const textures: Record<string, ViewerTexture> = {};
     const ibCache = new Map<string, Buffer>();
     const rawBufCache = new Map<string, Buffer>();
+    let textureEncodeMs = 0;
+    let textureCount = 0;
     const bufCache = new Map<
         string,
         {
@@ -128,7 +132,10 @@ export async function buildMeshResult(
             }
             const key = textureKey(path.relative(modDir, resolved).replaceAll("\\", "/"), role);
             if (!textures[key]) {
+                const encodeStartedAt = Date.now();
                 const encoded = await encodeTexture(resolved, role, readBuffer);
+                textureEncodeMs += Date.now() - encodeStartedAt;
+                textureCount += 1;
                 if (!encoded) {
                     return null;
                 }
@@ -384,6 +391,10 @@ export async function buildMeshResult(
         }
     }
 
+    logger?.info(
+        `Texture encoding completed in ${textureEncodeMs}ms (textures=${textureCount})`,
+        "StaticGlb.loadForViewer",
+    );
     return {
         meshes: meshes.map((mesh) => ({
             ...mesh,

--- a/src/main/lib/mod-viewer/toggles.ts
+++ b/src/main/lib/mod-viewer/toggles.ts
@@ -2,12 +2,18 @@ import type { IniSections } from "./ini";
 
 import { canonicalVarNames } from "./ini";
 
+export type ToggleEffect = {
+    var: string;
+    value: string;
+};
+
 export type ToggleKey = {
     name: string;
     key: string;
     back: string;
     keyDisplay: string;
     vars: Record<string, string[]>;
+    effects: ToggleEffect[];
     source?: string;
     iniPath?: string;
     section: string;
@@ -29,6 +35,7 @@ export function extractToggleKeys(
         let backCombo = "";
         let keyType: string | undefined;
         const cvars: Record<string, string[]> = {};
+        const effects: ToggleEffect[] = [];
         let iniPath: string | undefined;
         for (const line of lines) {
             iniPath ??= line.iniPath;
@@ -51,8 +58,15 @@ export function extractToggleKeys(
                     .split(",")
                     .map((entry) => entry.trim())
                     .filter(Boolean);
-                if (variable && values.length > 0) {
+                if (variable && values.length >= 2) {
                     cvars[varPrefix ? `${varPrefix}${variable}` : variable] = values;
+                } else if (variable && values.length === 1) {
+                    // Single-value entries (e.g. "$onepiece = 0") are side effects
+                    // that reset another variable when this key cycles, not toggle values.
+                    effects.push({
+                        var: varPrefix ? `${varPrefix}${variable}` : variable,
+                        value: values[0],
+                    });
                 }
             }
         }
@@ -66,6 +80,7 @@ export function extractToggleKeys(
             back: backCombo,
             keyDisplay: formatKeyCombo(keyCombo),
             vars: cvars,
+            effects,
             source,
             iniPath,
             section: name,

--- a/src/main/services/mod-tools/static-glb.ts
+++ b/src/main/services/mod-tools/static-glb.ts
@@ -247,7 +247,7 @@ export class StaticGlb {
         this.desktop.logger.info("Starting model viewer load", "StaticGlb.loadForViewer");
         const memorySessionId = createModelViewerMemorySession();
         try {
-            const payload = await loadModViewerPayload(modPath);
+            const payload = await loadModViewerPayload(modPath, this.desktop.logger);
             const writeBuffer = (bufferId: string, buffer: Buffer, contentType?: string) =>
                 writeModelViewerMemoryBuffer(memorySessionId, bufferId, buffer, contentType);
 

--- a/src/renderer/src/components/tools/model-viewer/model-viewer-dialog.tsx
+++ b/src/renderer/src/components/tools/model-viewer/model-viewer-dialog.tsx
@@ -11,9 +11,19 @@ import {
 import { Button } from "@renderer/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@renderer/components/ui/dialog";
 import { ScrollArea } from "@renderer/components/ui/scroll-area";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@renderer/components/ui/tooltip";
 import { getSetting, setSetting } from "@renderer/lib/settings";
 import { cn } from "@renderer/lib/utils";
-import { applyVariableSelection, evaluateViewerState } from "@shared/mod-viewer/eval";
+import {
+  applyVariableSelection,
+  computeIneffectiveValues,
+  evaluateViewerState,
+} from "@shared/mod-viewer/eval";
 import { toErrorMessage } from "@shared/utils";
 import { Loader2Icon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -570,6 +580,10 @@ export function ModelViewerDialog({
     () => (payloadTransport ? evaluateViewerState(payloadTransport, activeState) : null),
     [activeState, payloadTransport],
   );
+  const ineffectiveMap = useMemo(
+    () => (payloadTransport ? computeIneffectiveValues(payloadTransport, activeState) : new Map()),
+    [activeState, payloadTransport],
+  );
   const variables = manifest?.variables ?? payloadTransport?.variables ?? [];
   const uiAssets = manifest?.uiAssets ?? payloadTransport?.uiAssets;
   const visibleVariables = variables.filter(
@@ -897,50 +911,87 @@ export function ModelViewerDialog({
                       </div>
                     ) : null}
 
-                    <div className="space-y-3">
-                      {tileVariables.map((variable) => (
-                        <div key={variable.id} className="rounded-md border bg-background/50 p-3">
-                          <div className="mb-2 text-sm font-medium">{variable.label}</div>
-                          <div className="flex flex-wrap gap-2">
-                            {variable.values.map((entry) => {
-                              const active =
-                                String(activeState[variable.id]) === String(entry.value);
-                              return (
-                                <Button
-                                  key={`${variable.id}-${String(entry.value)}`}
-                                  type="button"
-                                  size="sm"
-                                  variant={active ? "default" : "outline"}
-                                  disabled={isViewerBusy}
-                                  onClick={() => handleSelectValue(variable.id, entry.value)}
-                                >
-                                  {entry.label}
-                                </Button>
-                              );
-                            })}
+                    <TooltipProvider>
+                      <div className="space-y-3">
+                        {tileVariables.map((variable) => (
+                          <div key={variable.id} className="rounded-md border bg-background/50 p-3">
+                            <div className="mb-2 text-sm font-medium">{variable.label}</div>
+                            <div className="flex flex-wrap gap-2">
+                              {variable.values.map((entry) => {
+                                const active =
+                                  String(activeState[variable.id]) === String(entry.value);
+                                const ineffectiveEntry = ineffectiveMap
+                                  .get(variable.id)
+                                  ?.get(String(entry.value));
+                                const isIneffective = Boolean(ineffectiveEntry);
+                                const button = (
+                                  <Button
+                                    type="button"
+                                    size="sm"
+                                    variant={active ? "default" : "outline"}
+                                    disabled={isViewerBusy || isIneffective}
+                                    onClick={() => handleSelectValue(variable.id, entry.value)}
+                                  >
+                                    {entry.label}
+                                  </Button>
+                                );
+                                if (!isIneffective || !ineffectiveEntry)
+                                  return (
+                                    <span key={`${variable.id}-${String(entry.value)}`}>
+                                      {button}
+                                    </span>
+                                  );
+                                return (
+                                  <Tooltip key={`${variable.id}-${String(entry.value)}`}>
+                                    <TooltipTrigger className="inline-flex">
+                                      {button}
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      <div className="space-y-1 text-left">
+                                        <div>
+                                          {t("page.tools.model_viewer.ineffective_blocked_by", {
+                                            variables: ineffectiveEntry.blockingVars.join(", "),
+                                          })}
+                                        </div>
+                                        {ineffectiveEntry.suggestions.length > 0 && (
+                                          <div>
+                                            {t("page.tools.model_viewer.ineffective_suggestion")}
+                                            <ul className="ml-3 list-disc">
+                                              {ineffectiveEntry.suggestions.map((suggestion) => (
+                                                <li key={suggestion}>{suggestion}</li>
+                                              ))}
+                                            </ul>
+                                          </div>
+                                        )}
+                                      </div>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                );
+                              })}
+                            </div>
                           </div>
-                        </div>
-                      ))}
-                      {sliderVariables.map((variable) => (
-                        <VariantSlider
-                          key={variable.id}
-                          variable={variable}
-                          activeValue={activeState[variable.id]}
-                          disabled={isViewerBusy}
-                          realtime={
-                            source?.mode === "payload" ||
-                            Boolean(
-                              shapeKeys?.some((shapeKey) =>
-                                shapeKey.dimensions.some(
-                                  (dimension) => dimension.variableId === variable.id,
+                        ))}
+                        {sliderVariables.map((variable) => (
+                          <VariantSlider
+                            key={variable.id}
+                            variable={variable}
+                            activeValue={activeState[variable.id]}
+                            disabled={isViewerBusy}
+                            realtime={
+                              source?.mode === "payload" ||
+                              Boolean(
+                                shapeKeys?.some((shapeKey) =>
+                                  shapeKey.dimensions.some(
+                                    (dimension) => dimension.variableId === variable.id,
+                                  ),
                                 ),
-                              ),
-                            )
-                          }
-                          onSelect={handleSelectValue}
-                        />
-                      ))}
-                    </div>
+                              )
+                            }
+                            onSelect={handleSelectValue}
+                          />
+                        ))}
+                      </div>
+                    </TooltipProvider>
                   </div>
                 </ScrollArea>
               </div>

--- a/src/renderer/src/components/tools/model-viewer/model-viewer-dialog.tsx
+++ b/src/renderer/src/components/tools/model-viewer/model-viewer-dialog.tsx
@@ -84,6 +84,7 @@ export function ModelViewerDialog({
 }) {
   const { t } = useTranslation();
   const [activeState, setActiveState] = useState<Record<string, VariableStateValue>>({});
+  const [previewState, setPreviewState] = useState<Record<string, VariableStateValue> | null>(null);
   const [manifest, setManifest] = useState<ModelViewerVariantManifest | null>(null);
   const [activeAnimationId, setActiveAnimationId] = useState<string | null>(null);
   const [animationFrameIndex, setAnimationFrameIndex] = useState(0);
@@ -583,9 +584,10 @@ export function ModelViewerDialog({
     viewerRefs.current[0]?.setAnimationFrame(0);
   };
 
+  const effectiveState = previewState ?? activeState;
   const payloadEval = useMemo(
-    () => (payloadTransport ? evaluateViewerState(payloadTransport, activeState) : null),
-    [activeState, payloadTransport],
+    () => (payloadTransport ? evaluateViewerState(payloadTransport, effectiveState) : null),
+    [effectiveState, payloadTransport],
   );
   const ineffectiveMap = useMemo(
     () => (payloadTransport ? computeIneffectiveValues(payloadTransport, activeState) : new Map()),
@@ -933,6 +935,9 @@ export function ModelViewerDialog({
                                   );
                                   if (entry) void handleSelectValue(variable.id, entry.value);
                                 }}
+                                onOpenChange={(open) => {
+                                  if (!open) setPreviewState(null);
+                                }}
                                 disabled={isViewerBusy}
                               >
                                 <SelectTrigger className="w-full">
@@ -950,6 +955,14 @@ export function ModelViewerDialog({
                                           <SelectItem
                                             key={String(entry.value)}
                                             value={String(entry.value)}
+                                            onMouseEnter={() => {
+                                              if (source?.mode === "payload")
+                                                setPreviewState({
+                                                  ...activeState,
+                                                  [variable.id]: entry.value,
+                                                });
+                                            }}
+                                            onMouseLeave={() => setPreviewState(null)}
                                           >
                                             {entry.label}
                                           </SelectItem>
@@ -963,6 +976,14 @@ export function ModelViewerDialog({
                                                 value={String(entry.value)}
                                                 disabled
                                                 style={{ pointerEvents: "auto" }}
+                                                onMouseEnter={() => {
+                                                  if (source?.mode === "payload")
+                                                    setPreviewState({
+                                                      ...activeState,
+                                                      [variable.id]: entry.value,
+                                                    });
+                                                }}
+                                                onMouseLeave={() => setPreviewState(null)}
                                               />
                                             }
                                           >

--- a/src/renderer/src/components/tools/model-viewer/model-viewer-dialog.tsx
+++ b/src/renderer/src/components/tools/model-viewer/model-viewer-dialog.tsx
@@ -30,9 +30,10 @@ import {
   applyVariableSelection,
   computeIneffectiveValues,
   evaluateViewerState,
+  type IneffectiveSuggestion,
 } from "@shared/mod-viewer/eval";
 import { toErrorMessage } from "@shared/utils";
-import { Loader2Icon } from "lucide-react";
+import { CheckIcon, Loader2Icon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -569,6 +570,21 @@ export function ModelViewerDialog({
     }
   };
 
+  const handleApplyResolution = (suggestion: IneffectiveSuggestion) => {
+    if (!source || source.mode !== "payload") return;
+    setActiveState((current) => {
+      let next = current;
+      for (const change of suggestion.changes) {
+        const variable = source.transport.variables.find((v) => v.id === change.varId) ?? {
+          id: change.varId,
+        };
+        next = applyVariableSelection(next, variable, change.toValue);
+      }
+      return next;
+    });
+    setPreviewState(null);
+  };
+
   const handleAnimationTogglePlayback = () => {
     if (!activeAnimation || activeAnimation.frames.length <= 1) {
       return;
@@ -968,55 +984,124 @@ export function ModelViewerDialog({
                                           </SelectItem>
                                         );
                                       return (
-                                        <Tooltip key={String(entry.value)}>
-                                          <TooltipTrigger
-                                            closeOnClick={false}
-                                            render={
-                                              <SelectItem
-                                                value={String(entry.value)}
-                                                disabled
-                                                style={{ pointerEvents: "auto" }}
-                                                onMouseEnter={() => {
-                                                  if (source?.mode === "payload")
-                                                    setPreviewState({
-                                                      ...activeState,
-                                                      [variable.id]: entry.value,
-                                                    });
-                                                }}
-                                                onMouseLeave={() => setPreviewState(null)}
-                                              />
-                                            }
-                                          >
-                                            {entry.label}
-                                          </TooltipTrigger>
-                                          <TooltipContent>
-                                            <div className="space-y-1 text-left">
-                                              <div>
-                                                {t(
-                                                  "page.tools.model_viewer.ineffective_blocked_by",
-                                                  {
-                                                    variables:
-                                                      ineffectiveEntry.blockingVars.join(", "),
-                                                  },
-                                                )}
-                                              </div>
-                                              {ineffectiveEntry.suggestions.length > 0 && (
+                                        <div
+                                          key={String(entry.value)}
+                                          className="group flex w-full items-center justify-between"
+                                        >
+                                          <Tooltip>
+                                            <TooltipTrigger
+                                              closeOnClick={false}
+                                              render={
+                                                <SelectItem
+                                                  value={String(entry.value)}
+                                                  disabled
+                                                  style={{ pointerEvents: "auto" }}
+                                                  onMouseEnter={() => {
+                                                    if (source?.mode === "payload")
+                                                      setPreviewState({
+                                                        ...activeState,
+                                                        [variable.id]: entry.value,
+                                                      });
+                                                  }}
+                                                  onMouseLeave={() => setPreviewState(null)}
+                                                />
+                                              }
+                                            >
+                                              {entry.label}
+                                            </TooltipTrigger>
+                                            <TooltipContent>
+                                              <div className="space-y-1 text-left">
                                                 <div>
                                                   {t(
-                                                    "page.tools.model_viewer.ineffective_suggestion",
+                                                    "page.tools.model_viewer.ineffective_blocked_by",
+                                                    {
+                                                      variables:
+                                                        ineffectiveEntry.blockingVars.join(", "),
+                                                    },
                                                   )}
-                                                  <ul className="ml-3 list-disc">
-                                                    {ineffectiveEntry.suggestions.map(
-                                                      (suggestion) => (
-                                                        <li key={suggestion}>{suggestion}</li>
-                                                      ),
-                                                    )}
-                                                  </ul>
                                                 </div>
-                                              )}
+                                                {ineffectiveEntry.suggestions.length > 0 && (
+                                                  <div>
+                                                    {t(
+                                                      "page.tools.model_viewer.ineffective_suggestion",
+                                                    )}
+                                                    <ul className="ml-3 list-disc">
+                                                      {ineffectiveEntry.suggestions.map(
+                                                        (suggestion) => (
+                                                          <li key={suggestion.display}>
+                                                            {suggestion.display}
+                                                          </li>
+                                                        ),
+                                                      )}
+                                                    </ul>
+                                                  </div>
+                                                )}
+                                              </div>
+                                            </TooltipContent>
+                                          </Tooltip>
+                                          {ineffectiveEntry.suggestions.length > 0 && (
+                                            <div className="w-0 overflow-hidden transition-all group-hover:w-8">
+                                              <Tooltip>
+                                                <TooltipTrigger
+                                                  render={
+                                                    <Button
+                                                      variant="ghost"
+                                                      size="icon-sm"
+                                                      onMouseEnter={() => {
+                                                        if (source?.mode === "payload") {
+                                                          let next = { ...activeState };
+                                                          for (const change of ineffectiveEntry
+                                                            .suggestions[0].changes) {
+                                                            const v =
+                                                              source.transport.variables.find(
+                                                                (entry) =>
+                                                                  entry.id === change.varId,
+                                                              ) ?? { id: change.varId };
+                                                            next = applyVariableSelection(
+                                                              next,
+                                                              v,
+                                                              change.toValue,
+                                                            );
+                                                          }
+                                                          setPreviewState(next);
+                                                        }
+                                                      }}
+                                                      onMouseLeave={() => setPreviewState(null)}
+                                                      onClick={() =>
+                                                        handleApplyResolution(
+                                                          ineffectiveEntry.suggestions[0],
+                                                        )
+                                                      }
+                                                    />
+                                                  }
+                                                >
+                                                  <CheckIcon className="size-4" />
+                                                </TooltipTrigger>
+                                                <TooltipContent>
+                                                  <div className="space-y-1 text-left">
+                                                    <div>
+                                                      {t(
+                                                        "page.tools.model_viewer.ineffective_apply",
+                                                      )}
+                                                    </div>
+                                                    <ul className="ml-3 list-disc">
+                                                      {ineffectiveEntry.suggestions[0].changes.map(
+                                                        (change) => (
+                                                          <li
+                                                            key={`${change.varId}-${change.toValue}`}
+                                                          >
+                                                            {change.varLabel}: {change.fromValue} →{" "}
+                                                            {change.toValue}
+                                                          </li>
+                                                        ),
+                                                      )}
+                                                    </ul>
+                                                  </div>
+                                                </TooltipContent>
+                                              </Tooltip>
                                             </div>
-                                          </TooltipContent>
-                                        </Tooltip>
+                                          )}
+                                        </div>
                                       );
                                     })}
                                   </SelectGroup>

--- a/src/renderer/src/components/tools/model-viewer/model-viewer-dialog.tsx
+++ b/src/renderer/src/components/tools/model-viewer/model-viewer-dialog.tsx
@@ -30,6 +30,7 @@ import {
   applyVariableSelection,
   computeIneffectiveValues,
   evaluateViewerState,
+  type IneffectiveMap,
   type IneffectiveSuggestion,
 } from "@shared/mod-viewer/eval";
 import { toErrorMessage } from "@shared/utils";
@@ -202,6 +203,8 @@ export function ModelViewerDialog({
     const nextSourceSessionKey = getSourceSessionKey(source);
     const shouldResetOrientation = sourceSessionKeyRef.current !== nextSourceSessionKey;
     sourceSessionKeyRef.current = nextSourceSessionKey;
+
+    setPreviewState(null);
 
     if (!source) {
       resetViewerSession({ resetOrientation: shouldResetOrientation });
@@ -605,7 +608,7 @@ export function ModelViewerDialog({
     () => (payloadTransport ? evaluateViewerState(payloadTransport, effectiveState) : null),
     [effectiveState, payloadTransport],
   );
-  const ineffectiveMap = useMemo(
+  const ineffectiveMap = useMemo<IneffectiveMap>(
     () => (payloadTransport ? computeIneffectiveValues(payloadTransport, activeState) : new Map()),
     [activeState, payloadTransport],
   );
@@ -1015,8 +1018,9 @@ export function ModelViewerDialog({
                                                   {t(
                                                     "page.tools.model_viewer.ineffective_blocked_by",
                                                     {
-                                                      variables:
-                                                        ineffectiveEntry.blockingVars.join(", "),
+                                                      variables: ineffectiveEntry.blockingVars
+                                                        .map((v) => `${v.label}=${v.value}`)
+                                                        .join(", "),
                                                     },
                                                   )}
                                                 </div>
@@ -1040,7 +1044,7 @@ export function ModelViewerDialog({
                                             </TooltipContent>
                                           </Tooltip>
                                           {ineffectiveEntry.suggestions.length > 0 && (
-                                            <div className="w-0 overflow-hidden transition-all group-hover:w-8">
+                                            <div className="w-0 overflow-hidden transition-all group-hover:w-8 focus-within:w-8">
                                               <Tooltip>
                                                 <TooltipTrigger
                                                   render={

--- a/src/renderer/src/components/tools/model-viewer/model-viewer-dialog.tsx
+++ b/src/renderer/src/components/tools/model-viewer/model-viewer-dialog.tsx
@@ -10,7 +10,14 @@ import {
 } from "@renderer/components/ui/alert-dialog";
 import { Button } from "@renderer/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@renderer/components/ui/dialog";
-import { ScrollArea } from "@renderer/components/ui/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@renderer/components/ui/select";
 import {
   Tooltip,
   TooltipContent,
@@ -883,7 +890,7 @@ export function ModelViewerDialog({
                     {t("page.tools.model_viewer.toggle_viewer")}
                   </div>
                 </div>
-                <ScrollArea className="min-h-0 flex-1">
+                <div className="min-h-0 flex-1 overflow-y-auto">
                   <div className="p-4">
                     {hasVariantTileUi ? (
                       <div
@@ -913,64 +920,90 @@ export function ModelViewerDialog({
 
                     <TooltipProvider>
                       <div className="space-y-3">
-                        {tileVariables.map((variable) => (
-                          <div key={variable.id} className="rounded-md border bg-background/50 p-3">
-                            <div className="mb-2 text-sm font-medium">{variable.label}</div>
-                            <div className="flex flex-wrap gap-2">
-                              {variable.values.map((entry) => {
-                                const active =
-                                  String(activeState[variable.id]) === String(entry.value);
-                                const ineffectiveEntry = ineffectiveMap
-                                  .get(variable.id)
-                                  ?.get(String(entry.value));
-                                const isIneffective = Boolean(ineffectiveEntry);
-                                const button = (
-                                  <Button
-                                    type="button"
-                                    size="sm"
-                                    variant={active ? "default" : "outline"}
-                                    disabled={isViewerBusy || isIneffective}
-                                    onClick={() => handleSelectValue(variable.id, entry.value)}
-                                  >
-                                    {entry.label}
-                                  </Button>
-                                );
-                                if (!isIneffective || !ineffectiveEntry)
-                                  return (
-                                    <span key={`${variable.id}-${String(entry.value)}`}>
-                                      {button}
-                                    </span>
+                        <div className="grid grid-cols-2 gap-3">
+                          {tileVariables.map((variable) => (
+                            <div key={variable.id} className="border-l-4 border-l-primary/40 pl-3">
+                              <div className="mb-2 text-sm font-medium">{variable.label}</div>
+                              <Select
+                                value={String(activeState[variable.id] ?? variable.defaultValue)}
+                                onValueChange={(value) => {
+                                  if (value === null) return;
+                                  const entry = variable.values.find(
+                                    (e) => String(e.value) === value,
                                   );
-                                return (
-                                  <Tooltip key={`${variable.id}-${String(entry.value)}`}>
-                                    <TooltipTrigger className="inline-flex">
-                                      {button}
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                      <div className="space-y-1 text-left">
-                                        <div>
-                                          {t("page.tools.model_viewer.ineffective_blocked_by", {
-                                            variables: ineffectiveEntry.blockingVars.join(", "),
-                                          })}
-                                        </div>
-                                        {ineffectiveEntry.suggestions.length > 0 && (
-                                          <div>
-                                            {t("page.tools.model_viewer.ineffective_suggestion")}
-                                            <ul className="ml-3 list-disc">
-                                              {ineffectiveEntry.suggestions.map((suggestion) => (
-                                                <li key={suggestion}>{suggestion}</li>
-                                              ))}
-                                            </ul>
-                                          </div>
-                                        )}
-                                      </div>
-                                    </TooltipContent>
-                                  </Tooltip>
-                                );
-                              })}
+                                  if (entry) void handleSelectValue(variable.id, entry.value);
+                                }}
+                                disabled={isViewerBusy}
+                              >
+                                <SelectTrigger className="w-full">
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectGroup>
+                                    {variable.values.map((entry) => {
+                                      const ineffectiveEntry = ineffectiveMap
+                                        .get(variable.id)
+                                        ?.get(String(entry.value));
+                                      const isIneffective = Boolean(ineffectiveEntry);
+                                      if (!isIneffective || !ineffectiveEntry)
+                                        return (
+                                          <SelectItem
+                                            key={String(entry.value)}
+                                            value={String(entry.value)}
+                                          >
+                                            {entry.label}
+                                          </SelectItem>
+                                        );
+                                      return (
+                                        <Tooltip key={String(entry.value)}>
+                                          <TooltipTrigger
+                                            closeOnClick={false}
+                                            render={
+                                              <SelectItem
+                                                value={String(entry.value)}
+                                                disabled
+                                                style={{ pointerEvents: "auto" }}
+                                              />
+                                            }
+                                          >
+                                            {entry.label}
+                                          </TooltipTrigger>
+                                          <TooltipContent>
+                                            <div className="space-y-1 text-left">
+                                              <div>
+                                                {t(
+                                                  "page.tools.model_viewer.ineffective_blocked_by",
+                                                  {
+                                                    variables:
+                                                      ineffectiveEntry.blockingVars.join(", "),
+                                                  },
+                                                )}
+                                              </div>
+                                              {ineffectiveEntry.suggestions.length > 0 && (
+                                                <div>
+                                                  {t(
+                                                    "page.tools.model_viewer.ineffective_suggestion",
+                                                  )}
+                                                  <ul className="ml-3 list-disc">
+                                                    {ineffectiveEntry.suggestions.map(
+                                                      (suggestion) => (
+                                                        <li key={suggestion}>{suggestion}</li>
+                                                      ),
+                                                    )}
+                                                  </ul>
+                                                </div>
+                                              )}
+                                            </div>
+                                          </TooltipContent>
+                                        </Tooltip>
+                                      );
+                                    })}
+                                  </SelectGroup>
+                                </SelectContent>
+                              </Select>
                             </div>
-                          </div>
-                        ))}
+                          ))}
+                        </div>
                         {sliderVariables.map((variable) => (
                           <VariantSlider
                             key={variable.id}
@@ -993,7 +1026,7 @@ export function ModelViewerDialog({
                       </div>
                     </TooltipProvider>
                   </div>
-                </ScrollArea>
+                </div>
               </div>
             ) : null}
           </div>

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -1069,6 +1069,8 @@
       "model_viewer": {
         "title": "Model Viewer",
         "toggle_viewer": "Toggle Viewer",
+        "ineffective_blocked_by": "This value has no effect with the current combination: {{variables}}",
+        "ineffective_suggestion": "To use this value, change the following:",
         "open_file": "Open File",
         "convert_first": "Convert a mod to GLB first, then open it here.",
         "generating_selected_state": "Generating selected state",

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -1071,6 +1071,7 @@
         "toggle_viewer": "Toggle Viewer",
         "ineffective_blocked_by": "This value has no effect with the current combination: {{variables}}",
         "ineffective_suggestion": "To use this value, change the following:",
+        "ineffective_apply": "Apply this combination",
         "open_file": "Open File",
         "convert_first": "Convert a mod to GLB first, then open it here.",
         "generating_selected_state": "Generating selected state",

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -1036,6 +1036,8 @@
       "model_viewer": {
         "title": "モデルビューアー",
         "toggle_viewer": "トグルビューアー",
+        "ineffective_blocked_by": "現在の組み合わせではこの値は効果がありません: {{variables}}",
+        "ineffective_suggestion": "この値を使用するには以下の変数を変更してください:",
         "open_file": "ファイルを開く",
         "convert_first": "先に MOD を GLB に変換してから、ここで開いてください。",
         "generating_selected_state": "選択した状態を生成中",

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -1038,6 +1038,7 @@
         "toggle_viewer": "トグルビューアー",
         "ineffective_blocked_by": "現在の組み合わせではこの値は効果がありません: {{variables}}",
         "ineffective_suggestion": "この値を使用するには以下の変数を変更してください:",
+        "ineffective_apply": "この組み合わせを適用",
         "open_file": "ファイルを開く",
         "convert_first": "先に MOD を GLB に変換してから、ここで開いてください。",
         "generating_selected_state": "選択した状態を生成中",

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -1057,6 +1057,7 @@
         "toggle_viewer": "토글 뷰어",
         "ineffective_blocked_by": "다음 설정이 함께 적용되어 이 값은 효과가 없습니다: {{variables}}",
         "ineffective_suggestion": "이 값을 사용하려면 아래 변수를 변경하세요:",
+        "ineffective_apply": "이 조합 적용",
         "open_file": "파일 열기",
         "convert_first": "먼저 모드를 GLB로 변환한 뒤 여기에서 여세요.",
         "generating_selected_state": "선택한 상태 생성 중",

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -1055,6 +1055,8 @@
       "model_viewer": {
         "title": "모델 뷰어",
         "toggle_viewer": "토글 뷰어",
+        "ineffective_blocked_by": "다음 설정이 함께 적용되어 이 값은 효과가 없습니다: {{variables}}",
+        "ineffective_suggestion": "이 값을 사용하려면 아래 변수를 변경하세요:",
         "open_file": "파일 열기",
         "convert_first": "먼저 모드를 GLB로 변환한 뒤 여기에서 여세요.",
         "generating_selected_state": "선택한 상태 생성 중",

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -1035,6 +1035,8 @@
       "model_viewer": {
         "title": "模型查看器",
         "toggle_viewer": "切换查看器",
+        "ineffective_blocked_by": "当前组合下此值无效: {{variables}}",
+        "ineffective_suggestion": "要使用此值，请更改以下变量:",
         "open_file": "打开文件",
         "convert_first": "请先将模组转换为 GLB，然后再在这里打开。",
         "generating_selected_state": "正在生成所选状态",

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -1037,6 +1037,7 @@
         "toggle_viewer": "切换查看器",
         "ineffective_blocked_by": "当前组合下此值无效: {{variables}}",
         "ineffective_suggestion": "要使用此值，请更改以下变量:",
+        "ineffective_apply": "应用此组合",
         "open_file": "打开文件",
         "convert_first": "请先将模组转换为 GLB，然后再在这里打开。",
         "generating_selected_state": "正在生成所选状态",

--- a/src/shared/mod-viewer/eval.ts
+++ b/src/shared/mod-viewer/eval.ts
@@ -9,9 +9,19 @@ import type {
     ViewerVariable,
 } from "./types";
 
+export type IneffectiveSuggestion = {
+    display: string;
+    changes: {
+        varId: string;
+        varLabel: string;
+        fromValue: string;
+        toValue: string;
+    }[];
+};
+
 export type IneffectiveEntry = {
     blockingVars: string[];
-    suggestions: string[];
+    suggestions: IneffectiveSuggestion[];
 };
 
 export type IneffectiveMap = Map<string, Map<string, IneffectiveEntry>>;
@@ -305,7 +315,8 @@ function conflictingVariableLabels(
 }
 
 // For each blocking variable, tries its other values to find ones that make the
-// tested variable value effective. Returns "Label: value → value" suggestions.
+// tested variable value effective. Returns structured suggestions with the
+// full set of variable changes needed to unblock the tested value.
 function resolveSuggestions(
     payload: ViewerEvalInput & { variables: ViewerVariable[] },
     testedVarId: string,
@@ -313,8 +324,8 @@ function resolveSuggestions(
     blockingVars: string[],
     state: Record<string, ViewerStateValue>,
     baseline: EvaluatedViewerState,
-): string[] {
-    const suggestions: string[] = [];
+): IneffectiveSuggestion[] {
+    const suggestions: IneffectiveSuggestion[] = [];
     const testedVar = payload.variables.find((v) => v.id === testedVarId);
     if (!testedVar) return suggestions;
 
@@ -340,7 +351,27 @@ function resolveSuggestions(
                 evaluatedStatesDiffer(altBaseline, testEval) &&
                 evaluatedStatesDiffer(baseline, testEval)
             ) {
-                suggestions.push(`${blockingVar.label}: ${currentValue} → ${altEntry.value}`);
+                const changes: IneffectiveSuggestion["changes"] = [];
+                for (const variable of payload.variables) {
+                    const fromValue = String(
+                        lookupStateValue(state, variable.id) ?? variable.defaultValue,
+                    );
+                    const toValue = String(
+                        lookupStateValue(testState, variable.id) ?? variable.defaultValue,
+                    );
+                    if (toValue !== fromValue) {
+                        changes.push({
+                            varId: variable.id,
+                            varLabel: variable.label,
+                            fromValue,
+                            toValue,
+                        });
+                    }
+                }
+                suggestions.push({
+                    display: `${blockingVar.label}: ${currentValue} → ${altEntry.value}`,
+                    changes,
+                });
             }
         }
     }

--- a/src/shared/mod-viewer/eval.ts
+++ b/src/shared/mod-viewer/eval.ts
@@ -9,6 +9,13 @@ import type {
     ViewerVariable,
 } from "./types";
 
+export type IneffectiveEntry = {
+    blockingVars: string[];
+    suggestions: string[];
+};
+
+export type IneffectiveMap = Map<string, Map<string, IneffectiveEntry>>;
+
 export function dnfSatisfied(
     condGroups: Dnf | undefined,
     state: Record<string, ViewerStateValue>,
@@ -185,4 +192,168 @@ function lookupStateValue(
 
     const lowered = variable.toLowerCase();
     return Object.entries(state).find(([key]) => key.toLowerCase() === lowered)?.[1];
+}
+
+export function computeIneffectiveValues(
+    payload: ViewerEvalInput & { variables: ViewerVariable[] },
+    state: Record<string, ViewerStateValue>,
+): IneffectiveMap {
+    const resolved = applyStateRules({ ...payload.defaultState, ...state }, payload.stateRules);
+    const baseline = evaluateViewerState(payload, resolved);
+    const result: IneffectiveMap = new Map();
+
+    for (const variable of payload.variables) {
+        if (variable.controlType === "slider" || variable.values.length === 0) {
+            continue;
+        }
+        const ineffective = new Map<string, IneffectiveEntry>();
+        const currentValue = String(
+            lookupStateValue(resolved, variable.id) ?? variable.defaultValue,
+        );
+        for (const entry of variable.values) {
+            if (String(entry.value) === currentValue) continue;
+            const nextState = applyVariableSelection(resolved, variable, entry.value);
+            const nextEval = evaluateViewerState(payload, nextState);
+            if (!evaluatedStatesDiffer(baseline, nextEval)) {
+                const blockingVars = conflictingVariableLabels(payload, variable.id, resolved);
+                ineffective.set(String(entry.value), {
+                    blockingVars,
+                    suggestions: resolveSuggestions(
+                        payload,
+                        variable.id,
+                        String(entry.value),
+                        blockingVars,
+                        resolved,
+                        baseline,
+                    ),
+                });
+            }
+        }
+        if (ineffective.size > 0) {
+            result.set(variable.id, ineffective);
+        }
+    }
+    return result;
+}
+
+function evaluatedStatesDiffer(left: EvaluatedViewerState, right: EvaluatedViewerState): boolean {
+    for (let index = 0; index < left.meshes.length; index++) {
+        const leftMesh = left.meshes[index];
+        const rightMesh = right.meshes[index];
+        if (leftMesh.visible !== rightMesh.visible) return true;
+        if (leftMesh.texKey !== rightMesh.texKey) return true;
+        if (leftMesh.normalMapKey !== rightMesh.normalMapKey) return true;
+        if (leftMesh.lightMapKey !== rightMesh.lightMapKey) return true;
+        if (leftMesh.materialMapKey !== rightMesh.materialMapKey) return true;
+        if (leftMesh.positionVariantIndex !== rightMesh.positionVariantIndex) return true;
+    }
+    return false;
+}
+
+// Identifies other variables whose current values co-occur with the tested variable
+// in mesh conditions, producing the dead combination.
+function conflictingVariableLabels(
+    payload: ViewerEvalInput & { variables: ViewerVariable[] },
+    testedVar: string,
+    state: Record<string, ViewerStateValue>,
+): string[] {
+    const testedLower = testedVar.toLowerCase();
+    const coOccurring = new Set<string>();
+    for (const mesh of payload.meshes) {
+        for (const group of [
+            ...mesh.conditions,
+            ...mesh.positionVariants.flatMap((v) => v.conditions),
+        ]) {
+            const hasTested = group.some((clause) => clause.var.toLowerCase() === testedLower);
+            if (!hasTested) continue;
+            for (const clause of group) {
+                const lower = clause.var.toLowerCase();
+                if (lower === testedLower) continue;
+                coOccurring.add(clause.var);
+            }
+        }
+        for (const variants of [
+            mesh.textureVariants,
+            mesh.normalMapVariants,
+            mesh.lightMapVariants,
+            mesh.materialMapVariants,
+        ]) {
+            for (const variant of variants) {
+                const hasTested = variant.conditions.some((group) =>
+                    group.some((clause) => clause.var.toLowerCase() === testedLower),
+                );
+                if (!hasTested) continue;
+                for (const group of variant.conditions) {
+                    for (const clause of group) {
+                        const lower = clause.var.toLowerCase();
+                        if (lower === testedLower) continue;
+                        coOccurring.add(clause.var);
+                    }
+                }
+            }
+        }
+    }
+    const labels: string[] = [];
+    for (const variable of payload.variables) {
+        if (variable.id.toLowerCase() === testedLower) continue;
+        if (![...coOccurring].some((v) => v.toLowerCase() === variable.id.toLowerCase())) continue;
+        const currentValue = lookupStateValue(state, variable.id);
+        if (currentValue === undefined) continue;
+        labels.push(`${variable.label}=${currentValue}`);
+    }
+    return labels;
+}
+
+// For each blocking variable, tries its other values to find ones that make the
+// tested variable value effective. Returns "Label: value → value" suggestions.
+function resolveSuggestions(
+    payload: ViewerEvalInput & { variables: ViewerVariable[] },
+    testedVarId: string,
+    testedValue: string,
+    blockingVars: string[],
+    state: Record<string, ViewerStateValue>,
+    baseline: EvaluatedViewerState,
+): string[] {
+    const suggestions: string[] = [];
+    const testedVar = payload.variables.find((v) => v.id === testedVarId);
+    if (!testedVar) return suggestions;
+
+    for (const blockingLabel of blockingVars) {
+        const blockingVarId = findVariableIdByLabel(payload, blockingLabel);
+        if (!blockingVarId) continue;
+        const blockingVar = payload.variables.find((v) => v.id === blockingVarId);
+        if (!blockingVar) continue;
+        const currentValue = String(
+            lookupStateValue(state, blockingVarId) ?? blockingVar.defaultValue,
+        );
+        for (const altEntry of blockingVar.values) {
+            if (String(altEntry.value) === currentValue) continue;
+            const altState = { ...state, [blockingVarId]: altEntry.value };
+            const altResolved = applyStateRules(
+                { ...payload.defaultState, ...altState },
+                payload.stateRules,
+            );
+            const testState = applyVariableSelection(altResolved, testedVar, testedValue);
+            const testEval = evaluateViewerState(payload, testState);
+            const altBaseline = evaluateViewerState(payload, altResolved);
+            if (
+                evaluatedStatesDiffer(altBaseline, testEval) &&
+                evaluatedStatesDiffer(baseline, testEval)
+            ) {
+                suggestions.push(`${blockingVar.label}: ${currentValue} → ${altEntry.value}`);
+            }
+        }
+    }
+    return suggestions;
+}
+
+function findVariableIdByLabel(
+    payload: ViewerEvalInput & { variables: ViewerVariable[] },
+    label: string,
+): string | undefined {
+    const eqIndex = label.indexOf("=");
+    if (eqIndex < 0) return undefined;
+    const labelName = label.slice(0, eqIndex);
+    const variable = payload.variables.find((v) => v.label === labelName);
+    return variable?.id;
 }

--- a/src/shared/mod-viewer/eval.ts
+++ b/src/shared/mod-viewer/eval.ts
@@ -309,10 +309,18 @@ function buildBlockingVars(
             }
         }
     }
+    const coOccurringLower = new Set([...coOccurring].map((v) => v.toLowerCase()));
     const blockingVars: BlockingVar[] = [];
     for (const variable of payload.variables) {
         if (variable.id.toLowerCase() === testedLower) continue;
-        if (![...coOccurring].some((v) => v.toLowerCase() === variable.id.toLowerCase())) continue;
+        // A variable blocks the tested value when it co-occurs directly in a
+        // mesh condition, or when its effect writes a hidden single-value
+        // target that co-occurs (e.g. $body set by $outfit's effect).
+        const directlyCoOccurring = coOccurringLower.has(variable.id.toLowerCase());
+        const effectCoOccurring = variable.effects?.some((e) =>
+            coOccurringLower.has(e.var.toLowerCase()),
+        );
+        if (!directlyCoOccurring && !effectCoOccurring) continue;
         const currentValue = lookupStateValue(state, variable.id);
         if (currentValue === undefined) continue;
         blockingVars.push({ id: variable.id, label: variable.label, value: currentValue });
@@ -342,13 +350,9 @@ function resolveSuggestions(
         for (const altEntry of blockingVar.values) {
             if (String(altEntry.value) === currentStr) continue;
             const altState = applyVariableSelection(state, blockingVar, altEntry.value);
-            const altResolved = applyStateRules(
-                { ...payload.defaultState, ...altState },
-                payload.stateRules,
-            );
-            const testState = applyVariableSelection(altResolved, testedVar, testedValue);
+            const testState = applyVariableSelection(altState, testedVar, testedValue);
             const testEval = evaluateViewerState(payload, testState);
-            const altBaseline = evaluateViewerState(payload, altResolved);
+            const altBaseline = evaluateViewerState(payload, altState);
             if (
                 evaluatedStatesDiffer(altBaseline, testEval) &&
                 evaluatedStatesDiffer(baseline, testEval)

--- a/src/shared/mod-viewer/eval.ts
+++ b/src/shared/mod-viewer/eval.ts
@@ -19,8 +19,14 @@ export type IneffectiveSuggestion = {
     }[];
 };
 
+export type BlockingVar = {
+    id: string;
+    label: string;
+    value: ViewerStateValue;
+};
+
 export type IneffectiveEntry = {
-    blockingVars: string[];
+    blockingVars: BlockingVar[];
     suggestions: IneffectiveSuggestion[];
 };
 
@@ -225,7 +231,7 @@ export function computeIneffectiveValues(
             const nextState = applyVariableSelection(resolved, variable, entry.value);
             const nextEval = evaluateViewerState(payload, nextState);
             if (!evaluatedStatesDiffer(baseline, nextEval)) {
-                const blockingVars = conflictingVariableLabels(payload, variable.id, resolved);
+                const blockingVars = buildBlockingVars(payload, variable.id, resolved);
                 ineffective.set(String(entry.value), {
                     blockingVars,
                     suggestions: resolveSuggestions(
@@ -262,11 +268,11 @@ function evaluatedStatesDiffer(left: EvaluatedViewerState, right: EvaluatedViewe
 
 // Identifies other variables whose current values co-occur with the tested variable
 // in mesh conditions, producing the dead combination.
-function conflictingVariableLabels(
+function buildBlockingVars(
     payload: ViewerEvalInput & { variables: ViewerVariable[] },
     testedVar: string,
     state: Record<string, ViewerStateValue>,
-): string[] {
+): BlockingVar[] {
     const testedLower = testedVar.toLowerCase();
     const coOccurring = new Set<string>();
     for (const mesh of payload.meshes) {
@@ -303,15 +309,15 @@ function conflictingVariableLabels(
             }
         }
     }
-    const labels: string[] = [];
+    const blockingVars: BlockingVar[] = [];
     for (const variable of payload.variables) {
         if (variable.id.toLowerCase() === testedLower) continue;
         if (![...coOccurring].some((v) => v.toLowerCase() === variable.id.toLowerCase())) continue;
         const currentValue = lookupStateValue(state, variable.id);
         if (currentValue === undefined) continue;
-        labels.push(`${variable.label}=${currentValue}`);
+        blockingVars.push({ id: variable.id, label: variable.label, value: currentValue });
     }
-    return labels;
+    return blockingVars;
 }
 
 // For each blocking variable, tries its other values to find ones that make the
@@ -321,7 +327,7 @@ function resolveSuggestions(
     payload: ViewerEvalInput & { variables: ViewerVariable[] },
     testedVarId: string,
     testedValue: string,
-    blockingVars: string[],
+    blockingVars: BlockingVar[],
     state: Record<string, ViewerStateValue>,
     baseline: EvaluatedViewerState,
 ): IneffectiveSuggestion[] {
@@ -329,17 +335,13 @@ function resolveSuggestions(
     const testedVar = payload.variables.find((v) => v.id === testedVarId);
     if (!testedVar) return suggestions;
 
-    for (const blockingLabel of blockingVars) {
-        const blockingVarId = findVariableIdByLabel(payload, blockingLabel);
-        if (!blockingVarId) continue;
+    for (const { id: blockingVarId, label: blockingLabel, value: currentValue } of blockingVars) {
         const blockingVar = payload.variables.find((v) => v.id === blockingVarId);
         if (!blockingVar) continue;
-        const currentValue = String(
-            lookupStateValue(state, blockingVarId) ?? blockingVar.defaultValue,
-        );
+        const currentStr = String(currentValue);
         for (const altEntry of blockingVar.values) {
-            if (String(altEntry.value) === currentValue) continue;
-            const altState = { ...state, [blockingVarId]: altEntry.value };
+            if (String(altEntry.value) === currentStr) continue;
+            const altState = applyVariableSelection(state, blockingVar, altEntry.value);
             const altResolved = applyStateRules(
                 { ...payload.defaultState, ...altState },
                 payload.stateRules,
@@ -369,22 +371,11 @@ function resolveSuggestions(
                     }
                 }
                 suggestions.push({
-                    display: `${blockingVar.label}: ${currentValue} → ${altEntry.value}`,
+                    display: `${blockingLabel}: ${currentStr} → ${altEntry.value}`,
                     changes,
                 });
             }
         }
     }
     return suggestions;
-}
-
-function findVariableIdByLabel(
-    payload: ViewerEvalInput & { variables: ViewerVariable[] },
-    label: string,
-): string | undefined {
-    const eqIndex = label.indexOf("=");
-    if (eqIndex < 0) return undefined;
-    const labelName = label.slice(0, eqIndex);
-    const variable = payload.variables.find((v) => v.label === labelName);
-    return variable?.id;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches native texture decode/encode and viewer state evaluation used for every mod load. Logic for ineffective values and side effects is combinatorial and could mis-disable options or mis-apply hidden resets.
> 
> **Overview**
> The model viewer now treats toggle values that do not change mesh visibility or maps as **ineffective**: they are disabled in a dropdown, show which other vars block them, and can apply a suggested combination. Hovering a value previews that state without committing it.
> 
> Cycle keys with a **single assignment** (e.g. `$onepiece = 0`) are stored as side effects instead of extra panel vars, still applied on selection, and still used as gating vars. Hidden effect targets can be attributed back to the visible blocking control.
> 
> Viewer textures go through a new native `prepare_viewer_texture` path (PNG/JPEG/DDS, downscale, JPEG when no alpha) with concurrent encoding and timing logs, instead of Sharp plus `prepareTextureForMaterial`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd6cb9a0d826a89832536865ec3090e8f7ef965. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model viewer previews when hovering over variable values.
  * Identifies ineffective values, explains blocking settings, and suggests resolutions.
  * Lets you apply suggested variable combinations.
  * Improved toggle behavior for single-value settings and clearer controls.
  * Improved texture loading for PNG, JPEG, and DDS files, including automatic resizing for large textures.
* **Localization**
  * Added guidance in English, Japanese, Korean, and Chinese.
* **Bug Fixes**
  * Improved handling of toggle effects without conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->