### PR TITLE
feat: replace /ping with /status endpoint and add maintenance state

### DIFF
--- a/src/main/internal/http.test.ts
+++ b/src/main/internal/http.test.ts
@@ -19,7 +19,12 @@ function createService(getToken = vi.fn(async () => "stored-token")) {
     const desktop = {
         service: {
             auth: { getToken, getSession: vi.fn() },
-            backendConnectivity: { setOffline: vi.fn(), setOnline: vi.fn() },
+            backendConnectivity: {
+                setOffline: vi.fn(),
+                setOnline: vi.fn(),
+                getStatus: vi.fn(() => "online" as const),
+                probe: vi.fn(async () => "online" as const),
+            },
         },
         logger: { warn: vi.fn(), error: vi.fn() },
     } as unknown as NahidaDesktop;
@@ -28,6 +33,7 @@ function createService(getToken = vi.fn(async () => "stored-token")) {
 
 describe("DesktopHttpService", () => {
     it("does not replace an Authorization header already provided by the caller", async () => {
+        mocks.ky.mockReset();
         mocks.ky.mockResolvedValue(new Response("ok"));
         const { service, getToken } = createService();
 
@@ -48,6 +54,7 @@ describe("DesktopHttpService", () => {
     });
 
     it("does not replace an Authorization header provided as a tuple array", async () => {
+        mocks.ky.mockReset();
         mocks.ky.mockResolvedValue(new Response("ok"));
         const { service, getToken } = createService();
 
@@ -68,6 +75,7 @@ describe("DesktopHttpService", () => {
     });
 
     it("resolves Authorization from the current token when the caller does not provide one", async () => {
+        mocks.ky.mockReset();
         mocks.ky.mockResolvedValue(new Response("ok"));
         const { service, getToken } = createService();
 
@@ -83,5 +91,80 @@ describe("DesktopHttpService", () => {
                 },
             }),
         );
+    });
+
+    it("short-circuits NHD requests when backend is offline", async () => {
+        mocks.ky.mockReset();
+        mocks.ky.mockResolvedValue(new Response("ok"));
+        const { service, getToken } = createService();
+
+        const desktop = service["desktop"] as unknown as {
+            service: { backendConnectivity: { getStatus: ReturnType<typeof vi.fn> } };
+        };
+        desktop.service.backendConnectivity.getStatus.mockReturnValue("offline");
+
+        await expect(
+            service.fetcher("https://api.nahida.live/api/drive"),
+        ).rejects.toThrow("DRIVE_BACKEND_UNAVAILABLE");
+        expect(getToken).not.toHaveBeenCalled();
+        expect(mocks.ky).not.toHaveBeenCalled();
+    });
+
+    it("short-circuits NHD requests when backend is in maintenance", async () => {
+        mocks.ky.mockReset();
+        mocks.ky.mockResolvedValue(new Response("ok"));
+        const { service } = createService();
+
+        const desktop = service["desktop"] as unknown as {
+            service: { backendConnectivity: { getStatus: ReturnType<typeof vi.fn> } };
+        };
+        desktop.service.backendConnectivity.getStatus.mockReturnValue("maintenance");
+
+        await expect(
+            service.fetcher("https://api.nahida.live/api/drive"),
+        ).rejects.toThrow("DRIVE_BACKEND_UNAVAILABLE");
+        expect(mocks.ky).not.toHaveBeenCalled();
+    });
+
+    it("still sends session requests when backend is offline", async () => {
+        mocks.ky.mockReset();
+        mocks.ky.mockResolvedValue(new Response("ok"));
+        const { service } = createService();
+
+        const desktop = service["desktop"] as unknown as {
+            service: { backendConnectivity: { getStatus: ReturnType<typeof vi.fn> } };
+        };
+        desktop.service.backendConnectivity.getStatus.mockReturnValue("offline");
+
+        await service.fetcher("https://api.nahida.live/api/auth/get-session");
+        expect(mocks.ky).toHaveBeenCalledOnce();
+    });
+
+    it("probes /status when a 503 response is received from an NHD endpoint", async () => {
+        mocks.ky.mockReset();
+        mocks.ky.mockResolvedValue(new Response("Service Unavailable", { status: 503 }));
+        const { service } = createService();
+
+        await service.fetcher("https://api.nahida.live/api/drive");
+
+        const backendConnectivity = (service["desktop"] as unknown as {
+            service: { backendConnectivity: { probe: ReturnType<typeof vi.fn>; setOffline: ReturnType<typeof vi.fn> } };
+        }).service.backendConnectivity;
+        expect(backendConnectivity.probe).toHaveBeenCalledOnce();
+        expect(backendConnectivity.setOffline).not.toHaveBeenCalled();
+    });
+
+    it("calls setOffline when a 502 response is received from an NHD endpoint", async () => {
+        mocks.ky.mockReset();
+        mocks.ky.mockResolvedValue(new Response("Bad Gateway", { status: 502 }));
+        const { service } = createService();
+
+        await service.fetcher("https://api.nahida.live/api/drive");
+
+        const backendConnectivity = (service["desktop"] as unknown as {
+            service: { backendConnectivity: { probe: ReturnType<typeof vi.fn>; setOffline: ReturnType<typeof vi.fn> } };
+        }).service.backendConnectivity;
+        expect(backendConnectivity.setOffline).toHaveBeenCalledOnce();
+        expect(backendConnectivity.probe).not.toHaveBeenCalled();
     });
 });

--- a/src/main/internal/http.test.ts
+++ b/src/main/internal/http.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
     ky: vi.fn(),
+    isHTTPError: vi.fn((_error: unknown): _error is Error => false),
 }));
 
 vi.mock("ky", () => ({
     default: mocks.ky,
+    isHTTPError: mocks.isHTTPError,
     isNetworkError: () => false,
     isTimeoutError: () => false,
 }));
@@ -103,9 +105,9 @@ describe("DesktopHttpService", () => {
         };
         desktop.service.backendConnectivity.getStatus.mockReturnValue("offline");
 
-        await expect(
-            service.fetcher("https://api.nahida.live/api/drive"),
-        ).rejects.toThrow("DRIVE_BACKEND_UNAVAILABLE");
+        await expect(service.fetcher("https://api.nahida.live/api/drive")).rejects.toThrow(
+            "DRIVE_BACKEND_UNAVAILABLE",
+        );
         expect(getToken).not.toHaveBeenCalled();
         expect(mocks.ky).not.toHaveBeenCalled();
     });
@@ -120,9 +122,9 @@ describe("DesktopHttpService", () => {
         };
         desktop.service.backendConnectivity.getStatus.mockReturnValue("maintenance");
 
-        await expect(
-            service.fetcher("https://api.nahida.live/api/drive"),
-        ).rejects.toThrow("DRIVE_BACKEND_UNAVAILABLE");
+        await expect(service.fetcher("https://api.nahida.live/api/drive")).rejects.toThrow(
+            "DRIVE_BACKEND_UNAVAILABLE",
+        );
         expect(mocks.ky).not.toHaveBeenCalled();
     });
 
@@ -147,9 +149,16 @@ describe("DesktopHttpService", () => {
 
         await service.fetcher("https://api.nahida.live/api/drive");
 
-        const backendConnectivity = (service["desktop"] as unknown as {
-            service: { backendConnectivity: { probe: ReturnType<typeof vi.fn>; setOffline: ReturnType<typeof vi.fn> } };
-        }).service.backendConnectivity;
+        const backendConnectivity = (
+            service["desktop"] as unknown as {
+                service: {
+                    backendConnectivity: {
+                        probe: ReturnType<typeof vi.fn>;
+                        setOffline: ReturnType<typeof vi.fn>;
+                    };
+                };
+            }
+        ).service.backendConnectivity;
         expect(backendConnectivity.probe).toHaveBeenCalledOnce();
         expect(backendConnectivity.setOffline).not.toHaveBeenCalled();
     });
@@ -161,9 +170,66 @@ describe("DesktopHttpService", () => {
 
         await service.fetcher("https://api.nahida.live/api/drive");
 
-        const backendConnectivity = (service["desktop"] as unknown as {
-            service: { backendConnectivity: { probe: ReturnType<typeof vi.fn>; setOffline: ReturnType<typeof vi.fn> } };
-        }).service.backendConnectivity;
+        const backendConnectivity = (
+            service["desktop"] as unknown as {
+                service: {
+                    backendConnectivity: {
+                        probe: ReturnType<typeof vi.fn>;
+                        setOffline: ReturnType<typeof vi.fn>;
+                    };
+                };
+            }
+        ).service.backendConnectivity;
+        expect(backendConnectivity.setOffline).toHaveBeenCalledOnce();
+        expect(backendConnectivity.probe).not.toHaveBeenCalled();
+    });
+
+    it("probes when a rejected Ky 503 HTTPError is received from an NHD endpoint", async () => {
+        mocks.ky.mockReset();
+        const httpError = Object.assign(new Error("Request failed with status code 503"), {
+            name: "HTTPError",
+            response: { status: 503 },
+        });
+        mocks.isHTTPError.mockImplementation((e: unknown) => e === httpError);
+        mocks.ky.mockRejectedValue(httpError);
+        const { service } = createService();
+
+        await expect(service.fetcher("https://api.nahida.live/api/drive")).rejects.toThrow();
+        const backendConnectivity = (
+            service["desktop"] as unknown as {
+                service: {
+                    backendConnectivity: {
+                        probe: ReturnType<typeof vi.fn>;
+                        setOffline: ReturnType<typeof vi.fn>;
+                    };
+                };
+            }
+        ).service.backendConnectivity;
+        expect(backendConnectivity.probe).toHaveBeenCalledOnce();
+        expect(backendConnectivity.setOffline).not.toHaveBeenCalled();
+    });
+
+    it("calls setOffline when a rejected Ky 502 HTTPError is received from an NHD endpoint", async () => {
+        mocks.ky.mockReset();
+        const httpError = Object.assign(new Error("Request failed with status code 502"), {
+            name: "HTTPError",
+            response: { status: 502 },
+        });
+        mocks.isHTTPError.mockImplementation((e: unknown) => e === httpError);
+        mocks.ky.mockRejectedValue(httpError);
+        const { service } = createService();
+
+        await expect(service.fetcher("https://api.nahida.live/api/drive")).rejects.toThrow();
+        const backendConnectivity = (
+            service["desktop"] as unknown as {
+                service: {
+                    backendConnectivity: {
+                        probe: ReturnType<typeof vi.fn>;
+                        setOffline: ReturnType<typeof vi.fn>;
+                    };
+                };
+            }
+        ).service.backendConnectivity;
         expect(backendConnectivity.setOffline).toHaveBeenCalledOnce();
         expect(backendConnectivity.probe).not.toHaveBeenCalled();
     });

--- a/src/main/internal/http.ts
+++ b/src/main/internal/http.ts
@@ -3,7 +3,7 @@ import ky, { isNetworkError, isTimeoutError } from "ky";
 import type { NahidaDesktop } from "../index";
 
 import { appVersion } from "../const";
-import { isBackendUnavailableStatus } from "../services/drive-errors";
+import { createDriveApiError, isBackendUnavailableStatus } from "../services/drive-errors";
 
 const NHD_PREFIXES = ["http://localhost", "https://api.nahida.live"];
 
@@ -32,7 +32,20 @@ export class DesktopHttpService {
 
     public async fetcher(url: string, options?: FetcherOptions) {
         const isNHD = this.isNHD(url);
-        const isSessionRequest = URL.parse(url)?.pathname === "/api/auth/get-session";
+        const parsedUrl = URL.parse(url);
+        const isSessionRequest = parsedUrl?.pathname === "/api/auth/get-session";
+
+        if (isNHD && !isSessionRequest) {
+            const status = this.desktop.service.backendConnectivity.getStatus();
+            if (status === "offline" || status === "maintenance") {
+                throw createDriveApiError(
+                    new Error("backend unavailable"),
+                    "fetch",
+                    503,
+                );
+            }
+        }
+
         const optionHeaders =
             options?.headers instanceof Headers
                 ? Object.fromEntries(options.headers.entries())
@@ -117,7 +130,9 @@ export class DesktopHttpService {
             });
 
             if (isNHD) {
-                if (isBackendUnavailableStatus(resp.status)) {
+                if (resp.status === 503) {
+                    void this.desktop.service.backendConnectivity.probe();
+                } else if (isBackendUnavailableStatus(resp.status)) {
                     this.desktop.service.backendConnectivity.setOffline();
                 } else {
                     this.desktop.service.backendConnectivity.setOnline();

--- a/src/main/internal/http.ts
+++ b/src/main/internal/http.ts
@@ -1,4 +1,4 @@
-import ky, { isNetworkError, isTimeoutError } from "ky";
+import ky, { isHTTPError, isNetworkError, isTimeoutError } from "ky";
 
 import type { NahidaDesktop } from "../index";
 
@@ -38,11 +38,7 @@ export class DesktopHttpService {
         if (isNHD && !isSessionRequest) {
             const status = this.desktop.service.backendConnectivity.getStatus();
             if (status === "offline" || status === "maintenance") {
-                throw createDriveApiError(
-                    new Error("backend unavailable"),
-                    "fetch",
-                    503,
-                );
+                throw createDriveApiError(new Error("backend unavailable"), "fetch", 503);
             }
         }
 
@@ -140,8 +136,17 @@ export class DesktopHttpService {
             }
             return resp;
         } catch (error) {
-            if (isNHD && isUnreachableError(error)) {
-                this.desktop.service.backendConnectivity.setOffline();
+            if (isNHD) {
+                if (isHTTPError(error) && error.response.status === 503) {
+                    void this.desktop.service.backendConnectivity.probe();
+                } else if (
+                    isHTTPError(error) &&
+                    isBackendUnavailableStatus(error.response.status)
+                ) {
+                    this.desktop.service.backendConnectivity.setOffline();
+                } else if (isUnreachableError(error)) {
+                    this.desktop.service.backendConnectivity.setOffline();
+                }
             }
             throw error;
         }

--- a/src/main/lib/download.ts
+++ b/src/main/lib/download.ts
@@ -135,7 +135,9 @@ class DownloadStreamer {
             signal,
         });
         if (!response.ok) {
-            if (isBackendUnavailableStatus(response.status)) {
+            if (response.status === 503) {
+                void this.desktop.service.backendConnectivity.probe();
+            } else if (isBackendUnavailableStatus(response.status)) {
                 this.desktop.service.backendConnectivity.setOffline();
             }
             const body = await readApiBody(response).catch(() => response.statusText);

--- a/src/main/services/backend-connectivity.ts
+++ b/src/main/services/backend-connectivity.ts
@@ -46,12 +46,7 @@ export class BackendConnectivity {
                     "User-Agent": `Nahida Desktop/${appVersion}`,
                 },
             });
-            await resp.arrayBuffer();
-
-            const body = await resp
-                .clone()
-                .json()
-                .catch(() => null) as { status?: string } | null;
+            const body = (await resp.json().catch(() => null)) as { status?: string } | null;
 
             if (body?.status === "maintenance") {
                 this.setStatus("maintenance");

--- a/src/main/services/backend-connectivity.ts
+++ b/src/main/services/backend-connectivity.ts
@@ -38,7 +38,7 @@ export class BackendConnectivity {
         this.probing = true;
 
         try {
-            const resp = await ky.get(`${BACKEND_URL}/ping`, {
+            const resp = await ky.get(`${BACKEND_URL}/status`, {
                 timeout: PROBE_TIMEOUT_MS,
                 retry: 0,
                 throwHttpErrors: false,
@@ -47,8 +47,18 @@ export class BackendConnectivity {
                 },
             });
             await resp.arrayBuffer();
-            if (resp.status > 0 && !isBackendUnavailableStatus(resp.status)) {
-                this.setOnline();
+
+            const body = await resp
+                .clone()
+                .json()
+                .catch(() => null) as { status?: string } | null;
+
+            if (body?.status === "maintenance") {
+                this.setStatus("maintenance");
+            } else if (body?.status === "online") {
+                this.setStatus("online");
+            } else if (resp.status > 0 && !isBackendUnavailableStatus(resp.status)) {
+                this.setStatus("online");
             } else {
                 this.setOffline();
             }
@@ -72,7 +82,9 @@ export class BackendConnectivity {
     private scheduleProbe() {
         if (this.probeTimer) clearTimeout(this.probeTimer);
         const delay =
-            this.status === "offline" ? OFFLINE_PROBE_INTERVAL_MS : ONLINE_PROBE_INTERVAL_MS;
+            this.status === "offline" || this.status === "maintenance"
+                ? OFFLINE_PROBE_INTERVAL_MS
+                : ONLINE_PROBE_INTERVAL_MS;
         this.probeTimer = setTimeout(() => {
             void this.probe();
         }, delay);

--- a/src/main/services/drive.ts
+++ b/src/main/services/drive.ts
@@ -1220,7 +1220,9 @@ export class DriveService {
         const preexistingChildIds = await this.listDestinationChildIds(destinationId, signal);
         const response = await networkFetch(requestUrl, { headers, signal });
         if (!response.ok) {
-            if (isBackendUnavailableStatus(response.status)) {
+            if (response.status === 503) {
+                void this.desktop.service.backendConnectivity.probe();
+            } else if (isBackendUnavailableStatus(response.status)) {
                 this.desktop.service.backendConnectivity.setOffline();
             }
             const body = await readApiBody(response).catch(() => response.statusText);
@@ -1511,7 +1513,9 @@ export class DriveService {
         });
 
         if (!response.ok) {
-            if (isBackendUnavailableStatus(response.status)) {
+            if (response.status === 503) {
+                void this.desktop.service.backendConnectivity.probe();
+            } else if (isBackendUnavailableStatus(response.status)) {
                 this.desktop.service.backendConnectivity.setOffline();
             }
             const body = await readApiBody(response).catch(() => response.statusText);

--- a/src/renderer/src/hooks/use-auth.ts
+++ b/src/renderer/src/hooks/use-auth.ts
@@ -69,7 +69,7 @@ export function useAuth() {
         backendStatus,
         hasToken,
         isLoggedIn: !!session,
-        isBackendOffline: backendStatus === "offline",
+        isBackendOffline: backendStatus === "offline" || backendStatus === "maintenance",
         refreshSession: async () => {
             const nextSession = await window.api.invoke("auth:getSession");
             setSession(nextSession);

--- a/src/renderer/src/hooks/use-global-events.ts
+++ b/src/renderer/src/hooks/use-global-events.ts
@@ -69,7 +69,7 @@ export function useGlobalEvents(
                 setBackendStatus(status);
             }
             if (status !== "online") return;
-            if (previousStatus !== "offline" && !isColdStartRestore) return;
+            if (previousStatus !== "offline" && previousStatus !== "maintenance" && !isColdStartRestore) return;
 
             void (async () => {
                 try {

--- a/src/renderer/src/lib/i18n/locales/en.json
+++ b/src/renderer/src/lib/i18n/locales/en.json
@@ -1771,6 +1771,8 @@
     }
   },
   "titlebar": {
+    "server_inactive_badge": "Server inactive",
+    "server_inactive_tooltip": "The server is inactive or under maintenance, so nahida.live features are unavailable.",
     "activity": {
       "more": "+{{count}}",
       "transfer": {

--- a/src/renderer/src/lib/i18n/locales/ja.json
+++ b/src/renderer/src/lib/i18n/locales/ja.json
@@ -1738,6 +1738,8 @@
     }
   },
   "titlebar": {
+    "server_inactive_badge": "サーバー無効",
+    "server_inactive_tooltip": "サーバーが無効化またはメンテナンス中のため、nahida.liveの機能を利用できません。",
     "activity": {
       "more": "+{{count}}",
       "transfer": {

--- a/src/renderer/src/lib/i18n/locales/ko.json
+++ b/src/renderer/src/lib/i18n/locales/ko.json
@@ -1757,6 +1757,8 @@
     }
   },
   "titlebar": {
+    "server_inactive_badge": "서버 비활성화됨",
+    "server_inactive_tooltip": "서버가 비활성화되거나 점검 중이므로 nahida.live 기능을 이용할 수 없습니다.",
     "activity": {
       "more": "+{{count}}",
       "transfer": {

--- a/src/renderer/src/lib/i18n/locales/zh.json
+++ b/src/renderer/src/lib/i18n/locales/zh.json
@@ -1737,6 +1737,8 @@
     }
   },
   "titlebar": {
+    "server_inactive_badge": "服务器已停用",
+    "server_inactive_tooltip": "服务器已停用或正在维护中，nahida.live 功能无法使用。",
     "activity": {
       "more": "+{{count}}",
       "transfer": {

--- a/src/renderer/src/routes/__root.tsx
+++ b/src/renderer/src/routes/__root.tsx
@@ -7,8 +7,10 @@ import { useModBisectTitlebarActivity } from "@renderer/components/titlebar/use-
 import { useTextureResizerTitlebarActivity } from "@renderer/components/titlebar/use-texture-resizer-titlebar-activity";
 import { useTransferTitlebarActivity } from "@renderer/components/titlebar/use-transfer-titlebar-activity";
 import { Alert, AlertDescription, AlertTitle } from "@renderer/components/ui/alert";
+import { Badge } from "@renderer/components/ui/badge";
 import { Button } from "@renderer/components/ui/button";
 import { Toaster } from "@renderer/components/ui/sonner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@renderer/components/ui/tooltip";
 import { UpdateAlertDialog } from "@renderer/components/update-alert-dialog";
 import { DEFAULT_BG } from "@renderer/const";
 import { useGlobalEvents } from "@renderer/hooks/use-global-events";
@@ -26,13 +28,14 @@ import {
   useLocation,
   useRouter,
 } from "@tanstack/react-router";
-import { ArrowLeftIcon, DownloadIcon, RefreshCwIcon, TriangleAlertIcon } from "lucide-react";
+import { ArrowLeftIcon, DownloadIcon, RefreshCwIcon, ServerOffIcon, TriangleAlertIcon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 function RootComponent() {
   const location = useLocation();
   const setAppStatus = useGlobalStore((state) => state.setAppStatus);
+  const backendStatus = useGlobalStore((state) => state.backendStatus);
   const updateAvailable = useGlobalStore((state) => state.updateAvailable);
   const updateDownloaded = useGlobalStore((state) => state.updateDownloaded);
   const setUpdateAvailable = useGlobalStore((state) => state.setUpdateAvailable);
@@ -176,6 +179,28 @@ function RootComponent() {
           isDarwin ? "pl-21" : "pl-2",
         )}
       >
+        {backendStatus !== "online" && backendStatus !== "unknown" && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <div className="no-drag flex min-w-0 shrink-0 items-center">
+                  <Badge
+                    variant="secondary"
+                    className="h-5 gap-1 border-border/60 bg-muted/70 px-1.5 text-[11px] font-medium text-muted-foreground"
+                  >
+                    <ServerOffIcon className="size-3!" />
+                    <span className="truncate">
+                      {t("titlebar.server_inactive_badge")}
+                    </span>
+                  </Badge>
+                </div>
+              }
+            />
+            <TooltipContent side="bottom">
+              {t("titlebar.server_inactive_tooltip")}
+            </TooltipContent>
+          </Tooltip>
+        )}
         <TitlebarActivityBadges />
         <div className="ml-auto flex h-full shrink-0 items-center gap-2 pr-2">
           {shouldShowUpdateButton && (

--- a/src/shared/backend.ts
+++ b/src/shared/backend.ts
@@ -1,1 +1,1 @@
-export type BackendStatus = "unknown" | "online" | "offline";
+export type BackendStatus = "unknown" | "online" | "offline" | "maintenance";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how the app decides the backend is down vs in maintenance and when it skips API calls, which can hide real outages or block features if `/status` parsing or 503 handling is wrong.
> 
> **Overview**
> Connectivity now probes `GET /status` and can enter a new **`maintenance`** state from the JSON body. Offline and maintenance both use the faster probe interval.
> 
> **503 no longer immediately marks the backend offline.** HTTP, download metadata, and import paths probe `/status` on 503; 502/504 and network errors still call `setOffline`. The fetcher also **fails fast** for NHD requests (except session) when status is offline or maintenance, throwing `DRIVE_BACKEND_UNAVAILABLE`.
> 
> The UI treats maintenance like offline (`isBackendOffline`), restores session when coming back from maintenance, and shows a localized **Server inactive** titlebar badge with tooltip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c34c7c9f97277f0f92193f9388d77d4eebd5148a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added maintenance status detection and support.
  - Displayed a localized server-inactive badge with an explanatory tooltip when services are offline or under maintenance.
  - Added translations in English, Japanese, Korean, and Chinese.

- **Bug Fixes**
  - Improved handling of temporary service interruptions by checking connectivity before marking the backend offline.
  - Preserved session access while offline where supported.
  - Improved metadata and remote import behavior during service outages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->