### PR TITLE
fix(nte): recognize generic preview media and search subfolders

### DIFF
--- a/src/main/services/mod-manager/library.ts
+++ b/src/main/services/mod-manager/library.ts
@@ -57,12 +57,12 @@ export class ModLibraryService {
             throw new Error(`No mod folder path set for ${game}`);
         }
 
-        if (isNteImporter(gameConfig.importer)) {
-            return await getNteCharacters(this.desktop, getNteRoots(gameConfig));
-        }
-
         const shouldFallback =
             searchModPreview ?? (await this.desktop.setting.mod.getSearchModPreview());
+
+        if (isNteImporter(gameConfig.importer)) {
+            return await getNteCharacters(this.desktop, getNteRoots(gameConfig), shouldFallback);
+        }
 
         try {
             return await this.addManualSubGroupFlags(
@@ -82,7 +82,12 @@ export class ModLibraryService {
         try {
             const game = await this.getGameByPath(folderPath);
             if (game && isNteImporter(game.importer)) {
-                return await getNteSubGroups(this.desktop, getNteRoots(game), folderPath);
+                return await getNteSubGroups(
+                    this.desktop,
+                    getNteRoots(game),
+                    folderPath,
+                    shouldFallback,
+                );
             }
 
             const relativePath = game
@@ -134,11 +139,16 @@ export class ModLibraryService {
         }
     }
 
-    public async mods(groupPath: string): Promise<FolderGroup> {
+    public async mods(groupPath: string, searchModPreview?: boolean): Promise<FolderGroup> {
         try {
             const game = await this.getGameByPath(groupPath);
             if (game && isNteImporter(game.importer)) {
-                return await getNteMods(this.desktop, getNteRoots(game), groupPath);
+                return await getNteMods(
+                    this.desktop,
+                    getNteRoots(game),
+                    groupPath,
+                    searchModPreview ?? (await this.desktop.setting.mod.getSearchModPreview()),
+                );
             }
 
             const group = await getMods(groupPath);

--- a/src/main/services/mod-manager/nte.test.ts
+++ b/src/main/services/mod-manager/nte.test.ts
@@ -51,7 +51,7 @@ describe("NTE wrapped pak folders", () => {
         await fse.writeFile(path.join(sparkle, "preview.png"), "preview");
 
         const roots = { modRoot, linkedRoot: null };
-        const group = await getNteMods(desktopStub(), roots, shinku);
+        const group = await getNteMods(desktopStub(), roots, shinku, false);
 
         assert.deepEqual(
             group.mods.map((mod) => ({ name: mod.name, isEnabled: mod.isEnabled })),
@@ -81,7 +81,12 @@ describe("NTE wrapped pak folders", () => {
             "Shinku Natsu Sparkle_P.pak",
         );
 
-        const groups = await getNteSubGroups(desktopStub(), { modRoot, linkedRoot: null }, shinku);
+        const groups = await getNteSubGroups(
+            desktopStub(),
+            { modRoot, linkedRoot: null },
+            shinku,
+            false,
+        );
 
         assert.deepEqual(
             groups.map((group) => group.name),
@@ -100,8 +105,8 @@ describe("NTE wrapped pak folders", () => {
         );
 
         const roots = { modRoot, linkedRoot: null };
-        const characterMods = await getNteMods(desktopStub(), roots, character);
-        const characterGroups = await getNteSubGroups(desktopStub(), roots, character);
+        const characterMods = await getNteMods(desktopStub(), roots, character, false);
+        const characterGroups = await getNteSubGroups(desktopStub(), roots, character, false);
         const shinkuGroup = characterGroups.find((group) => group.name === "Shinku");
 
         assert.deepEqual(
@@ -124,9 +129,9 @@ describe("NTE wrapped pak folders", () => {
         );
 
         const roots = { modRoot, linkedRoot: null };
-        const group = await getNteMods(desktopStub(), roots, npc);
-        const npcGroups = await getNteSubGroups(desktopStub(), roots, npc);
-        const rootGroups = await getNteSubGroups(desktopStub(), roots, modRoot);
+        const group = await getNteMods(desktopStub(), roots, npc, false);
+        const npcGroups = await getNteSubGroups(desktopStub(), roots, npc, false);
+        const rootGroups = await getNteSubGroups(desktopStub(), roots, modRoot, false);
 
         assert.deepEqual(
             group.mods.map((mod) => ({ name: mod.name, isEnabled: mod.isEnabled })),
@@ -151,8 +156,8 @@ describe("NTE wrapped pak folders", () => {
         await writePak(path.join(shinku, "DISABLED ShinkuSwim"), "mod_P.pak.disabled");
 
         const roots = { modRoot, linkedRoot: null };
-        const characterMods = await getNteMods(desktopStub(), roots, character);
-        const characterGroups = await getNteSubGroups(desktopStub(), roots, character);
+        const characterMods = await getNteMods(desktopStub(), roots, character, false);
+        const characterGroups = await getNteSubGroups(desktopStub(), roots, character, false);
 
         assert.deepEqual(
             characterMods.mods.map((mod) => mod.name),
@@ -171,7 +176,12 @@ describe("NTE wrapped pak folders", () => {
         await writePak(path.join(daffodil, "longhairdaff", "Alt Skin"), "mod_P.pak");
         await writePak(path.join(daffodil, "longhairdaff", "Default Skin"), "mod_P.pak");
 
-        const group = await getNteMods(desktopStub(), { modRoot, linkedRoot: null }, daffodil);
+        const group = await getNteMods(
+            desktopStub(),
+            { modRoot, linkedRoot: null },
+            daffodil,
+            false,
+        );
 
         assert.deepEqual(
             group.mods.map((mod) => mod.name),
@@ -181,5 +191,102 @@ describe("NTE wrapped pak folders", () => {
             group.mods.every((mod) => mod.isEnabled),
             true,
         );
+    });
+});
+
+describe("NTE preview discovery", () => {
+    it("uses a generic media file in the mod folder as the preview", async () => {
+        const modRoot = await makeModRoot();
+        const shopGirl = path.join(modRoot, "NPC", "NPC_Shop Girl");
+        await writePak(shopGirl, "NPC_023_NSFW_P.pak");
+        const cover = path.join(shopGirl, "cover.jpg");
+        await fse.writeFile(cover, "preview");
+
+        const group = await getNteMods(
+            desktopStub(),
+            { modRoot, linkedRoot: null },
+            path.join(modRoot, "NPC"),
+            false,
+        );
+
+        assert.equal(group.mods[0]?.preview, cover);
+    });
+
+    it("finds a nested preview inside the mod folder", async () => {
+        const modRoot = await makeModRoot();
+        const shopGirl = path.join(modRoot, "NPC", "NPC_Shop Girl");
+        await writePak(shopGirl, "NPC_023_NSFW_P.pak");
+        const nested = path.join(shopGirl, "images", "shot.png");
+        await fse.ensureDir(path.dirname(nested));
+        await fse.writeFile(nested, "preview");
+
+        const group = await getNteMods(
+            desktopStub(),
+            { modRoot, linkedRoot: null },
+            path.join(modRoot, "NPC"),
+            false,
+        );
+
+        assert.equal(group.mods[0]?.preview, nested);
+    });
+
+    it("falls back to a non-preview filename on a wrapper folder", async () => {
+        const modRoot = await makeModRoot();
+        const sparkle = path.join(modRoot, "Character", "Shinku", "Shinku Natsu Sparkle 1.3");
+        await writePak(path.join(sparkle, "shinku"), "Shinku Natsu Sparkle_P.pak");
+        const cover = path.join(sparkle, "cover.jpg");
+        await fse.writeFile(cover, "preview");
+
+        const group = await getNteMods(
+            desktopStub(),
+            { modRoot, linkedRoot: null },
+            path.join(modRoot, "Character", "Shinku"),
+            false,
+        );
+
+        assert.equal(
+            group.mods.find((mod) => mod.name === "Shinku Natsu Sparkle 1.3 / shinku")?.preview,
+            cover,
+        );
+    });
+
+    it("searches child folders for a group preview only when enabled", async () => {
+        const modRoot = await makeModRoot();
+        const shinku = path.join(modRoot, "Character", "Shinku");
+        const nestedPreview = path.join(shinku, "Shinku Mod", "preview.png");
+        await writePak(path.join(shinku, "Shinku Mod"), "mod_P.pak");
+        await fse.writeFile(nestedPreview, "preview");
+
+        const roots = { modRoot, linkedRoot: null };
+        const withSearch = await getNteSubGroups(
+            desktopStub(),
+            roots,
+            path.join(modRoot, "Character"),
+            true,
+        );
+        const withoutSearch = await getNteSubGroups(
+            desktopStub(),
+            roots,
+            path.join(modRoot, "Character"),
+            false,
+        );
+
+        assert.equal(withSearch.find((group) => group.name === "Shinku")?.preview, nestedPreview);
+        assert.equal(withoutSearch.find((group) => group.name === "Shinku")?.preview, undefined);
+    });
+
+    it("uses the search setting for the group preview when listing mods", async () => {
+        const modRoot = await makeModRoot();
+        const npc = path.join(modRoot, "NPC");
+        const nestedPreview = path.join(npc, "NPC_Shop Girl", "preview.png");
+        await writePak(path.join(npc, "NPC_Shop Girl"), "NPC_023_NSFW_P.pak");
+        await fse.writeFile(nestedPreview, "preview");
+
+        const roots = { modRoot, linkedRoot: null };
+        const withSearch = await getNteMods(desktopStub(), roots, npc, true);
+        const withoutSearch = await getNteMods(desktopStub(), roots, npc, false);
+
+        assert.equal(withSearch.preview, nestedPreview);
+        assert.equal(withoutSearch.preview, undefined);
     });
 });

--- a/src/main/services/mod-manager/nte.ts
+++ b/src/main/services/mod-manager/nte.ts
@@ -18,12 +18,16 @@ import {
     toPowerShellString,
 } from "../../lib/elevated-fs";
 import {
+    DISABLED_FILE_SUFFIX,
     DISABLED_PREFIX_REGEX,
+    isDisabledFile,
     isSameOrChildPath,
     normalizeModPath,
     renameWithUniqueName,
+    stripDisabledFileSuffix,
     stripDisabledPrefix,
 } from "./path-utils";
+import { findPreview } from "./preview";
 
 const NTE_EXE_NAME = "HTGame.exe";
 const NTE_COMMON_EXE_RELATIVE_PATH = path.join(
@@ -38,8 +42,6 @@ const NTE_COMMON_EXE_RELATIVE_PATH = path.join(
 const NTE_MODS_RELATIVE_PATH = path.join("Content", "Paks", "Mods");
 const NTE_DEFAULT_MOD_SUBFOLDERS = ["Character", "UI", "Enemy", "NPC"] as const;
 const NTE_USER_MODS_FOLDER_NAME = "NTE-Mods";
-const DISABLED_FILE_SUFFIX = ".disabled";
-const PREVIEW_FILE_REGEX = /^preview\.(jpeg|jpg|gif|png|webp|bmp|mp4|webm|ogg)$/i;
 
 export interface NtePathResolution {
     gameRootPath: string;
@@ -157,14 +159,16 @@ export function findNteGameByPath(games: GameConfig[], targetPath: string) {
 export async function getNteCharacters(
     desktop: NahidaDesktop,
     roots: NteGameRoots,
+    searchModPreview: boolean,
 ): Promise<FolderGroup[]> {
-    return await getNteSubGroups(desktop, roots, roots.modRoot);
+    return await getNteSubGroups(desktop, roots, roots.modRoot, searchModPreview);
 }
 
 export async function getNteSubGroups(
     _desktop: NahidaDesktop,
     roots: NteGameRoots,
     groupPath: string,
+    searchModPreview: boolean,
 ): Promise<FolderGroup[]> {
     const relativePath = getNteRelativePath(roots, groupPath);
     const groupDir = path.join(roots.modRoot, relativePath);
@@ -177,7 +181,7 @@ export async function getNteSubGroups(
             if (await hasDirectPak(nextPath)) return null;
             if (await isNtePakWrapper(roots, nextPath)) return null;
 
-            const preview = await findPreview(nextPath);
+            const preview = await findPreview(nextPath, searchModPreview);
             const modCounts = await countDirectMods(roots, nextPath);
             return {
                 name: groupName,
@@ -199,6 +203,7 @@ export async function getNteMods(
     desktop: NahidaDesktop,
     roots: NteGameRoots,
     groupPath: string,
+    searchModPreview: boolean,
 ): Promise<FolderGroup> {
     const relativePath = getNteRelativePath(roots, groupPath);
     const groupDir = path.join(roots.modRoot, relativePath);
@@ -213,7 +218,7 @@ export async function getNteMods(
         )
     ).sort((a, b) => a.name.localeCompare(b.name));
 
-    const preview = await findPreview(groupDir);
+    const preview = await findPreview(groupDir, searchModPreview);
     return {
         name: path.basename(groupPath),
         path: groupDir,
@@ -281,7 +286,7 @@ export async function setNteModEnabled(
                 .map((entry) =>
                     fse.rename(
                         path.join(modPath, entry.name),
-                        path.join(modPath, entry.name.slice(0, -DISABLED_FILE_SUFFIX.length)),
+                        path.join(modPath, stripDisabledFileSuffix(entry.name)),
                     ),
                 ),
         );
@@ -962,16 +967,8 @@ async function isNtePakWrapper(roots: NteGameRoots, dirPath: string) {
     return childInfos.every((child) => child.hasPak || !child.hasSubdirs);
 }
 
-function isDisabledFile(fileName: string) {
-    return fileName.toLowerCase().endsWith(DISABLED_FILE_SUFFIX);
-}
-
 function isPakModFile(fileName: string) {
-    const baseName = isDisabledFile(fileName)
-        ? fileName.slice(0, -DISABLED_FILE_SUFFIX.length)
-        : fileName;
-
-    return baseName.toLowerCase().endsWith(".pak");
+    return stripDisabledFileSuffix(fileName).toLowerCase().endsWith(".pak");
 }
 
 async function hasDirectPak(dirPath: string) {
@@ -995,17 +992,6 @@ async function countDirectMods(roots: NteGameRoots, groupDir: string) {
     };
 }
 
-async function findPreview(dirPath: string) {
-    if (!(await fse.pathExists(dirPath))) return undefined;
-
-    const preview = (await fse.readdir(dirPath)).find((entry) =>
-        PREVIEW_FILE_REGEX.test(
-            isDisabledFile(entry) ? entry.slice(0, -DISABLED_FILE_SUFFIX.length) : entry,
-        ),
-    );
-    return preview ? path.join(dirPath, preview) : undefined;
-}
-
 async function createNteModInfo(
     desktop: NahidaDesktop,
     modPath: string,
@@ -1014,8 +1000,10 @@ async function createNteModInfo(
 ) {
     const stat = await fse.stat(modPath);
     const preview =
-        (await findPreview(modPath)) ??
-        (options?.previewFallbackDir ? await findPreview(options.previewFallbackDir) : undefined);
+        (await findPreview(modPath, true)) ??
+        (options?.previewFallbackDir
+            ? await findPreview(options.previewFallbackDir, false)
+            : undefined);
 
     return {
         id: modPath,

--- a/src/main/services/mod-manager/path-utils.test.ts
+++ b/src/main/services/mod-manager/path-utils.test.ts
@@ -4,9 +4,12 @@ import { describe, it } from "vitest";
 
 import {
     DISABLED_PREFIX_REGEX,
+    isDisabledFile,
+    isDisabledFolderName,
     manualSubGroupSegmentMatches,
     normalizeRelativePath,
     restoreDisabledPrefix,
+    stripDisabledFileSuffix,
     stripDisabledPrefix,
 } from "./path-utils.ts";
 
@@ -98,6 +101,24 @@ describe("stripDisabledPrefix", () => {
         assert.equal(stripDisabledPrefix("disableddisableddisabled Foo"), "Foo");
         assert.equal(stripDisabledPrefix("disabled_disabled_disabled_foo"), "foo");
         assert.equal(stripDisabledPrefix("disabled disabled disabled foo"), "foo");
+    });
+});
+
+describe("disabled file suffix", () => {
+    it("detects and strips a trailing .disabled suffix", () => {
+        assert.equal(isDisabledFile("preview.png.disabled"), true);
+        assert.equal(isDisabledFile("preview.png.DISABLED"), true);
+        assert.equal(isDisabledFile("preview.png"), false);
+        assert.equal(stripDisabledFileSuffix("preview.png.disabled"), "preview.png");
+        assert.equal(stripDisabledFileSuffix("preview.png"), "preview.png");
+    });
+});
+
+describe("isDisabledFolderName", () => {
+    it("detects disabled folder prefixes", () => {
+        assert.equal(isDisabledFolderName("DISABLED Foo"), true);
+        assert.equal(isDisabledFolderName("DISABLED_Foo"), true);
+        assert.equal(isDisabledFolderName("Foo"), false);
     });
 });
 

--- a/src/main/services/mod-manager/path-utils.ts
+++ b/src/main/services/mod-manager/path-utils.ts
@@ -6,6 +6,22 @@ import type { NahidaDesktop } from "../..";
 
 export { DISABLED_PREFIX_REGEX, stripDisabledPrefix } from "@shared/mod";
 
+export const DISABLED_FILE_SUFFIX = ".disabled";
+
+export function isDisabledFile(fileName: string) {
+    return fileName.toLowerCase().endsWith(DISABLED_FILE_SUFFIX);
+}
+
+export function stripDisabledFileSuffix(fileName: string) {
+    if (!isDisabledFile(fileName)) return fileName;
+    return fileName.slice(0, -DISABLED_FILE_SUFFIX.length);
+}
+
+export function isDisabledFolderName(folderName: string) {
+    const trimmed = folderName.trim();
+    return stripDisabledPrefix(trimmed) !== trimmed;
+}
+
 export function normalizeModPath(modPath: string): string {
     return path.normalize(modPath).toLowerCase();
 }

--- a/src/main/services/mod-manager/preview.test.ts
+++ b/src/main/services/mod-manager/preview.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+
+import fse from "fs-extra";
+import { afterEach, describe, it } from "vitest";
+
+import { findPreview } from "./preview.ts";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+    await Promise.all(tempRoots.splice(0).map((root) => fse.remove(root)));
+});
+
+async function makeRoot() {
+    const root = await fse.mkdtemp(path.join(os.tmpdir(), "nhd-preview-"));
+    tempRoots.push(root);
+    return root;
+}
+
+async function writeFile(root: string, relativePath: string) {
+    const filePath = path.join(root, relativePath);
+    await fse.ensureDir(path.dirname(filePath));
+    await fse.writeFile(filePath, "preview");
+    return filePath;
+}
+
+describe("findPreview", () => {
+    it("accepts a media file that is not named preview", async () => {
+        const root = await makeRoot();
+        const screenshot = await writeFile(root, "screenshot.png");
+
+        assert.equal(await findPreview(root, false), screenshot);
+    });
+
+    it("prefers a preview-named file over a generic root image", async () => {
+        const root = await makeRoot();
+        const preview = await writeFile(root, "preview.webp");
+        await writeFile(root, "cover.jpg");
+
+        assert.equal(await findPreview(root, false), preview);
+    });
+
+    it("accepts a file whose name contains preview", async () => {
+        const root = await makeRoot();
+        const preview = await writeFile(root, "mod_preview.png");
+
+        assert.equal(await findPreview(root, false), preview);
+    });
+
+    it("searches nested folders only when asked", async () => {
+        const root = await makeRoot();
+        const nested = await writeFile(root, "images/cover.jpg");
+
+        assert.equal(await findPreview(root, true), nested);
+        assert.equal(await findPreview(root, false), undefined);
+    });
+
+    it("prefers a root image over a nested preview in a disabled folder", async () => {
+        const root = await makeRoot();
+        const screenshot = await writeFile(root, "screenshot.png");
+        await writeFile(root, "DISABLED Nested/preview.png");
+
+        assert.equal(await findPreview(root, true), screenshot);
+    });
+
+    it("prefers a group-root preview over a child folder", async () => {
+        const root = await makeRoot();
+        const rootPreview = await writeFile(root, "preview.png");
+        await writeFile(root, "Enabled Mod/preview.png");
+
+        assert.equal(await findPreview(root, true), rootPreview);
+    });
+
+    it("prefers an enabled child folder before a disabled one", async () => {
+        const root = await makeRoot();
+        const enabledPreview = await writeFile(root, "Enabled Mod/nested/deeper/preview.png");
+        await writeFile(root, "DISABLED Other Mod/preview.png");
+
+        assert.equal(await findPreview(root, true), enabledPreview);
+    });
+
+    it("falls back to a disabled child folder", async () => {
+        const root = await makeRoot();
+        const disabledPreview = await writeFile(root, "DISABLED Other Mod/preview.png");
+
+        assert.equal(await findPreview(root, true), disabledPreview);
+    });
+
+    it("accepts a non-preview filename in a child folder", async () => {
+        const root = await makeRoot();
+        const cover = await writeFile(root, "Enabled Mod/cover.jpg");
+
+        assert.equal(await findPreview(root, true), cover);
+    });
+
+    it("recognizes a disabled preview file suffix", async () => {
+        const root = await makeRoot();
+        const preview = await writeFile(root, "preview.png.disabled");
+
+        assert.equal(await findPreview(root, false), preview);
+    });
+
+    it("ignores texture-like names", async () => {
+        const root = await makeRoot();
+        await writeFile(root, "normal.png");
+        await writeFile(root, "light.jpg");
+        await writeFile(root, "material.webp");
+        await writeFile(root, "diffuse.png");
+
+        assert.equal(await findPreview(root, false), undefined);
+    });
+});

--- a/src/main/services/mod-manager/preview.ts
+++ b/src/main/services/mod-manager/preview.ts
@@ -1,0 +1,116 @@
+import path from "node:path";
+
+import fse from "fs-extra";
+
+import { isDisabledFolderName, stripDisabledFileSuffix } from "./path-utils";
+
+const MEDIA_EXTENSIONS = new Set([
+    "png",
+    "jpg",
+    "jpeg",
+    "gif",
+    "webp",
+    "bmp",
+    "avif",
+    "avifs",
+    "mp4",
+    "webm",
+    "avi",
+    "mkv",
+    "mov",
+    "ogg",
+]);
+const VIDEO_SCORE_EXTENSIONS = new Set(["mp4", "webm"]);
+const EXCLUDED_NAME_FRAGMENTS = ["normal", "light", "material", "diffuse"] as const;
+
+const PREVIEW_NAME_PREFIX_SCORE = 1000;
+const PREVIEW_NAME_CONTAINS_SCORE = 500;
+const ROOT_FILE_SCORE = 200;
+const VIDEO_FILE_SCORE = 10;
+
+type PreviewLocation = "root" | "enabled" | "disabled";
+
+type PreviewCandidate = {
+    score: number;
+    path: string;
+    location: PreviewLocation;
+};
+
+export async function findPreview(dirPath: string, searchSubfolders: boolean) {
+    const candidates = (await collectFiles(dirPath, searchSubfolders)).flatMap((filePath) => {
+        const candidate = toPreviewCandidate(dirPath, filePath);
+        return candidate ? [candidate] : [];
+    });
+
+    return pickBestCandidate(candidates)?.path;
+}
+
+async function collectFiles(dirPath: string, searchSubfolders: boolean): Promise<string[]> {
+    if (!(await fse.pathExists(dirPath))) return [];
+
+    const nested = await Promise.all(
+        (await fse.readdir(dirPath, { withFileTypes: true })).map(async (entry) => {
+            const entryPath = path.join(dirPath, entry.name);
+            if (entry.isFile()) return [entryPath];
+            if (!searchSubfolders || !entry.isDirectory()) return [];
+            return collectFiles(entryPath, true);
+        }),
+    );
+
+    return nested.flat();
+}
+
+function toPreviewCandidate(rootPath: string, filePath: string): PreviewCandidate | undefined {
+    const activeName = stripDisabledFileSuffix(path.basename(filePath));
+    const extension = path.extname(activeName).slice(1).toLowerCase();
+    if (!MEDIA_EXTENSIONS.has(extension)) return undefined;
+
+    const lowerName = activeName.toLowerCase();
+    if (EXCLUDED_NAME_FRAGMENTS.some((fragment) => lowerName.includes(fragment))) return undefined;
+
+    const relativeSegments = path
+        .relative(rootPath, filePath)
+        .split(/[\\/]+/)
+        .filter(Boolean);
+    if (relativeSegments.length === 0) return undefined;
+
+    const isRoot = relativeSegments.length === 1;
+    return {
+        score: previewScore(lowerName, isRoot, VIDEO_SCORE_EXTENSIONS.has(extension)),
+        path: filePath,
+        location: isRoot
+            ? "root"
+            : relativeSegments.slice(0, -1).some(isDisabledFolderName)
+              ? "disabled"
+              : "enabled",
+    };
+}
+
+function previewScore(fileName: string, isRoot: boolean, isVideo: boolean) {
+    const nameScore = fileName.startsWith("preview")
+        ? PREVIEW_NAME_PREFIX_SCORE
+        : fileName.includes("preview")
+          ? PREVIEW_NAME_CONTAINS_SCORE
+          : 0;
+
+    return nameScore + (isRoot ? ROOT_FILE_SCORE : 0) + (isVideo ? VIDEO_FILE_SCORE : 0);
+}
+
+function pickBestCandidate(candidates: PreviewCandidate[]) {
+    if (candidates.length === 0) return undefined;
+
+    return candidates.reduce((best, candidate) => {
+        const locationDelta = locationRank(candidate.location) - locationRank(best.location);
+        if (locationDelta !== 0) return locationDelta < 0 ? candidate : best;
+        if (candidate.score !== best.score) return candidate.score > best.score ? candidate : best;
+        return candidate.path.localeCompare(best.path, undefined, { numeric: true }) < 0
+            ? candidate
+            : best;
+    });
+}
+
+function locationRank(location: PreviewLocation) {
+    if (location === "root") return 0;
+    if (location === "enabled") return 1;
+    return 2;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Preview-path selection and listing-only filesystem walks; no auth, install, or enable/disable behavior changes. Nested search can scan more files when the setting is enabled.
> 
> **Overview**
> NTE mod listing now finds previews from generic media files (not just `preview.*`) and can search nested folders when the existing search-preview setting is on.
> 
> A shared `findPreview` scorer prefers root files, names containing “preview”, enabled folders over disabled ones, and skips texture-like names (`normal`, `light`, `material`, `diffuse`). Individual mods always search inside their own folder; group-level nested search follows the setting. Disabled `.disabled` suffixes are handled via shared path helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2362091bbd57d129943a116c4347b5ac94304c4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved mod preview discovery, including nested folders, fallback locations, and disabled files or folders.
  - Added support for explicitly enabling or disabling preview searches when browsing characters, groups, and mods.
  - Preview selection now prioritizes the most relevant supported media files.

- **Bug Fixes**
  - Improved restoration of disabled mod files when enabling mods.
  - Excluded unsuitable texture-like files from preview results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->