### PR TITLE
resolve lint warnings

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,7 +4,8 @@
   "categories": {},
   "rules": {
     "typescript/no-explicit-any": "warn",
-    "react/exhaustive-deps": "off"
+    "react/exhaustive-deps": "off",
+    "react/incompatible-library": "off"
   },
   "overrides": [
     {

--- a/src/renderer/src/components/akasha/index.tsx
+++ b/src/renderer/src/components/akasha/index.tsx
@@ -81,7 +81,7 @@ export function AkashaBreadcrumb(props: AkashaBreadcrumbProps) {
     }
 
     return [
-      { id: session?.drive.rootId!, name: t("page.drive.title"), parentId: null },
+      { id: session?.drive.rootId ?? "", name: t("page.drive.title"), parentId: null },
       ...ancestors,
     ];
   }, [ancestors, location.pathname, session?.drive.rootId, t]);
@@ -124,7 +124,9 @@ export function AkashaBreadcrumb(props: AkashaBreadcrumbProps) {
                 ? current.parentId
                 : isSharePath
                   ? "share"
-                  : session?.drive.rootId!;
+                  : (session?.drive.rootId ?? "");
+
+              if (!parentId) return;
 
               queueRevealForDestination(parentId);
 

--- a/src/renderer/src/components/common.tsx
+++ b/src/renderer/src/components/common.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@renderer/lib/utils";
-import type { HTMLAttributes, ReactNode } from "react";
+import { type HTMLAttributes, type ReactNode, useState } from "react";
 
 interface CenterProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
@@ -15,7 +15,7 @@ export function Center({ children, size = "full", className, ...props }: CenterP
 
   return (
     <div
-      className={cn(`flex p-6 justify-center items-center ${sizeClasses[size]}`, className)}
+      className={cn(`flex items-center justify-center p-6 ${sizeClasses[size]}`, className)}
       {...props}
     >
       {children}
@@ -32,26 +32,28 @@ export function ServerCrash({ message }: { message?: string }) {
   );
 }
 
+const RANDOM_1619_IMAGES = [
+  "/img/1619/1619-miyabi.gif",
+  "/img/1619/1619-miyabi_2.gif",
+  "/img/1619/1619-miyabi_3.gif",
+];
+
 interface Random1619Props {
   className?: string;
   alt?: string;
 }
 
 export function Random1619({ className, alt, ...props }: Random1619Props) {
-  const images = [
-    "/img/1619/1619-miyabi.gif",
-    "/img/1619/1619-miyabi_2.gif",
-    "/img/1619/1619-miyabi_3.gif",
-  ];
-
-  const randomImage = images[Math.floor(Math.random() * images.length)];
+  const [randomImage] = useState(
+    () => RANDOM_1619_IMAGES[Math.floor(Math.random() * RANDOM_1619_IMAGES.length)],
+  );
 
   return <img className={className} alt={alt} src={randomImage} {...props} />;
 }
 
 export function AlertWithRandom1619({ message }: { message: string }) {
   return (
-    <div className="flex flex-col space-y-4 justify-center items-center">
+    <div className="flex flex-col items-center justify-center space-y-4">
       <Random1619 />
       <span className="text-lg">{message}</span>
     </div>

--- a/src/renderer/src/components/download-confirmation-overlay.tsx
+++ b/src/renderer/src/components/download-confirmation-overlay.tsx
@@ -4,18 +4,27 @@ import { Input } from "@renderer/components/ui/input";
 import { useSetting } from "@renderer/hooks/use-settings";
 import { Logger } from "@renderer/lib/logger";
 import { setSetting } from "@renderer/lib/settings";
-import { useModStore } from "@renderer/store/mod";
+import { type DownloadMode, useModStore } from "@renderer/store/mod";
 import { useNavigate } from "@tanstack/react-router";
 import { Download } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
 export function DownloadConfirmationOverlay() {
+  const downloadMode = useModStore((s) => s.downloadMode);
+
+  if (!downloadMode) return null;
+
+  return (
+    <DownloadConfirmationOverlayContent key={downloadMode.downloadId} downloadMode={downloadMode} />
+  );
+}
+
+function DownloadConfirmationOverlayContent({ downloadMode }: { downloadMode: DownloadMode }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  const downloadMode = useModStore((s) => s.downloadMode);
   const setDownloadMode = useModStore((s) => s.setDownloadMode);
   const resetUserSelectedDuringDownload = useModStore((s) => s.resetUserSelectedDuringDownload);
   const selectedGroup = useModStore((s) => s.selectedGroup);
@@ -24,21 +33,12 @@ export function DownloadConfirmationOverlay() {
 
   const selectedPath = selectedGroup?.path || null;
   const selectedGroupName = selectedGroup?.name;
-  const suggestedName = downloadMode?.suggestedName;
+  const suggestedName = downloadMode.suggestedName;
 
   const [fileName, setFileName] = useState(suggestedName || "");
-  const [shouldReturnToGamebanana, setShouldReturnToGamebanana] = useState(returnToGamebanana);
-
-  useEffect(() => {
-    setFileName(suggestedName || "");
-  }, [suggestedName]);
-
-  useEffect(() => {
-    setShouldReturnToGamebanana(returnToGamebanana);
-  }, [returnToGamebanana]);
 
   const handleConfirm = async () => {
-    if (!downloadMode || !selectedGroup) return;
+    if (!selectedGroup) return;
 
     try {
       await window.api.invoke(
@@ -50,7 +50,7 @@ export function DownloadConfirmationOverlay() {
 
       setDownloadMode(null);
       resetUserSelectedDuringDownload();
-      if (downloadMode.downloadSource === "gamebanana" && shouldReturnToGamebanana) {
+      if (downloadMode.downloadSource === "gamebanana" && returnToGamebanana) {
         void navigate({ to: "/gamebanana" });
       }
     } catch (error) {
@@ -60,8 +60,6 @@ export function DownloadConfirmationOverlay() {
   };
 
   const handleCancel = async () => {
-    if (!downloadMode) return;
-
     try {
       await window.api.invoke("pathSelector:cancel", downloadMode.downloadId);
       setDownloadMode(null);
@@ -70,8 +68,6 @@ export function DownloadConfirmationOverlay() {
       Logger.error(error, "DownloadConfirmationOverlay:handleCancel");
     }
   };
-
-  if (!downloadMode) return null;
 
   return (
     <div
@@ -133,9 +129,8 @@ export function DownloadConfirmationOverlay() {
           {downloadMode.downloadSource === "gamebanana" && (
             <label className="flex cursor-pointer items-center gap-2 text-sm">
               <Checkbox
-                checked={shouldReturnToGamebanana}
+                checked={returnToGamebanana}
                 onCheckedChange={(checked) => {
-                  setShouldReturnToGamebanana(checked);
                   void setSetting("mod.returnToGamebananaAfterDownload", checked);
                 }}
               />

--- a/src/renderer/src/components/drive/drive-import-overlay.tsx
+++ b/src/renderer/src/components/drive/drive-import-overlay.tsx
@@ -82,14 +82,31 @@ function isValidDriveUrl(value: string) {
 }
 
 export function DriveImportOverlay({ destinationId }: { destinationId: string }) {
+  const importOverlay = useViewStore((s) => s.importOverlay);
+  if (!importOverlay) return null;
+  return (
+    <DriveImportDialog
+      key={importOverlay.url}
+      importOverlay={importOverlay}
+      destinationId={destinationId}
+    />
+  );
+}
+
+function DriveImportDialog({
+  importOverlay,
+  destinationId,
+}: {
+  importOverlay: { url: string };
+  destinationId: string;
+}) {
   const { t } = useTranslation();
   const { session, sessionInitialized, startLogin } = useAuth();
   const queryClient = useQueryClient();
 
-  const importOverlay = useViewStore((s) => s.importOverlay);
   const setImportOverlay = useViewStore((s) => s.setImportOverlay);
 
-  const [url, setUrl] = useState("");
+  const [url, setUrl] = useState(importOverlay.url);
   const [password, setPassword] = useState("");
   const [createCollectionFolders, setCreateCollectionFolders] = useState(true);
   const [requiresPassword, setRequiresPassword] = useState(false);
@@ -116,76 +133,9 @@ export function DriveImportOverlay({ destinationId }: { destinationId: string })
 
   const destinationQuery = useQuery({
     queryKey: ["drive", "import-destination", destinationId],
-    enabled: !!importOverlay && !!destinationId,
+    enabled: !!destinationId,
     queryFn: async () => await window.api.invoke("drive:get:item", destinationId),
   });
-
-  // reset when overlay opens
-  useEffect(() => {
-    if (!importOverlay) return;
-    setUrl(importOverlay.url);
-    setPassword("");
-    setCreateCollectionFolders(true);
-    setRequiresPassword(false);
-    setPasswordInvalid(false);
-    setResolveFailed(false);
-    setStep(1);
-    setResolving(false);
-    setSourceInfo(null);
-    setTreeData(new Map());
-    setRootId(null);
-    setExpanded(new Set());
-    setSelected(new Set());
-    setLoadingIds(new Set());
-    setCopyProgress(null);
-    setIsImporting(false);
-    copyOperationIdRef.current = undefined;
-    isPendingRef.current = false;
-    loadSeqRef.current = 0;
-    lastResolvedUrlRef.current = "";
-    requestAnimationFrame(() => urlInputRef.current?.focus());
-  }, [importOverlay]);
-
-  useEffect(() => {
-    if (!importOverlay) return;
-    return window.api.on("drive:copy-progress", (progress) => {
-      if (progress.operationId !== copyOperationIdRef.current) return;
-      setCopyProgress(progress);
-    });
-  }, [importOverlay]);
-
-  // auto-resolve when the URL becomes a valid drive source URL
-  useEffect(() => {
-    if (!importOverlay) return;
-    const trimmed = url.trim();
-    if (trimmed === lastResolvedUrlRef.current) return;
-    loadSeqRef.current += 1;
-    setSourceInfo(null);
-    setTreeData(new Map());
-    setRootId(null);
-    setExpanded(new Set());
-    setSelected(new Set());
-    setStep(1);
-    setRequiresPassword(false);
-    setPasswordInvalid(false);
-    setResolveFailed(false);
-    if (!isValidDriveUrl(trimmed)) return;
-    if (!session) return;
-    const seq = ++loadSeqRef.current;
-    const timer = setTimeout(() => {
-      if (seq === loadSeqRef.current) void handleResolve(seq);
-    }, 500);
-    return () => clearTimeout(timer);
-  }, [url, importOverlay, session]);
-
-  // 가져오기는 transfer로 승격되어 백그라운드에서 계속되므로
-  // overlay 닫힘/페이지 이동이 전송을 취소하면 안된다.
-  // 취소는 명시적 handleCancel 또는 transfer 탭에서만 수행한다.
-
-  // focus password when required
-  useEffect(() => {
-    if (requiresPassword) requestAnimationFrame(() => passwordInputRef.current?.focus());
-  }, [requiresPassword]);
 
   const descendantMap = useMemo(() => {
     const map = new Map<string, Set<string>>();
@@ -204,12 +154,7 @@ export function DriveImportOverlay({ destinationId }: { destinationId: string })
           result.add(childId);
           const sub = getDescendants(childId, visited);
           for (const s of sub) result.add(s);
-        } else {
-          // files not counted for folder selection descendantMap, but we still traverse if it were folder
         }
-        // also need to consider deeper via child's descendants already
-        // Actually we already added via recursion, but need to ensure we also add grandchildren via child's descendant set
-        // The recursion above handles.
       }
       return result;
     };
@@ -252,6 +197,272 @@ export function DriveImportOverlay({ destinationId }: { destinationId: string })
     }
     return result;
   }, [rootId, treeData, expanded]);
+
+  const loadLinkChildren = useCallback(
+    async (
+      parentId: string,
+      linkId: string,
+      linkToken: string,
+      currentMap?: Map<string, NodeData>,
+      _currentRootId?: string | null,
+    ) => {
+      setLoadingIds((prev) => new Set(prev).add(parentId));
+      try {
+        const result: DriveListChildrenResult = await window.api.invoke(
+          "drive:fn:listLinkChildren",
+          {
+            linkId,
+            linkToken,
+            itemId: parentId,
+          },
+        );
+        setTreeData((prev) => {
+          const base = currentMap ? new Map(currentMap) : new Map(prev);
+          const parentNode = base.get(parentId);
+          if (!parentNode) return prev;
+          const parentDepth = parentNode.depth;
+          const childIds: string[] = [];
+          for (const child of result.children) {
+            const cid = child.id;
+            childIds.push(cid);
+            if (!base.has(cid)) {
+              base.set(cid, {
+                content: child,
+                children: [],
+                depth: parentDepth + 1,
+                loaded: false,
+              });
+            }
+          }
+          base.set(parentId, { ...parentNode, children: childIds, loaded: true });
+          return base;
+        });
+      } catch (error) {
+        if (isNotFoundError(error)) {
+          toast.error("링크가 만료되었습니다. 처음부터 다시 시도하세요.");
+          setSourceInfo(null);
+          setTreeData(new Map());
+          setRootId(null);
+          setExpanded(new Set());
+          setSelected(new Set());
+          setStep(1);
+          setRequiresPassword(false);
+          return;
+        }
+        toast.error("폴더 목록을 불러오지 못했습니다", { description: toErrorMessage(error) });
+      } finally {
+        setLoadingIds((prev) => {
+          const n = new Set(prev);
+          n.delete(parentId);
+          return n;
+        });
+      }
+    },
+    [],
+  );
+
+  const loadModChildren = useCallback(
+    async (
+      parentId: string,
+      modToken?: string,
+      modSig?: string,
+      currentMap?: Map<string, NodeData>,
+      _virtualRoot?: string | null,
+    ) => {
+      setLoadingIds((prev) => new Set(prev).add(parentId));
+      try {
+        const result: DriveListChildrenResult = await window.api.invoke(
+          "drive:fn:listModChildren",
+          {
+            itemId: parentId,
+            modToken,
+            modSig,
+          },
+        );
+        setTreeData((prev) => {
+          const base = currentMap ? new Map(currentMap) : new Map(prev);
+          const parentNode = base.get(parentId);
+          if (!parentNode) return prev;
+          const parentDepth = parentNode.depth;
+          const childIds: string[] = [];
+          for (const child of result.children) {
+            const cid = child.id;
+            childIds.push(cid);
+            if (!base.has(cid)) {
+              base.set(cid, {
+                content: child,
+                children: [],
+                depth: parentDepth + 1,
+                loaded: false,
+              });
+            }
+          }
+          base.set(parentId, { ...parentNode, children: childIds, loaded: true });
+          return base;
+        });
+      } catch (error) {
+        if (isNotFoundError(error)) {
+          toast.error("컬렉션을 불러오지 못했습니다. 링크가 만료되었을 수 있습니다.");
+          setSourceInfo(null);
+          setTreeData(new Map());
+          setRootId(null);
+          setExpanded(new Set());
+          setSelected(new Set());
+          setStep(1);
+          return;
+        }
+        toast.error("폴더 목록을 불러오지 못했습니다", { description: toErrorMessage(error) });
+      } finally {
+        setLoadingIds((prev) => {
+          const n = new Set(prev);
+          n.delete(parentId);
+          return n;
+        });
+      }
+    },
+    [],
+  );
+
+  const applyResolvedResult = useCallback(
+    (resolved: DriveResolveImportSourceResult, seq: number, trimmedUrl: string) => {
+      if (seq !== loadSeqRef.current) return;
+      setSourceInfo(resolved);
+      lastResolvedUrlRef.current = trimmedUrl;
+      // Build initial tree
+      if (resolved.source === "link") {
+        const rid = resolved.parent.id;
+        const rootContent: DriveImportContent = {
+          id: rid,
+          name: resolved.parent.name,
+          isDir: true,
+          size: null,
+          mimeType: null,
+          parentId: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+        const newMap = new Map<string, NodeData>();
+        newMap.set(rid, { content: rootContent, children: [], depth: 0, loaded: false });
+        setTreeData(newMap);
+        setRootId(rid);
+        setExpanded(new Set([rid]));
+        setSelected(new Set());
+        setStep(3);
+        // load children
+        void loadLinkChildren(rid, resolved.linkId, resolved.token, newMap, rid);
+      } else {
+        // mod
+        const virtualId = `mod:virtual:${resolved.modId}`;
+        const modTitle =
+          (resolved.modData as unknown as { mod?: { title?: string } }).mod?.title ??
+          (resolved.modData as unknown as { title?: string }).title ??
+          resolved.modId;
+        const virtualContent: DriveImportContent = {
+          id: virtualId,
+          name: String(modTitle),
+          isDir: true,
+          size: null,
+          mimeType: null,
+          parentId: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+        const newMap = new Map<string, NodeData>();
+        newMap.set(virtualId, { content: virtualContent, children: [], depth: 0, loaded: true });
+        const collectionNodes: NodeData[] = [];
+        for (const col of resolved.modData.collections as Array<{
+          id: string;
+          name: string;
+          rootId: string | null;
+          private: boolean;
+        }>) {
+          if (!col.rootId) continue;
+          // skip private already filtered in backend, but keep
+          const colContent: DriveImportContent = {
+            id: col.rootId,
+            name: col.name,
+            isDir: true,
+            size: null,
+            mimeType: null,
+            parentId: virtualId,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          };
+          collectionNodes.push({ content: colContent, children: [], depth: 1, loaded: false });
+          newMap.get(virtualId)!.children.push(col.rootId);
+          newMap.set(col.rootId, { content: colContent, children: [], depth: 1, loaded: false });
+        }
+        if (collectionNodes.length === 0) {
+          toast.warning("가져올 수 있는 컬렉션이 없습니다.");
+        }
+        setTreeData(newMap);
+        setRootId(virtualId);
+        setExpanded(new Set([virtualId, ...collectionNodes.map((n) => n.content.id)]));
+        setSelected(new Set());
+        setStep(3);
+        // Optionally auto-load first collection's children
+        for (const n of collectionNodes) {
+          void loadModChildren(n.content.id, resolved.token, resolved.sig, newMap, virtualId);
+        }
+      }
+      setRequiresPassword(false);
+      setPasswordInvalid(false);
+    },
+    [loadLinkChildren, loadModChildren],
+  );
+
+  const tryAutoPasswords = useCallback(
+    async (trimmedUrl: string, seq: number): Promise<boolean> => {
+      try {
+        const settings = await getSetting(["drive.autoTryPasswords", "drive.passwordList"]);
+        if (seq !== loadSeqRef.current) return true;
+        if (!settings["drive.autoTryPasswords"]) return false;
+
+        const candidates = settings["drive.passwordList"].filter(Boolean);
+        if (candidates.length === 0) return false;
+
+        const winner = await new Promise<{
+          resolved: DriveResolveImportSourceResult;
+          password: string;
+        } | null>((resolve) => {
+          let pending = candidates.length;
+          let settled = false;
+
+          for (const candidate of candidates) {
+            void window.api
+              .invoke("drive:fn:resolveImportSource", {
+                url: trimmedUrl,
+                password: candidate,
+              })
+              .then((resolved) => {
+                if (settled) return;
+                settled = true;
+                resolve({
+                  resolved: resolved as unknown as DriveResolveImportSourceResult,
+                  password: candidate,
+                });
+              })
+              .catch(() => {
+                pending -= 1;
+                if (!settled && pending === 0) resolve(null);
+              });
+          }
+        });
+
+        if (seq !== loadSeqRef.current) return true;
+        if (!winner) return false;
+
+        setPassword(winner.password);
+        setRequiresPassword(false);
+        setPasswordInvalid(false);
+        applyResolvedResult(winner.resolved, seq, trimmedUrl);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [applyResolvedResult],
+  );
 
   const handleResolve = useCallback(
     async (seqArg?: number) => {
@@ -328,263 +539,56 @@ export function DriveImportOverlay({ destinationId }: { destinationId: string })
         if (seq === loadSeqRef.current) setResolving(false);
       }
     },
-    [url, password, session, sessionInitialized, startLogin, t],
+    [
+      url,
+      password,
+      session,
+      sessionInitialized,
+      startLogin,
+      t,
+      applyResolvedResult,
+      tryAutoPasswords,
+    ],
   );
 
-  const tryAutoPasswords = useCallback(
-    async (trimmedUrl: string, seq: number): Promise<boolean> => {
-      try {
-        const settings = await getSetting(["drive.autoTryPasswords", "drive.passwordList"]);
-        if (seq !== loadSeqRef.current) return true;
-        if (!settings["drive.autoTryPasswords"]) return false;
+  useEffect(() => {
+    requestAnimationFrame(() => urlInputRef.current?.focus());
+  }, []);
 
-        const candidates = settings["drive.passwordList"].filter(Boolean);
-        if (candidates.length === 0) return false;
+  useEffect(() => {
+    return window.api.on("drive:copy-progress", (progress) => {
+      if (progress.operationId !== copyOperationIdRef.current) return;
+      setCopyProgress(progress);
+    });
+  }, []);
 
-        const winner = await new Promise<{
-          resolved: DriveResolveImportSourceResult;
-          password: string;
-        } | null>((resolve) => {
-          let pending = candidates.length;
-          let settled = false;
-
-          for (const candidate of candidates) {
-            void window.api
-              .invoke("drive:fn:resolveImportSource", {
-                url: trimmedUrl,
-                password: candidate,
-              })
-              .then((resolved) => {
-                if (settled) return;
-                settled = true;
-                resolve({
-                  resolved: resolved as unknown as DriveResolveImportSourceResult,
-                  password: candidate,
-                });
-              })
-              .catch(() => {
-                pending -= 1;
-                if (!settled && pending === 0) resolve(null);
-              });
-          }
-        });
-
-        if (seq !== loadSeqRef.current) return true;
-        if (!winner) return false;
-
-        setPassword(winner.password);
-        setRequiresPassword(false);
-        setPasswordInvalid(false);
-        applyResolvedResult(winner.resolved, seq, trimmedUrl);
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    [],
-  );
-
-  function applyResolvedResult(
-    resolved: DriveResolveImportSourceResult,
-    seq: number,
-    trimmedUrl: string,
-  ) {
-    if (seq !== loadSeqRef.current) return;
-    setSourceInfo(resolved);
-    lastResolvedUrlRef.current = trimmedUrl;
-    // Build initial tree
-    if (resolved.source === "link") {
-      const rid = resolved.parent.id;
-      const rootContent: DriveImportContent = {
-        id: rid,
-        name: resolved.parent.name,
-        isDir: true,
-        size: null,
-        mimeType: null,
-        parentId: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
-      const newMap = new Map<string, NodeData>();
-      newMap.set(rid, { content: rootContent, children: [], depth: 0, loaded: false });
-      setTreeData(newMap);
-      setRootId(rid);
-      setExpanded(new Set([rid]));
-      setSelected(new Set());
-      setStep(3);
-      // load children
-      void loadLinkChildren(rid, resolved.linkId, resolved.token, newMap, rid);
-    } else {
-      // mod
-      const virtualId = `mod:virtual:${resolved.modId}`;
-      const modTitle =
-        (resolved.modData as unknown as { mod?: { title?: string } }).mod?.title ??
-        (resolved.modData as unknown as { title?: string }).title ??
-        resolved.modId;
-      const virtualContent: DriveImportContent = {
-        id: virtualId,
-        name: String(modTitle),
-        isDir: true,
-        size: null,
-        mimeType: null,
-        parentId: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
-      const newMap = new Map<string, NodeData>();
-      newMap.set(virtualId, { content: virtualContent, children: [], depth: 0, loaded: true });
-      const collectionNodes: NodeData[] = [];
-      for (const col of resolved.modData.collections as Array<{
-        id: string;
-        name: string;
-        rootId: string | null;
-        private: boolean;
-      }>) {
-        if (!col.rootId) continue;
-        // skip private already filtered in backend, but keep
-        const colContent: DriveImportContent = {
-          id: col.rootId,
-          name: col.name,
-          isDir: true,
-          size: null,
-          mimeType: null,
-          parentId: virtualId,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        };
-        collectionNodes.push({ content: colContent, children: [], depth: 1, loaded: false });
-        newMap.get(virtualId)!.children.push(col.rootId);
-        newMap.set(col.rootId, { content: colContent, children: [], depth: 1, loaded: false });
-      }
-      if (collectionNodes.length === 0) {
-        toast.warning("가져올 수 있는 컬렉션이 없습니다.");
-      }
-      setTreeData(newMap);
-      setRootId(virtualId);
-      setExpanded(new Set([virtualId, ...collectionNodes.map((n) => n.content.id)]));
-      setSelected(new Set());
-      setStep(3);
-      // Optionally auto-load first collection's children
-      for (const n of collectionNodes) {
-        void loadModChildren(n.content.id, resolved.token, resolved.sig, newMap, virtualId);
-      }
-    }
+  // auto-resolve when the URL becomes a valid drive source URL
+  useEffect(() => {
+    const trimmed = url.trim();
+    if (trimmed === lastResolvedUrlRef.current) return;
+    loadSeqRef.current += 1;
+    setSourceInfo(null);
+    setTreeData(new Map());
+    setRootId(null);
+    setExpanded(new Set());
+    setSelected(new Set());
+    setStep(1);
     setRequiresPassword(false);
     setPasswordInvalid(false);
-  }
+    setResolveFailed(false);
+    if (!isValidDriveUrl(trimmed)) return;
+    if (!session) return;
+    const seq = ++loadSeqRef.current;
+    const timer = setTimeout(() => {
+      if (seq === loadSeqRef.current) void handleResolve(seq);
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [url, session, handleResolve]);
 
-  const loadLinkChildren = async (
-    parentId: string,
-    linkId: string,
-    linkToken: string,
-    currentMap?: Map<string, NodeData>,
-    _currentRootId?: string | null,
-  ) => {
-    setLoadingIds((prev) => new Set(prev).add(parentId));
-    try {
-      const result: DriveListChildrenResult = await window.api.invoke("drive:fn:listLinkChildren", {
-        linkId,
-        linkToken,
-        itemId: parentId,
-      });
-      setTreeData((prev) => {
-        const base = currentMap ? new Map(currentMap) : new Map(prev);
-        const parentNode = base.get(parentId);
-        if (!parentNode) return prev;
-        const parentDepth = parentNode.depth;
-        const childIds: string[] = [];
-        for (const child of result.children) {
-          const cid = child.id;
-          childIds.push(cid);
-          if (!base.has(cid)) {
-            base.set(cid, {
-              content: child,
-              children: [],
-              depth: parentDepth + 1,
-              loaded: false,
-            });
-          }
-        }
-        base.set(parentId, { ...parentNode, children: childIds, loaded: true });
-        return base;
-      });
-    } catch (error) {
-      if (isNotFoundError(error)) {
-        toast.error("링크가 만료되었습니다. 처음부터 다시 시도하세요.");
-        setSourceInfo(null);
-        setTreeData(new Map());
-        setRootId(null);
-        setExpanded(new Set());
-        setSelected(new Set());
-        setStep(1);
-        setRequiresPassword(false);
-        return;
-      }
-      toast.error("폴더 목록을 불러오지 못했습니다", { description: toErrorMessage(error) });
-    } finally {
-      setLoadingIds((prev) => {
-        const n = new Set(prev);
-        n.delete(parentId);
-        return n;
-      });
-    }
-  };
-
-  const loadModChildren = async (
-    parentId: string,
-    modToken?: string,
-    modSig?: string,
-    currentMap?: Map<string, NodeData>,
-    _virtualRoot?: string | null,
-  ) => {
-    setLoadingIds((prev) => new Set(prev).add(parentId));
-    try {
-      const result: DriveListChildrenResult = await window.api.invoke("drive:fn:listModChildren", {
-        itemId: parentId,
-        modToken,
-        modSig,
-      });
-      setTreeData((prev) => {
-        const base = currentMap ? new Map(currentMap) : new Map(prev);
-        const parentNode = base.get(parentId);
-        if (!parentNode) return prev;
-        const parentDepth = parentNode.depth;
-        const childIds: string[] = [];
-        for (const child of result.children) {
-          const cid = child.id;
-          childIds.push(cid);
-          if (!base.has(cid)) {
-            base.set(cid, {
-              content: child,
-              children: [],
-              depth: parentDepth + 1,
-              loaded: false,
-            });
-          }
-        }
-        base.set(parentId, { ...parentNode, children: childIds, loaded: true });
-        return base;
-      });
-    } catch (error) {
-      if (isNotFoundError(error)) {
-        toast.error("컬렉션을 불러오지 못했습니다. 링크가 만료되었을 수 있습니다.");
-        setSourceInfo(null);
-        setTreeData(new Map());
-        setRootId(null);
-        setExpanded(new Set());
-        setSelected(new Set());
-        setStep(1);
-        return;
-      }
-      toast.error("폴더 목록을 불러오지 못했습니다", { description: toErrorMessage(error) });
-    } finally {
-      setLoadingIds((prev) => {
-        const n = new Set(prev);
-        n.delete(parentId);
-        return n;
-      });
-    }
-  };
+  // focus password when required
+  useEffect(() => {
+    if (requiresPassword) requestAnimationFrame(() => passwordInputRef.current?.focus());
+  }, [requiresPassword]);
 
   const handleExpand = useCallback(
     (id: string) => {
@@ -597,7 +601,7 @@ export function DriveImportOverlay({ destinationId }: { destinationId: string })
         void loadModChildren(id, sourceInfo.token, sourceInfo.sig);
       }
     },
-    [treeData, sourceInfo],
+    [treeData, sourceInfo, loadLinkChildren, loadModChildren],
   );
 
   const handleCollapse = useCallback((id: string) => {
@@ -617,7 +621,6 @@ export function DriveImportOverlay({ destinationId }: { destinationId: string })
         ancestors.push(pid);
         cur = treeData.get(pid);
       }
-      // for mod virtual root, also need to handle virtual parent
       return ancestors;
     },
     [treeData],
@@ -766,8 +769,6 @@ export function DriveImportOverlay({ destinationId }: { destinationId: string })
     setIsImporting(false);
     setImportOverlay(null);
   };
-
-  if (!importOverlay) return null;
 
   const isUrlStep = step === 1;
   const isTreeStep = step === 3;

--- a/src/renderer/src/components/drive/drive-import-overlay.tsx
+++ b/src/renderer/src/components/drive/drive-import-overlay.tsx
@@ -32,7 +32,7 @@ import {
   LockIcon,
   XIcon,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -550,6 +550,10 @@ function DriveImportDialog({
       tryAutoPasswords,
     ],
   );
+  const handleResolveRef = useRef(handleResolve);
+  useLayoutEffect(() => {
+    handleResolveRef.current = handleResolve;
+  });
 
   useEffect(() => {
     requestAnimationFrame(() => urlInputRef.current?.focus());
@@ -580,10 +584,10 @@ function DriveImportDialog({
     if (!session) return;
     const seq = ++loadSeqRef.current;
     const timer = setTimeout(() => {
-      if (seq === loadSeqRef.current) void handleResolve(seq);
+      if (seq === loadSeqRef.current) void handleResolveRef.current(seq);
     }, 500);
     return () => clearTimeout(timer);
-  }, [url, session, handleResolve]);
+  }, [url, session]);
 
   // focus password when required
   useEffect(() => {

--- a/src/renderer/src/components/mod/add-game-dialog.tsx
+++ b/src/renderer/src/components/mod/add-game-dialog.tsx
@@ -25,7 +25,7 @@ import { useForm } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { FolderOpen, Plus, ShieldAlert, XIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -56,6 +56,36 @@ interface NteResolution {
 }
 
 export function AddGameDialog({ isAddingGame, onPickFolder, onAddGame }: AddGameDialogProps) {
+  const isOpen = useModStore((s) => s.isAddGameDialogOpen);
+  const setIsOpen = useModStore((s) => s.setIsAddGameDialogOpen);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger render={<Button variant="outline" size="icon" />}>
+        <Plus className="size-4" />
+      </DialogTrigger>
+      {isOpen && (
+        <AddGameDialogContent
+          isAddingGame={isAddingGame}
+          onPickFolder={onPickFolder}
+          onAddGame={onAddGame}
+          onClose={() => setIsOpen(false)}
+        />
+      )}
+    </Dialog>
+  );
+}
+
+interface AddGameDialogContentProps extends AddGameDialogProps {
+  onClose: () => void;
+}
+
+function AddGameDialogContent({
+  isAddingGame,
+  onPickFolder,
+  onAddGame,
+  onClose,
+}: AddGameDialogContentProps) {
   const formId = "add-game-dialog-form";
   const { t } = useTranslation();
   const navi = useNavigate();
@@ -64,8 +94,6 @@ export function AddGameDialog({ isAddingGame, onPickFolder, onAddGame }: AddGame
   const [selectedImporter, setSelectedImporter] = useState(NO_IMPORTER_VALUE);
   const isNteSelected = isNteImporter(selectedImporter);
 
-  const isOpen = useModStore((s) => s.isAddGameDialogOpen);
-  const setIsOpen = useModStore((s) => s.setIsAddGameDialogOpen);
   const { data: xxmiData } = useQuery({
     queryKey: ["xxmi:getXXMIData"],
     queryFn: () => window.api.invoke("xxmi:getXXMIData"),
@@ -127,14 +155,6 @@ export function AddGameDialog({ isAddingGame, onPickFolder, onAddGame }: AddGame
     },
   });
 
-  useEffect(() => {
-    if (!isOpen) {
-      form.reset();
-      setNteResolution(null);
-      setSelectedImporter(NO_IMPORTER_VALUE);
-    }
-  }, [form, isOpen]);
-
   const handlePickFolder = async () => {
     const path = await onPickFolder();
     if (!path) return;
@@ -154,17 +174,8 @@ export function AddGameDialog({ isAddingGame, onPickFolder, onAddGame }: AddGame
     }
   };
 
-  const handleOpenChange = (open: boolean) => {
-    setIsOpen(open);
-    if (!open) {
-      form.reset();
-      setNteResolution(null);
-      setSelectedImporter(NO_IMPORTER_VALUE);
-    }
-  };
-
   const handleOpenXXMISettings = () => {
-    handleOpenChange(false);
+    onClose();
     void navi({ to: "/setting/xxmi" });
   };
 
@@ -200,221 +211,212 @@ export function AddGameDialog({ isAddingGame, onPickFolder, onAddGame }: AddGame
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogTrigger render={<Button variant="outline" size="icon" />}>
-        <Plus className="size-4" />
-      </DialogTrigger>
-      <DialogContent className="w-100">
-        <DialogHeader>
-          <DialogTitle>{t("page.mod.dialog.add-game.title")}</DialogTitle>
-        </DialogHeader>
-        <form
-          id={formId}
-          className="space-y-4 py-4"
-          onSubmit={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            void form.handleSubmit();
+    <DialogContent className="w-100">
+      <DialogHeader>
+        <DialogTitle>{t("page.mod.dialog.add-game.title")}</DialogTitle>
+      </DialogHeader>
+      <form
+        id={formId}
+        className="space-y-4 py-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          void form.handleSubmit();
+        }}
+      >
+        <form.Field
+          name="name"
+          validators={{
+            onChange: ({ value }) => (value.trim() ? undefined : t("page.mod.dialog.add-game.#.0")),
           }}
-        >
-          <form.Field
-            name="name"
-            validators={{
-              onChange: ({ value }) =>
-                value.trim() ? undefined : t("page.mod.dialog.add-game.#.0"),
-            }}
-            children={(field) => (
-              <Field>
-                <FieldLabel htmlFor={field.name}>
-                  {t("page.mod.dialog.add-game.name_input_placeholder")}
-                </FieldLabel>
+          children={(field) => (
+            <Field>
+              <FieldLabel htmlFor={field.name}>
+                {t("page.mod.dialog.add-game.name_input_placeholder")}
+              </FieldLabel>
+              <Input
+                id={field.name}
+                value={field.state.value}
+                readOnly={isNteSelected}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              {field.state.meta.isTouched && !field.state.meta.isValid ? (
+                <FieldError>{field.state.meta.errors.join(", ")}</FieldError>
+              ) : null}
+            </Field>
+          )}
+        />
+
+        <form.Field
+          name="path"
+          validators={{
+            onChange: ({ value }) => (value.trim() ? undefined : t("page.mod.dialog.add-game.#.1")),
+          }}
+          children={(field) => (
+            <Field>
+              <FieldLabel htmlFor={field.name}>
+                {isNteSelected
+                  ? t("page.mod.dialog.add-game.nte_install_path")
+                  : t("page.mod.dialog.add-game.path_input_placeholder")}
+              </FieldLabel>
+              <div className="flex gap-2">
                 <Input
                   id={field.name}
                   value={field.state.value}
-                  readOnly={isNteSelected}
+                  readOnly={!isNteSelected}
+                  hideFocusRing
                   onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
+                  onChange={(e) => {
+                    field.handleChange(e.target.value);
+                    setNteResolution(null);
+                  }}
                 />
-                {field.state.meta.isTouched && !field.state.meta.isValid ? (
-                  <FieldError>{field.state.meta.errors.join(", ")}</FieldError>
-                ) : null}
-              </Field>
-            )}
-          />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  disabled={isNteSelected && isResolvingNte}
+                  onClick={() => void handlePickFolder()}
+                >
+                  <FolderOpen className="size-4" />
+                </Button>
+              </div>
+              {nteResolution && isNteSelected ? (
+                <p className="text-xs break-all text-muted-foreground">
+                  {nteResolution.modFolderPath}
+                </p>
+              ) : null}
+              {field.state.meta.isTouched && !field.state.meta.isValid ? (
+                <FieldError>{field.state.meta.errors.join(", ")}</FieldError>
+              ) : null}
+            </Field>
+          )}
+        />
 
+        {isNteSelected && (
           <form.Field
-            name="path"
-            validators={{
-              onChange: ({ value }) =>
-                value.trim() ? undefined : t("page.mod.dialog.add-game.#.1"),
-            }}
+            name="customModFolderPath"
             children={(field) => (
               <Field>
-                <FieldLabel htmlFor={field.name}>
-                  {isNteSelected
-                    ? t("page.mod.dialog.add-game.nte_install_path")
-                    : t("page.mod.dialog.add-game.path_input_placeholder")}
-                </FieldLabel>
+                <FieldLabel>{t("page.mod.dialog.add-game.nte_custom_mod_folder")}</FieldLabel>
                 <div className="flex gap-2">
                   <Input
                     id={field.name}
                     value={field.state.value}
-                    readOnly={!isNteSelected}
+                    readOnly
                     hideFocusRing
                     onBlur={field.handleBlur}
-                    onChange={(e) => {
-                      field.handleChange(e.target.value);
-                      setNteResolution(null);
-                    }}
                   />
                   <Button
                     type="button"
                     variant="outline"
                     size="icon"
-                    disabled={isNteSelected && isResolvingNte}
-                    onClick={() => void handlePickFolder()}
+                    onClick={handlePickCustomModFolder}
                   >
                     <FolderOpen className="size-4" />
                   </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    disabled={!field.state.value}
+                    onClick={() => field.handleChange("")}
+                  >
+                    <XIcon className="size-4" />
+                  </Button>
                 </div>
-                {nteResolution && isNteSelected ? (
-                  <p className="text-xs break-all text-muted-foreground">
-                    {nteResolution.modFolderPath}
-                  </p>
-                ) : null}
-                {field.state.meta.isTouched && !field.state.meta.isValid ? (
-                  <FieldError>{field.state.meta.errors.join(", ")}</FieldError>
-                ) : null}
+                <p className="text-xs text-muted-foreground">
+                  {t("page.mod.dialog.add-game.nte_custom_mod_folder_description")}
+                </p>
               </Field>
             )}
           />
+        )}
 
-          {isNteSelected && (
-            <form.Field
-              name="customModFolderPath"
-              children={(field) => (
-                <Field>
-                  <FieldLabel>{t("page.mod.dialog.add-game.nte_custom_mod_folder")}</FieldLabel>
-                  <div className="flex gap-2">
-                    <Input
-                      id={field.name}
-                      value={field.state.value}
-                      readOnly
-                      hideFocusRing
-                      onBlur={field.handleBlur}
-                    />
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      onClick={handlePickCustomModFolder}
-                    >
-                      <FolderOpen className="size-4" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      disabled={!field.state.value}
-                      onClick={() => field.handleChange("")}
-                    >
-                      <XIcon className="size-4" />
-                    </Button>
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    {t("page.mod.dialog.add-game.nte_custom_mod_folder_description")}
-                  </p>
-                </Field>
-              )}
-            />
-          )}
+        {isNteSelected && nteResolution?.requiresElevation ? (
+          <Alert className="border-amber-500/40 bg-amber-500/10 text-amber-950 dark:text-amber-200">
+            <ShieldAlert className="size-4" />
+            <AlertTitle>{t("page.mod.dialog.add-game.nte_system_folder_warning_title")}</AlertTitle>
+            <AlertDescription className="text-current/80">
+              {t("page.mod.dialog.add-game.nte_system_folder_warning_description")}
+            </AlertDescription>
+          </Alert>
+        ) : null}
 
-          {isNteSelected && nteResolution?.requiresElevation ? (
-            <Alert className="border-amber-500/40 bg-amber-500/10 text-amber-950 dark:text-amber-200">
-              <ShieldAlert className="size-4" />
-              <AlertTitle>
-                {t("page.mod.dialog.add-game.nte_system_folder_warning_title")}
-              </AlertTitle>
-              <AlertDescription className="text-current/80">
-                {t("page.mod.dialog.add-game.nte_system_folder_warning_description")}
-              </AlertDescription>
-            </Alert>
-          ) : null}
+        <NteBootstrapProgressView active={isAddingGame && isNteSelected} />
 
-          <NteBootstrapProgressView active={isAddingGame && isNteSelected} />
-
-          <form.Field
-            name="importer"
-            children={(field) => (
-              <Field>
-                <FieldLabel>{t("page.mod.dialog.edit-game.importer_label")}</FieldLabel>
-                <Select
-                  value={field.state.value}
-                  items={[
-                    { value: NO_IMPORTER_VALUE, label: t("page.mod.dialog.edit-game.no_importer") },
-                    ...importers.map((importer) => ({ value: importer.key, label: importer.key })),
-                  ]}
-                  onValueChange={(value) => {
-                    if (value === null) return;
-                    handleImporterChange(value, field.handleChange);
-                  }}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder={t("g.select")} />
-                  </SelectTrigger>
-                  <SelectContent aria-describedby={undefined}>
-                    <SelectGroup>
-                      <SelectItem value={NO_IMPORTER_VALUE}>
-                        {t("page.mod.dialog.edit-game.no_importer")}
-                      </SelectItem>
-                      {importers.map((importer) => (
-                        <SelectItem key={importer.key} value={importer.key}>
-                          {importer.key}
-                        </SelectItem>
-                      ))}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-                {!isXXMIConfigured && !isNteImporter(field.state.value) && (
-                  <Alert>
-                    <AlertDescription>
-                      <div className="flex flex-col gap-3">
-                        <span>{t("page.mod.dialog.add-game.xxmi_path_required")}</span>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          className="w-fit"
-                          onClick={handleOpenXXMISettings}
-                        >
-                          {t("page.mod.dialog.add-game.open_xxmi_settings")}
-                        </Button>
-                      </div>
-                    </AlertDescription>
-                  </Alert>
-                )}
-              </Field>
-            )}
-          />
-        </form>
-        <DialogFooter>
-          <DialogClose render={<Button type="button" variant="outline" />}>
-            {t("g.cancel")}
-          </DialogClose>
-          <form.Subscribe
-            selector={(state) => [state.canSubmit, state.isSubmitting]}
-            children={([canSubmit, isSubmitting]) => (
-              <Button
-                form={formId}
-                type="submit"
-                disabled={!canSubmit || isSubmitting || isAddingGame}
+        <form.Field
+          name="importer"
+          children={(field) => (
+            <Field>
+              <FieldLabel>{t("page.mod.dialog.edit-game.importer_label")}</FieldLabel>
+              <Select
+                value={field.state.value}
+                items={[
+                  { value: NO_IMPORTER_VALUE, label: t("page.mod.dialog.edit-game.no_importer") },
+                  ...importers.map((importer) => ({ value: importer.key, label: importer.key })),
+                ]}
+                onValueChange={(value) => {
+                  if (value === null) return;
+                  handleImporterChange(value, field.handleChange);
+                }}
               >
-                {t("g.add")}
-              </Button>
-            )}
-          />
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder={t("g.select")} />
+                </SelectTrigger>
+                <SelectContent aria-describedby={undefined}>
+                  <SelectGroup>
+                    <SelectItem value={NO_IMPORTER_VALUE}>
+                      {t("page.mod.dialog.edit-game.no_importer")}
+                    </SelectItem>
+                    {importers.map((importer) => (
+                      <SelectItem key={importer.key} value={importer.key}>
+                        {importer.key}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              {!isXXMIConfigured && !isNteImporter(field.state.value) && (
+                <Alert>
+                  <AlertDescription>
+                    <div className="flex flex-col gap-3">
+                      <span>{t("page.mod.dialog.add-game.xxmi_path_required")}</span>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="w-fit"
+                        onClick={handleOpenXXMISettings}
+                      >
+                        {t("page.mod.dialog.add-game.open_xxmi_settings")}
+                      </Button>
+                    </div>
+                  </AlertDescription>
+                </Alert>
+              )}
+            </Field>
+          )}
+        />
+      </form>
+      <DialogFooter>
+        <DialogClose render={<Button type="button" variant="outline" />}>
+          {t("g.cancel")}
+        </DialogClose>
+        <form.Subscribe
+          selector={(state) => [state.canSubmit, state.isSubmitting]}
+          children={([canSubmit, isSubmitting]) => (
+            <Button
+              form={formId}
+              type="submit"
+              disabled={!canSubmit || isSubmitting || isAddingGame}
+            >
+              {t("g.add")}
+            </Button>
+          )}
+        />
+      </DialogFooter>
+    </DialogContent>
   );
 }
 

--- a/src/renderer/src/components/mod/character-sidebar-visible-rows.ts
+++ b/src/renderer/src/components/mod/character-sidebar-visible-rows.ts
@@ -117,7 +117,7 @@ export function collectManualSubGroupPaths(
         expandedGroups: Set<string>;
         persistentGroups: Set<string>;
         subGroupsByPath: Map<string, FolderGroup[]>;
-        manualSubGroupsByPath: Map<string, FolderGroup[]>;
+        manualSubGroupsByPath: { get(path: string): FolderGroup[] | undefined };
     },
 ) {
     const paths: string[] = [];

--- a/src/renderer/src/components/mod/character-sidebar.tsx
+++ b/src/renderer/src/components/mod/character-sidebar.tsx
@@ -279,7 +279,7 @@ export const CharacterSidebar = memo(function CharacterSidebar({
           : Promise.resolve(),
       ]);
     },
-    [queryClient, selectedGame, selectedGroup?.path],
+    [queryClient, selectedGame, selectedGroup],
   );
 
   const savePreviewFile = useCallback(

--- a/src/renderer/src/components/mod/edit-game-dialog.tsx
+++ b/src/renderer/src/components/mod/edit-game-dialog.tsx
@@ -21,11 +21,12 @@ import {
 import { useModStore } from "@renderer/store/mod";
 import { isNteImporter, NTE_IMPORTER_KEY } from "@shared/mod";
 import type { GameConfig } from "@shared/types";
-import { useForm } from "@tanstack/react-form";
+import { useForm, useStore } from "@tanstack/react-form";
 import { ArrowDownIcon, ArrowUpIcon, FolderOpen, Trash2Icon, XIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+
 import { NteBootstrapProgressView } from "./nte-bootstrap-progress";
 
 const NO_IMPORTER_VALUE = "__none__";
@@ -76,34 +77,93 @@ export function EditGameDialog({
   onDeleteGameClick,
   onReorderGames,
 }: EditGameDialogProps) {
-  const formId = "edit-game-dialog-form";
-  const { t } = useTranslation();
-  const [nteResolution, setNteResolution] = useState<NteResolution | null>(null);
-  const [isResolvingNte, setIsResolvingNte] = useState(false);
-  const [selectedImporter, setSelectedImporter] = useState(NO_IMPORTER_VALUE);
-  const isNteSelected = isNteImporter(selectedImporter);
   const isOpen = useModStore((s) => s.isEditGameDialogOpen);
   const setIsOpen = useModStore((s) => s.setIsEditGameDialogOpen);
   const editingGame = useModStore((s) => s.editingGame);
   const setEditingGame = useModStore((s) => s.setEditingGame);
-  const currentGameIndex = editingGame
-    ? games.findIndex((game) => game.game === editingGame.game)
-    : -1;
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    if (!open) {
+      setEditingGame(null);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      {editingGame && (
+        <EditGameDialogContent
+          key={editingGame.game}
+          editingGame={editingGame}
+          games={games}
+          enabledImporters={enabledImporters}
+          isUpdatingGame={isUpdatingGame}
+          onPickFolder={onPickFolder}
+          onUpdateGame={onUpdateGame}
+          onDeleteGameClick={onDeleteGameClick}
+          onReorderGames={onReorderGames}
+        />
+      )}
+    </Dialog>
+  );
+}
+
+interface EditGameDialogContentProps {
+  editingGame: GameConfig;
+  games: GameConfig[];
+  enabledImporters: Array<{ key: string }>;
+  onPickFolder: () => Promise<string | null>;
+  isUpdatingGame: boolean;
+  onUpdateGame: (
+    game: string,
+    updates: {
+      modFolderPath: string;
+      importer: string | null;
+      linkedModFolderPath: string | null;
+      gameInstallPath: string | null;
+      gameExecutablePath: string | null;
+    },
+  ) => void;
+  onDeleteGameClick: (game: string) => void;
+  onReorderGames: (games: string[]) => void;
+}
+
+function EditGameDialogContent({
+  editingGame,
+  games,
+  enabledImporters,
+  onPickFolder,
+  isUpdatingGame,
+  onUpdateGame,
+  onDeleteGameClick,
+  onReorderGames,
+}: EditGameDialogContentProps) {
+  const formId = "edit-game-dialog-form";
+  const { t } = useTranslation();
+  const [nteResolution, setNteResolution] = useState<NteResolution | null>(() =>
+    isNteImporter(editingGame.importer)
+      ? {
+          gameRootPath: editingGame.gameInstallPath ?? "",
+          executablePath: editingGame.gameExecutablePath ?? "",
+          modFolderPath: editingGame.modFolderPath,
+          linkedModFolderPath: editingGame.linkedModFolderPath ?? editingGame.modFolderPath,
+        }
+      : null,
+  );
+  const [isResolvingNte, setIsResolvingNte] = useState(false);
+  const currentGameIndex = games.findIndex((game) => game.game === editingGame.game);
   const canMoveUp = currentGameIndex > 0;
   const canMoveDown = currentGameIndex >= 0 && currentGameIndex < games.length - 1;
   const importers = [...enabledImporters, { key: NTE_IMPORTER_KEY }];
 
   const form = useForm({
     defaultValues: {
-      path: "",
-      customModFolderPath: "",
-      importer: NO_IMPORTER_VALUE,
+      path:
+        editingGame.gameInstallPath ?? editingGame.linkedModFolderPath ?? editingGame.modFolderPath,
+      customModFolderPath: editingGame.linkedModFolderPath ? editingGame.modFolderPath : "",
+      importer: editingGame.importer ?? NO_IMPORTER_VALUE,
     },
     onSubmit: async ({ value }) => {
-      if (!editingGame) {
-        return;
-      }
-
       const path = value.path.trim();
       const customModFolderPath = value.customModFolderPath.trim();
       const importer = value.importer === NO_IMPORTER_VALUE ? null : value.importer;
@@ -142,50 +202,8 @@ export function EditGameDialog({
     },
   });
 
-  useEffect(() => {
-    if (!isOpen || !editingGame) {
-      form.reset({
-        path: "",
-        customModFolderPath: "",
-        importer: NO_IMPORTER_VALUE,
-      });
-      setNteResolution(null);
-      setSelectedImporter(NO_IMPORTER_VALUE);
-      return;
-    }
-
-    form.reset({
-      path:
-        editingGame.gameInstallPath ?? editingGame.linkedModFolderPath ?? editingGame.modFolderPath,
-      customModFolderPath: editingGame.linkedModFolderPath ? editingGame.modFolderPath : "",
-      importer: editingGame.importer ?? NO_IMPORTER_VALUE,
-    });
-    setSelectedImporter(editingGame.importer ?? NO_IMPORTER_VALUE);
-    setNteResolution(
-      isNteImporter(editingGame.importer)
-        ? {
-            gameRootPath: editingGame.gameInstallPath ?? "",
-            executablePath: editingGame.gameExecutablePath ?? "",
-            modFolderPath: editingGame.modFolderPath,
-            linkedModFolderPath: editingGame.linkedModFolderPath ?? editingGame.modFolderPath,
-          }
-        : null,
-    );
-  }, [editingGame, form, isOpen]);
-
-  const handleOpenChange = (open: boolean) => {
-    setIsOpen(open);
-    if (!open) {
-      setEditingGame(null);
-      form.reset({
-        path: "",
-        customModFolderPath: "",
-        importer: NO_IMPORTER_VALUE,
-      });
-      setNteResolution(null);
-      setSelectedImporter(NO_IMPORTER_VALUE);
-    }
-  };
+  const selectedImporter = useStore(form.store, (s) => s.values.importer);
+  const isNteSelected = isNteImporter(selectedImporter);
 
   const handlePickFolder = async () => {
     const path = await onPickFolder();
@@ -221,7 +239,7 @@ export function EditGameDialog({
   };
 
   const handleMove = (direction: -1 | 1) => {
-    if (!editingGame || currentGameIndex < 0) {
+    if (currentGameIndex < 0) {
       return;
     }
 
@@ -237,233 +255,224 @@ export function EditGameDialog({
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogContent className="w-100">
-        <DialogHeader>
-          <DialogTitle>{editingGame?.game}</DialogTitle>
-        </DialogHeader>
-        <form
-          id={formId}
-          className="space-y-4 py-4"
-          onSubmit={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            void form.handleSubmit();
+    <DialogContent className="w-100">
+      <DialogHeader>
+        <DialogTitle>{editingGame.game}</DialogTitle>
+      </DialogHeader>
+      <form
+        id={formId}
+        className="space-y-4 py-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          void form.handleSubmit();
+        }}
+      >
+        <form.Field
+          name="path"
+          validators={{
+            onChange: ({ value }) => (value.trim() ? undefined : t("page.mod.dialog.add-game.#.1")),
           }}
-        >
+          children={(field) => (
+            <Field>
+              <FieldLabel>{t("page.mod.dialog.edit-game.path_label")}</FieldLabel>
+              <div className="flex gap-2">
+                <Input
+                  placeholder={
+                    isNteSelected
+                      ? t("page.mod.dialog.add-game.nte_install_path")
+                      : t("page.mod.dialog.add-game.path_input_placeholder")
+                  }
+                  value={field.state.value}
+                  readOnly={!isNteSelected}
+                  onBlur={field.handleBlur}
+                  onChange={(event) => {
+                    field.handleChange(event.target.value);
+                    setNteResolution(null);
+                  }}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  disabled={isNteSelected && isResolvingNte}
+                  onClick={() => void handlePickFolder()}
+                >
+                  <FolderOpen className="size-4" />
+                </Button>
+              </div>
+              {nteResolution && isNteSelected ? (
+                <p className="text-xs break-all text-muted-foreground">
+                  {nteResolution.modFolderPath}
+                </p>
+              ) : null}
+              {field.state.meta.isTouched && !field.state.meta.isValid ? (
+                <FieldError>{field.state.meta.errors.join(", ")}</FieldError>
+              ) : null}
+            </Field>
+          )}
+        />
+
+        <form.Field
+          name="importer"
+          children={(field) => (
+            <Field>
+              <FieldLabel>{t("page.mod.dialog.edit-game.importer_label")}</FieldLabel>
+              <Select
+                value={field.state.value}
+                items={[
+                  {
+                    value: NO_IMPORTER_VALUE,
+                    label: t("page.mod.dialog.edit-game.no_importer"),
+                  },
+                  ...importers.map((importer) => ({
+                    value: importer.key,
+                    label: importer.key,
+                  })),
+                ]}
+                onValueChange={(value) => {
+                  if (value === null) return;
+                  const wasNte = isNteImporter(field.state.value);
+                  const nextIsNte = isNteImporter(value);
+                  field.handleChange(value);
+                  setNteResolution(null);
+
+                  if (wasNte && !nextIsNte) {
+                    form.setFieldValue(
+                      "path",
+                      isNteImporter(editingGame.importer) ? "" : (editingGame.modFolderPath ?? ""),
+                    );
+                    form.setFieldValue("customModFolderPath", "");
+                  }
+                }}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder={t("g.select")} />
+                </SelectTrigger>
+                <SelectContent aria-describedby={undefined}>
+                  <SelectGroup>
+                    <SelectItem value={NO_IMPORTER_VALUE}>
+                      {t("page.mod.dialog.edit-game.no_importer")}
+                    </SelectItem>
+                    {importers.map((importer) => (
+                      <SelectItem key={importer.key} value={importer.key}>
+                        {importer.key}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </Field>
+          )}
+        />
+
+        {isNteSelected && (
           <form.Field
-            name="path"
-            validators={{
-              onChange: ({ value }) =>
-                value.trim() ? undefined : t("page.mod.dialog.add-game.#.1"),
-            }}
+            name="customModFolderPath"
             children={(field) => (
               <Field>
-                <FieldLabel>{t("page.mod.dialog.edit-game.path_label")}</FieldLabel>
+                <FieldLabel>{t("page.mod.dialog.add-game.nte_custom_mod_folder")}</FieldLabel>
                 <div className="flex gap-2">
                   <Input
-                    placeholder={
-                      isNteSelected
-                        ? t("page.mod.dialog.add-game.nte_install_path")
-                        : t("page.mod.dialog.add-game.path_input_placeholder")
-                    }
                     value={field.state.value}
-                    readOnly={!isNteSelected}
+                    readOnly
+                    hideFocusRing
                     onBlur={field.handleBlur}
-                    onChange={(event) => {
-                      field.handleChange(event.target.value);
-                      setNteResolution(null);
-                    }}
                   />
                   <Button
                     type="button"
                     variant="outline"
                     size="icon"
-                    disabled={isNteSelected && isResolvingNte}
-                    onClick={() => void handlePickFolder()}
+                    onClick={handlePickCustomModFolder}
                   >
                     <FolderOpen className="size-4" />
                   </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    disabled={!field.state.value}
+                    onClick={() => field.handleChange("")}
+                  >
+                    <XIcon className="size-4" />
+                  </Button>
                 </div>
-                {nteResolution && isNteSelected ? (
-                  <p className="text-xs text-muted-foreground break-all">
-                    {nteResolution.modFolderPath}
-                  </p>
-                ) : null}
-                {field.state.meta.isTouched && !field.state.meta.isValid ? (
-                  <FieldError>{field.state.meta.errors.join(", ")}</FieldError>
-                ) : null}
+                <p className="text-xs text-muted-foreground">
+                  {t("page.mod.dialog.add-game.nte_custom_mod_folder_description")}
+                </p>
               </Field>
             )}
           />
+        )}
 
-          <form.Field
-            name="importer"
-            children={(field) => (
-              <Field>
-                <FieldLabel>{t("page.mod.dialog.edit-game.importer_label")}</FieldLabel>
-                <Select
-                  value={field.state.value}
-                  items={[
-                    {
-                      value: NO_IMPORTER_VALUE,
-                      label: t("page.mod.dialog.edit-game.no_importer"),
-                    },
-                    ...importers.map((importer) => ({
-                      value: importer.key,
-                      label: importer.key,
-                    })),
-                  ]}
-                  onValueChange={(value) => {
-                    if (value === null) return;
-                    const wasNte = isNteImporter(field.state.value);
-                    const nextIsNte = isNteImporter(value);
-                    field.handleChange(value);
-                    setSelectedImporter(value);
-                    setNteResolution(null);
+        <NteBootstrapProgressView active={isUpdatingGame && isNteSelected} />
 
-                    if (wasNte && !nextIsNte) {
-                      form.setFieldValue(
-                        "path",
-                        isNteImporter(editingGame?.importer)
-                          ? ""
-                          : (editingGame?.modFolderPath ?? ""),
-                      );
-                      form.setFieldValue("customModFolderPath", "");
-                    }
-                  }}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder={t("g.select")} />
-                  </SelectTrigger>
-                  <SelectContent aria-describedby={undefined}>
-                    <SelectGroup>
-                      <SelectItem value={NO_IMPORTER_VALUE}>
-                        {t("page.mod.dialog.edit-game.no_importer")}
-                      </SelectItem>
-                      {importers.map((importer) => (
-                        <SelectItem key={importer.key} value={importer.key}>
-                          {importer.key}
-                        </SelectItem>
-                      ))}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-              </Field>
-            )}
-          />
-
-          {isNteSelected && (
-            <form.Field
-              name="customModFolderPath"
-              children={(field) => (
-                <Field>
-                  <FieldLabel>{t("page.mod.dialog.add-game.nte_custom_mod_folder")}</FieldLabel>
-                  <div className="flex gap-2">
-                    <Input
-                      value={field.state.value}
-                      readOnly
-                      hideFocusRing
-                      onBlur={field.handleBlur}
-                    />
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      onClick={handlePickCustomModFolder}
-                    >
-                      <FolderOpen className="size-4" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      disabled={!field.state.value}
-                      onClick={() => field.handleChange("")}
-                    >
-                      <XIcon className="size-4" />
-                    </Button>
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    {t("page.mod.dialog.add-game.nte_custom_mod_folder_description")}
-                  </p>
-                </Field>
-              )}
-            />
-          )}
-
-          <NteBootstrapProgressView active={isUpdatingGame && isNteSelected} />
-
-          <div className="space-y-2">
-            <FieldLabel>{t("page.mod.dialog.edit-game.order_label")}</FieldLabel>
-            <div className="flex items-center justify-between gap-2 rounded-lg border px-3 py-2">
-              <span className="text-sm text-muted-foreground">
-                {t("page.mod.dialog.edit-game.order_value", {
-                  current: currentGameIndex + 1,
-                  total: games.length,
-                })}
-              </span>
-              <div className="flex gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon"
-                  disabled={!canMoveUp}
-                  onClick={() => handleMove(-1)}
-                >
-                  <ArrowUpIcon className="size-4" />
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon"
-                  disabled={!canMoveDown}
-                  onClick={() => handleMove(1)}
-                >
-                  <ArrowDownIcon className="size-4" />
-                </Button>
-              </div>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {t("page.mod.dialog.edit-game.order_description")}
-            </p>
-          </div>
-
-          <div className="flex justify-end items-center">
-            <Button
-              type="button"
-              variant="outline"
-              disabled={!editingGame}
-              onClick={() => {
-                if (editingGame) {
-                  onDeleteGameClick(editingGame.game);
-                }
-              }}
-            >
-              <Trash2Icon className="size-4 text-destructive" />
-              {t("page.mod.dialog.delete-game.title")}
-            </Button>
-          </div>
-        </form>
-        <DialogFooter>
-          <DialogClose render={<Button type="button" variant="outline" />}>
-            {t("g.cancel")}
-          </DialogClose>
-          <form.Subscribe
-            selector={(state) => [state.canSubmit, state.isSubmitting]}
-            children={([canSubmit, isSubmitting]) => (
+        <div className="space-y-2">
+          <FieldLabel>{t("page.mod.dialog.edit-game.order_label")}</FieldLabel>
+          <div className="flex items-center justify-between gap-2 rounded-lg border px-3 py-2">
+            <span className="text-sm text-muted-foreground">
+              {t("page.mod.dialog.edit-game.order_value", {
+                current: currentGameIndex + 1,
+                total: games.length,
+              })}
+            </span>
+            <div className="flex gap-2">
               <Button
-                form={formId}
-                type="submit"
-                disabled={!canSubmit || isSubmitting || isUpdatingGame}
+                type="button"
+                variant="outline"
+                size="icon"
+                disabled={!canMoveUp}
+                onClick={() => handleMove(-1)}
               >
-                {t("g.save")}
+                <ArrowUpIcon className="size-4" />
               </Button>
-            )}
-          />
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                disabled={!canMoveDown}
+                onClick={() => handleMove(1)}
+              >
+                <ArrowDownIcon className="size-4" />
+              </Button>
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {t("page.mod.dialog.edit-game.order_description")}
+          </p>
+        </div>
+
+        <div className="flex items-center justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              onDeleteGameClick(editingGame.game);
+            }}
+          >
+            <Trash2Icon className="size-4 text-destructive" />
+            {t("page.mod.dialog.delete-game.title")}
+          </Button>
+        </div>
+      </form>
+      <DialogFooter>
+        <DialogClose render={<Button type="button" variant="outline" />}>
+          {t("g.cancel")}
+        </DialogClose>
+        <form.Subscribe
+          selector={(state) => [state.canSubmit, state.isSubmitting]}
+          children={([canSubmit, isSubmitting]) => (
+            <Button
+              form={formId}
+              type="submit"
+              disabled={!canSubmit || isSubmitting || isUpdatingGame}
+            >
+              {t("g.save")}
+            </Button>
+          )}
+        />
+      </DialogFooter>
+    </DialogContent>
   );
 }
 

--- a/src/renderer/src/components/mod/merge-mods-dialog.tsx
+++ b/src/renderer/src/components/mod/merge-mods-dialog.tsx
@@ -26,7 +26,7 @@ import type {
 import { toErrorMessage } from "@shared/utils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowDownIcon, ArrowUpIcon, GroupIcon, Loader2Icon, UngroupIcon } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -41,19 +41,22 @@ export function MergeModsDialog() {
 
   const selectedPathsArray = useMemo(() => Array.from(selectedModPaths), [selectedModPaths]);
 
-  const { data: classification, isLoading } = useQuery({
+  const {
+    data: classification,
+    isLoading,
+    error: classificationError,
+  } = useQuery({
     queryKey: ["mod:classifyMergePacks", selectedPathsArray],
-    queryFn: async () => {
-      try {
-        return await window.api.invoke("mod:classifyMergePacks", selectedPathsArray);
-      } catch (error) {
-        toast.error(toErrorMessage(error) || t("page.mod.merge.classify_failed"));
-        setOpen(false);
-        throw error;
-      }
-    },
+    queryFn: () => window.api.invoke("mod:classifyMergePacks", selectedPathsArray),
     enabled: open && selectedPathsArray.length > 0,
+    retry: false,
   });
+
+  useEffect(() => {
+    if (!open || !classificationError) return;
+    toast.error(toErrorMessage(classificationError) || t("page.mod.merge.classify_failed"));
+    setOpen(false);
+  }, [classificationError, open, setOpen, t]);
 
   const [userPlan, setUserPlan] = useState<MergePlanGroup | null>(null);
   const [userPackName, setUserPackName] = useState<string | null>(null);

--- a/src/renderer/src/components/mod/merge-mods-dialog.tsx
+++ b/src/renderer/src/components/mod/merge-mods-dialog.tsx
@@ -17,7 +17,6 @@ import { useModStore } from "@renderer/store/mod";
 import { formatKeyLabel } from "@shared/key-formatter";
 import { stripDisabledPrefix } from "@shared/mod";
 import type {
-  ClassifyMergePacksResult,
   MergeEngine,
   MergePackClassification,
   MergePlacement,
@@ -25,9 +24,9 @@ import type {
   MergePlanNode,
 } from "@shared/types";
 import { toErrorMessage } from "@shared/utils";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowDownIcon, ArrowUpIcon, GroupIcon, Loader2Icon, UngroupIcon } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -40,54 +39,63 @@ export function MergeModsDialog() {
   const selectedGroupPath = useModStore((s) => s.selectedGroup?.path);
   const exitMergeMode = useModStore((s) => s.exitMergeMode);
 
-  const [classification, setClassification] = useState<ClassifyMergePacksResult | null>(null);
-  const [plan, setPlan] = useState<MergePlanGroup | null>(null);
+  const selectedPathsArray = useMemo(() => Array.from(selectedModPaths), [selectedModPaths]);
+
+  const { data: classification, isLoading } = useQuery({
+    queryKey: ["mod:classifyMergePacks", selectedPathsArray],
+    queryFn: async () => {
+      try {
+        return await window.api.invoke("mod:classifyMergePacks", selectedPathsArray);
+      } catch (error) {
+        toast.error(toErrorMessage(error) || t("page.mod.merge.classify_failed"));
+        setOpen(false);
+        throw error;
+      }
+    },
+    enabled: open && selectedPathsArray.length > 0,
+  });
+
+  const [userPlan, setUserPlan] = useState<MergePlanGroup | null>(null);
+  const [userPackName, setUserPackName] = useState<string | null>(null);
   const [placement, setPlacement] = useState<MergePlacement>("new_folder");
-  const [packName, setPackName] = useState("Merged");
-  const [isLoading, setIsLoading] = useState(false);
   const [isMerging, setIsMerging] = useState(false);
   const [editingKey, setEditingKey] = useState<"forward" | "back" | null>(null);
+  const [prevClassification, setPrevClassification] = useState(classification);
+
+  if (classification !== prevClassification) {
+    setPrevClassification(classification);
+    setUserPlan(null);
+    setUserPackName(null);
+  }
+
+  const defaultPackName = useMemo(() => {
+    if (!classification) return "Merged";
+    return (
+      stripDisabledPrefix(classification.packs[0]?.name ?? "Merged").replace(/\s+/g, "") || "Merged"
+    );
+  }, [classification]);
+
+  const defaultPlan = useMemo(() => {
+    if (!classification) return null;
+    return buildDefaultPlan(classification, defaultPackName);
+  }, [classification, defaultPackName]);
+
+  const packName = userPackName ?? defaultPackName;
+  const plan = userPlan ?? defaultPlan;
+
+  const setPackName = (name: string) => setUserPackName(name);
+  const setPlan = (
+    nextPlan: MergePlanGroup | ((prev: MergePlanGroup | null) => MergePlanGroup | null),
+  ) => {
+    setUserPlan((prev) =>
+      typeof nextPlan === "function" ? nextPlan(prev ?? defaultPlan) : nextPlan,
+    );
+  };
 
   const packsByPath = useMemo(
     () => new Map((classification?.packs ?? []).map((pack) => [pack.path, pack])),
     [classification],
   );
-
-  useEffect(() => {
-    if (!open) {
-      setClassification(null);
-      setPlan(null);
-      setEditingKey(null);
-      return;
-    }
-
-    let cancelled = false;
-    const paths = Array.from(selectedModPaths);
-    setIsLoading(true);
-    void window.api
-      .invoke("mod:classifyMergePacks", paths)
-      .then((result) => {
-        if (cancelled) return;
-        setClassification(result);
-        const nextName =
-          stripDisabledPrefix(result.packs[0]?.name ?? "Merged").replace(/\s+/g, "") || "Merged";
-        setPackName(nextName);
-        setPlan(buildDefaultPlan(result, nextName));
-      })
-      .catch((error) => {
-        if (cancelled) return;
-        toast.error(toErrorMessage(error) || t("page.mod.merge.classify_failed"));
-        setOpen(false);
-      })
-      .finally(() => {
-        if (cancelled) return;
-        setIsLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [open, selectedModPaths, setOpen]);
 
   const classicLocked = plan ? planHasClassicViolation(plan, packsByPath) : false;
   const canSubmit = Boolean(plan && selectedGroupPath && planIsValid(plan) && !classicLocked);

--- a/src/renderer/src/components/mod/mod-fix-runner-dialogs.tsx
+++ b/src/renderer/src/components/mod/mod-fix-runner-dialogs.tsx
@@ -32,6 +32,7 @@ import {
   TerminalSquareIcon,
 } from "lucide-react";
 import path from "path-browserify";
+import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 type ModFixRunner = ReturnType<typeof useModFixRunner>;
@@ -40,6 +41,14 @@ export function ModFixRunnerDialogs({ runner }: { runner: ModFixRunner }) {
   const { t } = useTranslation();
   const translationKey = "page.mod.dialog.wuwa-fix-runner";
   const aeroEnabled = runner.wuwaOptions.aeroFix !== "none";
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [runner.logs]);
 
   return (
     <>
@@ -514,7 +523,7 @@ export function ModFixRunnerDialogs({ runner }: { runner: ModFixRunner }) {
         onOpenChange={(nextOpen, eventDetails) => {
           if (nextOpen) {
             runner.setShowLogModal(true);
-            queueMicrotask(() => runner.inputRef.current?.focus());
+            queueMicrotask(() => inputRef.current?.focus());
             return;
           }
 
@@ -531,7 +540,7 @@ export function ModFixRunnerDialogs({ runner }: { runner: ModFixRunner }) {
             <AlertDialogTitle>{runner.labels.logTitle}</AlertDialogTitle>
           </AlertDialogHeader>
           <ScrollArea
-            viewportRef={runner.scrollRef}
+            viewportRef={scrollRef}
             className="h-[calc(100vh-430px)] w-full rounded-md border bg-muted font-mono text-xs break-all whitespace-pre-wrap"
           >
             <div className="space-y-2 p-3">
@@ -556,7 +565,7 @@ export function ModFixRunnerDialogs({ runner }: { runner: ModFixRunner }) {
           </ScrollArea>
           <div className="flex gap-2">
             <Input
-              ref={runner.inputRef}
+              ref={inputRef}
               placeholder={t(`${translationKey}.log.input_placeholder`)}
               value={runner.inputCmd}
               disabled={!runner.isRunning}

--- a/src/renderer/src/components/mod/nte-bootstrap-progress.tsx
+++ b/src/renderer/src/components/mod/nte-bootstrap-progress.tsx
@@ -11,14 +11,18 @@ interface NteBootstrapProgressViewProps {
 export function NteBootstrapProgressView({ active }: NteBootstrapProgressViewProps) {
   const { t } = useTranslation();
   const [progress, setProgress] = useState<NteBootstrapProgress | null>(null);
+  const [prevActive, setPrevActive] = useState(active);
+
+  if (active !== prevActive) {
+    setPrevActive(active);
+    if (active) {
+      setProgress(null);
+    }
+  }
 
   useEffect(() => {
     return window.api.on("mod:nte-bootstrap-progress", setProgress);
   }, []);
-
-  useEffect(() => {
-    if (active) setProgress(null);
-  }, [active]);
 
   const showPanel = active || progress?.phase === "failed";
   if (!showPanel) return null;
@@ -59,7 +63,7 @@ export function NteBootstrapProgressView({ active }: NteBootstrapProgressViewPro
         className={displayProgress.progress === null ? "animate-pulse" : undefined}
       />
       {displayProgress.message ? (
-        <p className="break-all text-xs text-muted-foreground">{displayProgress.message}</p>
+        <p className="text-xs break-all text-muted-foreground">{displayProgress.message}</p>
       ) : null}
     </div>
   );

--- a/src/renderer/src/components/mod/use-character-sidebar-visible-rows.ts
+++ b/src/renderer/src/components/mod/use-character-sidebar-visible-rows.ts
@@ -50,7 +50,7 @@ export function useCharacterSidebarVisibleRows(
         return map;
     }, [subGroupPaths, subGroupQueries]);
 
-    const manualPaths = collectManualSubGroupPaths(groups, {
+    const collectedManualPaths = collectManualSubGroupPaths(groups, {
         isSearching,
         expandedGroups,
         persistentGroups,
@@ -59,6 +59,8 @@ export function useCharacterSidebarVisibleRows(
             get: (path) => queryClient.getQueryData<FolderGroup[]>(["manualSubGroups", path]),
         },
     });
+    const manualPathsKey = collectedManualPaths.join("\0");
+    const manualPaths = useMemo(() => collectedManualPaths, [manualPathsKey]);
 
     const manualQueries = useQueries({
         queries: manualPaths.map((path) => ({

--- a/src/renderer/src/components/mod/use-character-sidebar-visible-rows.ts
+++ b/src/renderer/src/components/mod/use-character-sidebar-visible-rows.ts
@@ -1,28 +1,13 @@
 import { type FolderSortDirection, type FolderSortKey, useModStore } from "@renderer/store/mod";
 import type { FolderGroup } from "@renderer/types/mod";
 import { keepPreviousData, useQueries, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 
 import {
     buildVisibleSidebarRows,
     collectManualSubGroupPaths,
     type VisibleSidebarRow,
 } from "./character-sidebar-visible-rows";
-
-function readManualSubGroupsByPath(
-    queryClient: ReturnType<typeof useQueryClient>,
-    paths: Iterable<string>,
-) {
-    const map = new Map<string, FolderGroup[]>();
-    for (const path of paths) {
-        map.set(path, queryClient.getQueryData<FolderGroup[]>(["manualSubGroups", path]) ?? []);
-    }
-    return map;
-}
-
-function samePaths(a: string[], b: string[]) {
-    return a.length === b.length && a.every((path, index) => path === b[index]);
-}
 
 export function useCharacterSidebarVisibleRows(
     groups: FolderGroup[],
@@ -35,7 +20,6 @@ export function useCharacterSidebarVisibleRows(
     const expandedGroups = useModStore((s) => s.expandedGroups);
     const persistentGroups = useModStore((s) => s.persistentGroups);
     const isSearching = searchTerm.trim().length > 0;
-    const [manualCacheEpoch, setManualCacheEpoch] = useState(0);
 
     const subGroupPaths = useMemo(() => {
         const paths = new Set<string>();
@@ -66,45 +50,15 @@ export function useCharacterSidebarVisibleRows(
         return map;
     }, [subGroupPaths, subGroupQueries]);
 
-    const manualPaths = useMemo(() => {
-        const knownPaths = new Set<string>();
-        for (const group of groups) {
-            if (group.hasManualSubGroups) {
-                knownPaths.add(group.path);
-            }
-        }
-        for (const children of subGroupsByPath.values()) {
-            for (const child of children) {
-                if (child.hasManualSubGroups) {
-                    knownPaths.add(child.path);
-                }
-            }
-        }
-        for (const query of queryClient
-            .getQueryCache()
-            .findAll({ queryKey: ["manualSubGroups"] })) {
-            const path = query.queryKey[1];
-            if (typeof path === "string") {
-                knownPaths.add(path);
-            }
-        }
-
-        return collectManualSubGroupPaths(groups, {
-            isSearching,
-            expandedGroups,
-            persistentGroups,
-            subGroupsByPath,
-            manualSubGroupsByPath: readManualSubGroupsByPath(queryClient, knownPaths),
-        });
-    }, [
-        expandedGroups,
-        groups,
+    const manualPaths = collectManualSubGroupPaths(groups, {
         isSearching,
-        manualCacheEpoch,
+        expandedGroups,
         persistentGroups,
-        queryClient,
         subGroupsByPath,
-    ]);
+        manualSubGroupsByPath: {
+            get: (path) => queryClient.getQueryData<FolderGroup[]>(["manualSubGroups", path]),
+        },
+    });
 
     const manualQueries = useQueries({
         queries: manualPaths.map((path) => ({
@@ -113,36 +67,6 @@ export function useCharacterSidebarVisibleRows(
             placeholderData: keepPreviousData,
         })),
     });
-
-    useEffect(() => {
-        const nextPaths = collectManualSubGroupPaths(groups, {
-            isSearching,
-            expandedGroups,
-            persistentGroups,
-            subGroupsByPath,
-            manualSubGroupsByPath: readManualSubGroupsByPath(queryClient, [
-                ...manualPaths,
-                ...manualQueries.flatMap((query) =>
-                    (query.data ?? [])
-                        .filter((child) => child.hasManualSubGroups)
-                        .map((child) => child.path),
-                ),
-            ]),
-        });
-
-        if (!samePaths(nextPaths, manualPaths)) {
-            setManualCacheEpoch((value) => value + 1);
-        }
-    }, [
-        expandedGroups,
-        groups,
-        isSearching,
-        manualPaths,
-        manualQueries,
-        persistentGroups,
-        queryClient,
-        subGroupsByPath,
-    ]);
 
     const manualSubGroupsByPath = useMemo(() => {
         const map = new Map<string, FolderGroup[]>();

--- a/src/renderer/src/components/setting/xxmi/xxmi-dll-version.tsx
+++ b/src/renderer/src/components/setting/xxmi/xxmi-dll-version.tsx
@@ -9,8 +9,9 @@ import {
 } from "@renderer/components/ui/select";
 import type { XXMIData } from "@renderer/routes/setting/xxmi";
 import { toErrorMessage } from "@shared/utils";
+import { useQuery } from "@tanstack/react-query";
 import { Loader2Icon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -22,48 +23,19 @@ export function XXMIDllVersion({
   refetch: () => void;
 }) {
   const { t } = useTranslation();
-  const [versions, setVersions] = useState<string[] | null>(null);
-  const [version, setVersion] = useState("");
-  const [fetchError, setFetchError] = useState(false);
+  const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
 
+  const query = useQuery({
+    queryKey: ["xxmi:getLibsReleases"],
+    queryFn: () => window.api.invoke("xxmi:getLibsReleases"),
+  });
+
+  const versions = query.data;
+  const version = selectedVersion ?? versions?.[0] ?? "";
   const hasPath = !!xxmiData?.xxmiPath;
   const isCurrentVersion = (value: string) => isSameDllVersion(value, xxmiData?.dllVersion);
   const currentVersionLabel =
     versions?.find((item) => isCurrentVersion(item)) ?? xxmiData?.dllVersion;
-
-  const fetchReleases = (cancelled: { current: boolean }) => {
-    setVersions(null);
-    setFetchError(false);
-
-    void window.api
-      .invoke("xxmi:getLibsReleases")
-      .then((releases) => {
-        if (cancelled.current) return;
-        setVersions(releases);
-        setVersion(releases[0] ?? "");
-        setFetchError(false);
-      })
-      .catch(() => {
-        if (cancelled.current) return;
-        setVersions([]);
-        setVersion("");
-        setFetchError(true);
-      });
-  };
-
-  useEffect(() => {
-    const cancelled = { current: false };
-    fetchReleases(cancelled);
-
-    return () => {
-      cancelled.current = true;
-    };
-  }, []);
-
-  const handleRetry = () => {
-    const cancelled = { current: false };
-    fetchReleases(cancelled);
-  };
 
   const applyVersion = async () => {
     try {
@@ -99,19 +71,21 @@ export function XXMIDllVersion({
           <p className="text-sm text-muted-foreground">
             {t("page.setting.xxmi.persistNotFoundXXMI")}
           </p>
-        ) : fetchError ? (
+        ) : query.isError ? (
           <>
-            <p className="text-sm text-destructive">{t("page.setting.xxmi.dllVersionLoadFailed")}</p>
-            <Button variant="outline" size="sm" onClick={handleRetry}>
+            <p className="text-sm text-destructive">
+              {t("page.setting.xxmi.dllVersionLoadFailed")}
+            </p>
+            <Button variant="outline" size="sm" onClick={() => void query.refetch()}>
               {t("page.setting.xxmi.dllVersionRetry")}
             </Button>
           </>
-        ) : versions === null ? (
+        ) : query.isPending ? (
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <Loader2Icon className="size-3.5 animate-spin" />
             {t("page.setting.xxmi.dllVersionLoading")}
           </div>
-        ) : versions.length === 0 ? (
+        ) : !versions || versions.length === 0 ? (
           <p className="text-sm text-muted-foreground">{t("page.setting.xxmi.dllVersionEmpty")}</p>
         ) : (
           <>
@@ -120,7 +94,7 @@ export function XXMIDllVersion({
               value={version}
               onValueChange={(value) => {
                 if (value === null) return;
-                setVersion(value);
+                setSelectedVersion(value);
               }}
             >
               <SelectTrigger className="w-36">
@@ -139,7 +113,11 @@ export function XXMIDllVersion({
             <Button
               onClickPromise={applyVersion}
               disabled={
-                !hasPath || !version || fetchError || versions === null || isCurrentVersion(version)
+                !hasPath ||
+                !version ||
+                query.isError ||
+                query.isPending ||
+                isCurrentVersion(version)
               }
             >
               {t("g.confirm")}

--- a/src/renderer/src/components/setting/xxmi/xxmi-path.tsx
+++ b/src/renderer/src/components/setting/xxmi/xxmi-path.tsx
@@ -3,24 +3,23 @@ import { Button } from "@renderer/components/ui/button";
 import { Input } from "@renderer/components/ui/input";
 import type { XXMIData } from "@renderer/routes/setting/xxmi";
 import { InfoIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
 export function XXMIPath({ xxmiData, refetch }: { xxmiData?: XXMIData; refetch: () => void }) {
   const { t } = useTranslation();
   const [showAutoSearchAlert, setShowAutoSearchAlert] = useState(false);
-  const [xxmiPath, setXXMIPath] = useState("");
+  const [customPath, setCustomPath] = useState<string | null>(null);
 
-  useEffect(() => {
-    setXXMIPath(xxmiData?.xxmiPath || "");
-  }, [xxmiData]);
+  const xxmiPath = customPath ?? xxmiData?.xxmiPath ?? "";
 
   const saveXXMIPath = async () => {
     try {
       await window.api.invoke("xxmi:saveXXMIPath", xxmiPath);
       toast.success(t("page.setting.xxmi.fn.saveXXMIPath.success"));
       setShowAutoSearchAlert(false);
+      setCustomPath(null);
       refetch();
     } catch (rawErr) {
       const err = (rawErr as Error).message;
@@ -40,7 +39,7 @@ export function XXMIPath({ xxmiData, refetch }: { xxmiData?: XXMIData; refetch: 
         <Input
           value={xxmiPath}
           onChange={(e) => {
-            setXXMIPath(e.target.value);
+            setCustomPath(e.target.value);
           }}
         />
         <Button
@@ -54,7 +53,7 @@ export function XXMIPath({ xxmiData, refetch }: { xxmiData?: XXMIData; refetch: 
               return;
             }
 
-            setXXMIPath(path);
+            setCustomPath(path);
             setShowAutoSearchAlert(true);
           }}
         >

--- a/src/renderer/src/components/tools/4001-fixer.tsx
+++ b/src/renderer/src/components/tools/4001-fixer.tsx
@@ -93,42 +93,30 @@ export default function FourThousandOneFixer() {
   }, []);
 
   useEffect(() => {
-    const fetchVersions = async () => {
-      const requestId = ++versionsRequestId.current;
-      const requestedProvider = provider;
+    if (isUpdating) return;
 
-      try {
-        const v: string[] = await window.api.invoke(
-          "tools:4001FixerGetProviderReleases",
-          requestedProvider,
-        );
+    const requestId = ++versionsRequestId.current;
+    const requestedProvider = provider;
+
+    void window.api
+      .invoke("tools:4001FixerGetProviderReleases", requestedProvider)
+      .then((v: string[]) => {
         if (versionsRequestId.current !== requestId) return;
 
         setVersions(v);
         setVersion(v[0] ?? "");
         setFetchError(false);
-      } catch {
+      })
+      .catch(() => {
         if (versionsRequestId.current !== requestId) return;
 
         setVersion("");
         setFetchError(true);
-      }
-    };
-
-    if (!isUpdating) {
-      setVersions(null);
-      setVersion("");
-      setFetchError(false);
-      void fetchVersions();
-    }
+      });
   }, [provider, isUpdating]);
 
   useEffect(() => {
-    if (!selectedImporter) {
-      setBackupPath("");
-      setRequiresElevation(false);
-      return;
-    }
+    if (!selectedImporter) return;
 
     let cancelled = false;
 
@@ -284,8 +272,11 @@ export default function FourThousandOneFixer() {
             <button
               key={importer.key}
               onClick={() => {
+                if (selectedImporter === importer.importerFolder) return;
                 setSelectedImporter(importer.importerFolder);
                 setSelectedImporterKey(importer.key);
+                setBackupPath("");
+                setRequiresElevation(false);
               }}
               className={`rounded border px-3 py-1.5 font-mono text-xs transition-all ${
                 selectedImporter === importer.importerFolder
@@ -333,7 +324,13 @@ export default function FourThousandOneFixer() {
                 {["SpectrumQT"].map((v) => (
                   <button
                     key={v}
-                    onClick={() => setProvider(v)}
+                    onClick={() => {
+                      if (provider === v) return;
+                      setProvider(v);
+                      setVersions(null);
+                      setVersion("");
+                      setFetchError(false);
+                    }}
                     className={`rounded border px-3 py-1.5 font-mono text-xs transition-all ${
                       provider === v
                         ? "border-accent bg-accent text-accent-foreground"

--- a/src/renderer/src/components/tools/body-shape/body-shape-viewport.tsx
+++ b/src/renderer/src/components/tools/body-shape/body-shape-viewport.tsx
@@ -14,6 +14,7 @@ import {
   type MutableRefObject,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
 } from "react";
@@ -158,7 +159,6 @@ function BodyShapeMesh({
 }) {
   const meshRef = useRef<Mesh>(null);
   const brushRingRef = useRef<LineLoop>(null);
-  const colorsRef = useRef(new Float32Array(Math.floor(originalPositions.length / 3) * 3));
   const framedKeyRef = useRef<string | Float32Array | null>(null);
   const isPaintingRef = useRef(false);
   const { camera, raycaster, gl } = useThree();
@@ -170,6 +170,17 @@ function BodyShapeMesh({
   const onBrushStrokeRef = useRef(onBrushStroke);
   const onBrushStrokeStartRef = useRef(onBrushStrokeStart);
   const onBrushStrokeEndRef = useRef(onBrushStrokeEnd);
+
+  const initialColors = useMemo(
+    () => new Float32Array(Math.floor(originalPositions.length / 3) * 3),
+    [originalPositions],
+  );
+  const colorsRef = useRef(initialColors);
+  useLayoutEffect(() => {
+    if (colorsRef.current.length === initialColors.length) {
+      colorsRef.current = initialColors;
+    }
+  }, [initialColors]);
 
   useEffect(() => {
     heatmapRegionsRef.current = regions;
@@ -193,11 +204,6 @@ function BodyShapeMesh({
   useEffect(() => {
     onRegisterUpdateColors(writeColors);
   });
-
-  const initialColors = useMemo(
-    () => new Float32Array(Math.floor(originalPositions.length / 3) * 3),
-    [originalPositions],
-  );
 
   const geometry = useMemo(() => {
     const geo = new BufferGeometry();
@@ -226,7 +232,7 @@ function BodyShapeMesh({
 
     const vertexCount = Math.floor(originalPositions.length / 3);
     if (colorsRef.current.length !== vertexCount * 3) {
-      colorsRef.current = new Float32Array(vertexCount * 3);
+      colorsRef.current = initialColors;
       geometry.setAttribute("color", new BufferAttribute(colorsRef.current, 3));
     }
 
@@ -260,6 +266,7 @@ function BodyShapeMesh({
     }
   }, [
     geometry,
+    initialColors,
     originalPositions,
     previewPositions,
     regions,

--- a/src/renderer/src/components/tools/body-shape/body-shape-viewport.tsx
+++ b/src/renderer/src/components/tools/body-shape/body-shape-viewport.tsx
@@ -55,8 +55,8 @@ export type BodyShapeViewportProps = {
   showWeights: boolean;
   /** Bumped when region selection or amounts change. */
   weightVersion: number;
-  /** When false, positions are unchanged since the last apply — skip deform and normal recomputation. */
-  positionsChanged: boolean;
+  /** When false, positions are unchanged since the last apply — skip deform and normal recomputation. If omitted, tracked automatically. */
+  positionsChanged?: boolean;
   /** Stable identity for the mesh frame; changing mask data should not reframe the camera. */
   frameKey?: string;
   orientation?: string;
@@ -162,14 +162,21 @@ function BodyShapeMesh({
   const framedKeyRef = useRef<string | Float32Array | null>(null);
   const isPaintingRef = useRef(false);
   const { camera, raycaster, gl } = useThree();
+  const prevPositionsRef = useRef<{
+    regions: readonly ActiveRegionDeform[];
+    showOriginal: boolean;
+  } | null>(null);
   const heatmapRegionsRef = useRef<ActiveRegionDeform[]>(regions);
-  heatmapRegionsRef.current = regions;
   const onBrushStrokeRef = useRef(onBrushStroke);
-  onBrushStrokeRef.current = onBrushStroke;
   const onBrushStrokeStartRef = useRef(onBrushStrokeStart);
-  onBrushStrokeStartRef.current = onBrushStrokeStart;
   const onBrushStrokeEndRef = useRef(onBrushStrokeEnd);
-  onBrushStrokeEndRef.current = onBrushStrokeEnd;
+
+  useEffect(() => {
+    heatmapRegionsRef.current = regions;
+    onBrushStrokeRef.current = onBrushStroke;
+    onBrushStrokeStartRef.current = onBrushStrokeStart;
+    onBrushStrokeEndRef.current = onBrushStrokeEnd;
+  });
 
   const writeColors = (regions: ActiveRegionDeform[]) => {
     const vertexCount = Math.floor(originalPositions.length / 3);
@@ -187,13 +194,18 @@ function BodyShapeMesh({
     onRegisterUpdateColors(writeColors);
   });
 
+  const initialColors = useMemo(
+    () => new Float32Array(Math.floor(originalPositions.length / 3) * 3),
+    [originalPositions],
+  );
+
   const geometry = useMemo(() => {
     const geo = new BufferGeometry();
     const positionAttr = new BufferAttribute(previewPositions, 3);
     positionAttr.setUsage(35048);
     geo.setAttribute("position", positionAttr);
 
-    const colorAttr = new BufferAttribute(colorsRef.current, 3);
+    const colorAttr = new BufferAttribute(initialColors, 3);
     colorAttr.setUsage(35048);
     geo.setAttribute("color", colorAttr);
 
@@ -203,16 +215,22 @@ function BodyShapeMesh({
     geo.computeVertexNormals();
     geo.computeBoundingSphere();
     return geo;
-  }, [indices, originalPositions, previewPositions]);
+  }, [indices, initialColors, originalPositions, previewPositions]);
 
   useEffect(() => {
+    const isPositionsChanged =
+      positionsChanged ??
+      (prevPositionsRef.current?.regions !== regions ||
+        prevPositionsRef.current?.showOriginal !== showOriginal);
+    prevPositionsRef.current = { regions, showOriginal };
+
     const vertexCount = Math.floor(originalPositions.length / 3);
     if (colorsRef.current.length !== vertexCount * 3) {
       colorsRef.current = new Float32Array(vertexCount * 3);
       geometry.setAttribute("color", new BufferAttribute(colorsRef.current, 3));
     }
 
-    if (positionsChanged) {
+    if (isPositionsChanged) {
       if (showOriginal || regions.length === 0) {
         previewPositions.set(originalPositions);
       } else {
@@ -236,7 +254,7 @@ function BodyShapeMesh({
     const colorAttr = geometry.getAttribute("color") as BufferAttribute;
     colorAttr.needsUpdate = true;
 
-    if (positionsChanged) {
+    if (isPositionsChanged) {
       geometry.computeVertexNormals();
       geometry.computeBoundingSphere();
     }

--- a/src/renderer/src/components/tools/body-shape/body-shape.tsx
+++ b/src/renderer/src/components/tools/body-shape/body-shape.tsx
@@ -301,6 +301,7 @@ export default function BodyShapeTool({
 } = {}) {
   const { t } = useTranslation();
   const [modPath, setModPath] = useState(fixedTargetPath ?? "");
+  const [prevFixedTargetPath, setPrevFixedTargetPath] = useState(fixedTargetPath);
   const [loading, setLoading] = useState(Boolean(fixedTargetPath));
   const [exporting, setExporting] = useState(false);
   const [loaded, setLoaded] = useState<LoadResult | null>(null);
@@ -334,6 +335,14 @@ export default function BodyShapeTool({
     canUndoSelection: false,
     canRedoSelection: false,
   });
+
+  if (fixedTargetPath !== prevFixedTargetPath) {
+    setPrevFixedTargetPath(fixedTargetPath);
+    if (fixedTargetPath) {
+      setLoading(true);
+      setLoaded(null);
+    }
+  }
 
   const selectedMesh = useMemo(() => {
     if (!loaded) return null;

--- a/src/renderer/src/components/tools/body-shape/body-shape.tsx
+++ b/src/renderer/src/components/tools/body-shape/body-shape.tsx
@@ -240,6 +240,56 @@ function buildHighlightRegions(
   ];
 }
 
+function buildLoadedMeshes(
+  rawMeshes: Array<{
+    id: string;
+    name: string;
+    positions: unknown;
+    positionPath: string;
+    positionRelativePath: string;
+    positionStride: number;
+    vertexCount: number;
+    indices?: unknown;
+    vectorPath?: string;
+    vectorLayout?: "snorm8-tangent-normal" | null;
+    blendBytes?: unknown;
+    blendStride?: number;
+    bones?: BlendBoneInfo[];
+  }>,
+): LoadedMesh[] {
+  return rawMeshes.map((mesh) => {
+    const originalPositions = toFloat32(mesh.positions);
+    const indices = toUint32(mesh.indices);
+    const adjacency = indices ? buildVertexAdjacency(mesh.vertexCount, indices) : undefined;
+    const componentIds = adjacency
+      ? buildConnectedComponents(mesh.vertexCount, adjacency)
+      : undefined;
+    const symmetryMap = buildSymmetryMap(originalPositions, "x", 1e-3);
+    return {
+      id: mesh.id,
+      name: mesh.name,
+      positionPath: mesh.positionPath,
+      positionRelativePath: mesh.positionRelativePath,
+      positionStride: mesh.positionStride,
+      vertexCount: mesh.vertexCount,
+      originalPositions,
+      previewPositions: new Float32Array(originalPositions),
+      indices,
+      vectorPath: mesh.vectorPath,
+      vectorLayout: mesh.vectorLayout ?? null,
+      blendBytes: toUint8(mesh.blendBytes),
+      blendStride: mesh.blendStride ?? DEFAULT_BLEND_STRIDE,
+      bones: mesh.bones ?? [],
+      weightCache: new Map(),
+      selectionWeights: new Float32Array(mesh.vertexCount),
+      adjacency,
+      originalNormals: indices ? computeVertexNormals(originalPositions, indices) : undefined,
+      componentIds,
+      symmetryMap,
+    };
+  });
+}
+
 export default function BodyShapeTool({
   fixedTargetPath,
   modName,
@@ -251,7 +301,7 @@ export default function BodyShapeTool({
 } = {}) {
   const { t } = useTranslation();
   const [modPath, setModPath] = useState(fixedTargetPath ?? "");
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(Boolean(fixedTargetPath));
   const [exporting, setExporting] = useState(false);
   const [loaded, setLoaded] = useState<LoadResult | null>(null);
   const [selectedMeshId, setSelectedMeshId] = useState<string>("");
@@ -274,24 +324,23 @@ export default function BodyShapeTool({
 
   const isFixedTarget = Boolean(fixedTargetPath);
   const simpleViewportRef = useRef<BodyShapeViewportHandle | null>(null);
-  const prevPositionInputsRef = useRef<{
-    regions: readonly ActiveRegionDeform[] | null;
-    showOriginal: boolean;
-  }>({ regions: null, showOriginal: false });
   const previewKeyRef = useRef<string | null>(null);
   const selectionStrokeBeforeRef = useRef<Float32Array | null>(null);
   const selectionHistoryRef = useRef<{
     undo: SelectionHistoryEntry[];
     redo: SelectionHistoryEntry[];
   }>({ undo: [], redo: [] });
-  const [, setHistoryVersion] = useState(0);
+  const [{ canUndoSelection, canRedoSelection }, setHistoryState] = useState({
+    canUndoSelection: false,
+    canRedoSelection: false,
+  });
 
   const selectedMesh = useMemo(() => {
     if (!loaded) return null;
     return loaded.meshes.find((mesh) => mesh.id === selectedMeshId) ?? loaded.meshes[0] ?? null;
   }, [loaded, selectedMeshId]);
 
-  const useBones = !!selectedMesh && selectedMesh.bones.length > 0;
+  const useBones = Boolean(selectedMesh && selectedMesh.bones.length > 0);
 
   const selectableItems = useMemo(() => {
     if (!selectedMesh) return [] as { key: string; label: string }[];
@@ -337,10 +386,17 @@ export default function BodyShapeTool({
     ];
   }, [selectedMesh, hasSelection, unifiedControl, deformOperation, weightVersion]);
 
+  const updateHistoryState = () => {
+    setHistoryState({
+      canUndoSelection: selectionHistoryRef.current.undo.length > 0,
+      canRedoSelection: selectionHistoryRef.current.redo.length > 0,
+    });
+  };
+
   const resetSelectionHistory = () => {
     selectionHistoryRef.current = { undo: [], redo: [] };
     selectionStrokeBeforeRef.current = null;
-    setHistoryVersion((version) => version + 1);
+    updateHistoryState();
   };
 
   const commitSelectionHistory = (before: Float32Array) => {
@@ -352,7 +408,7 @@ export default function BodyShapeTool({
       selectionHistoryRef.current.undo.shift();
     }
     selectionHistoryRef.current.redo = [];
-    setHistoryVersion((version) => version + 1);
+    updateHistoryState();
   };
 
   const handleBrushStroke = (stroke: BrushStrokeInput) => {
@@ -496,7 +552,7 @@ export default function BodyShapeTool({
     selectedMesh.selectionWeights.set(entry.before);
     selectionHistoryRef.current.redo.push(entry);
     setSelectedKeys([]);
-    setHistoryVersion((version) => version + 1);
+    updateHistoryState();
     setWeightVersion((version) => version + 1);
   };
 
@@ -507,7 +563,7 @@ export default function BodyShapeTool({
     selectedMesh.selectionWeights.set(entry.after);
     selectionHistoryRef.current.undo.push(entry);
     setSelectedKeys([]);
-    setHistoryVersion((version) => version + 1);
+    updateHistoryState();
     setWeightVersion((version) => version + 1);
   };
 
@@ -542,13 +598,6 @@ export default function BodyShapeTool({
     return displacementMetrics(selectedMesh.originalPositions, selectedMesh.previewPositions);
   }, [selectedMesh, activeRegions, showOriginal, weightVersion]);
 
-  const positionsChanged =
-    prevPositionInputsRef.current.regions !== activeRegions ||
-    prevPositionInputsRef.current.showOriginal !== showOriginal;
-  useEffect(() => {
-    prevPositionInputsRef.current = { regions: activeRegions, showOriginal };
-  }, [activeRegions, showOriginal]);
-
   const selectFolder = async () => {
     const selected = await window.api.invoke("util:showOpenDialog", {
       properties: ["openDirectory"],
@@ -557,42 +606,10 @@ export default function BodyShapeTool({
     setModPath(selected.filePaths[0]);
   };
 
-  const loadMod = async (path = modPath) => {
-    if (!path || loading) return;
-    setLoading(true);
+  const loadModFromPath = async (path: string) => {
     try {
       const result = await window.api.invoke("tools:bodyShapeLoadMod", path);
-      const meshes: LoadedMesh[] = result.meshes.map((mesh) => {
-        const originalPositions = toFloat32(mesh.positions);
-        const indices = toUint32(mesh.indices);
-        const adjacency = indices ? buildVertexAdjacency(mesh.vertexCount, indices) : undefined;
-        const componentIds = adjacency
-          ? buildConnectedComponents(mesh.vertexCount, adjacency)
-          : undefined;
-        const symmetryMap = buildSymmetryMap(originalPositions, "x", 1e-3);
-        return {
-          id: mesh.id,
-          name: mesh.name,
-          positionPath: mesh.positionPath,
-          positionRelativePath: mesh.positionRelativePath,
-          positionStride: mesh.positionStride,
-          vertexCount: mesh.vertexCount,
-          originalPositions,
-          previewPositions: new Float32Array(originalPositions),
-          indices,
-          vectorPath: mesh.vectorPath,
-          vectorLayout: mesh.vectorLayout ?? null,
-          blendBytes: toUint8(mesh.blendBytes),
-          blendStride: mesh.blendStride ?? DEFAULT_BLEND_STRIDE,
-          bones: mesh.bones ?? [],
-          weightCache: new Map(),
-          selectionWeights: new Float32Array(mesh.vertexCount),
-          adjacency,
-          originalNormals: indices ? computeVertexNormals(originalPositions, indices) : undefined,
-          componentIds,
-          symmetryMap,
-        };
-      });
+      const meshes = buildLoadedMeshes(result.meshes);
       setLoaded({
         modRoot: result.modRoot,
         iniPath: result.iniPath,
@@ -616,28 +633,64 @@ export default function BodyShapeTool({
     }
   };
 
+  const loadMod = async (path = modPath) => {
+    if (!path || loading) return;
+    setModPath(path);
+    setLoading(true);
+    await loadModFromPath(path);
+  };
+
   useEffect(() => {
     if (!fixedTargetPath) return;
-    setModPath(fixedTargetPath);
-    void loadMod(fixedTargetPath);
+    let active = true;
+    const loadInitial = async () => {
+      try {
+        const result = await window.api.invoke("tools:bodyShapeLoadMod", fixedTargetPath);
+        if (!active) return;
+        const meshes = buildLoadedMeshes(result.meshes);
+        setLoaded({
+          modRoot: result.modRoot,
+          iniPath: result.iniPath,
+          meshes,
+        });
+        setSelectedMeshId(meshes[0]?.id ?? "");
+        setSelectedKeys([]);
+        resetSelectionHistory();
+        previewKeyRef.current = null;
+        setUnifiedControl(DEFAULT_UNIFIED_CONTROL);
+        setDeformOperation("scale");
+        setWeightVersion((v) => v + 1);
+        setModelOrientation(DEFAULT_MODEL_ORIENTATION);
+        setShowWeights(true);
+      } catch (error) {
+        if (!active) return;
+        toast.error(t("page.tools.body_shape.toast.load_failed"), {
+          description: toErrorMessage(error),
+        });
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+    void loadInitial();
+    return () => {
+      active = false;
+    };
   }, [fixedTargetPath]);
 
   const applySelectedKeys = (nextKeys: string[]) => {
     setSelectedKeys(nextKeys);
     if (!selectedMesh) return;
     const before = new Float32Array(selectedMesh.selectionWeights);
-    selectedMesh.selectionWeights.fill(0);
+    const newWeights = new Float32Array(selectedMesh.vertexCount);
     for (const key of nextKeys) {
       const source = parseWeightKey(key);
       if (!source) continue;
       const boneWeights = getOrCreateWeights(selectedMesh, source);
       for (let index = 0; index < selectedMesh.vertexCount; index++) {
-        selectedMesh.selectionWeights[index] = Math.max(
-          selectedMesh.selectionWeights[index],
-          boneWeights[index] ?? 0,
-        );
+        newWeights[index] = Math.max(newWeights[index], boneWeights[index] ?? 0);
       }
     }
+    selectedMesh.selectionWeights.set(newWeights);
     commitSelectionHistory(before);
     setWeightVersion((version) => version + 1);
   };
@@ -756,8 +809,6 @@ export default function BodyShapeTool({
   };
 
   const selectedItems = selectableItems.filter((item) => selectedKeys.includes(item.key));
-  const canUndoSelection = selectionHistoryRef.current.undo.length > 0;
-  const canRedoSelection = selectionHistoryRef.current.redo.length > 0;
 
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col gap-3">
@@ -799,7 +850,6 @@ export default function BodyShapeTool({
               showOriginal={showOriginal}
               showWeights={showWeights}
               weightVersion={weightVersion}
-              positionsChanged={positionsChanged}
               orientation={modelOrientation}
               brushEnabled={brushEnabled}
               brushMode={brushMode}

--- a/src/renderer/src/components/tools/mod-bisect.tsx
+++ b/src/renderer/src/components/tools/mod-bisect.tsx
@@ -43,13 +43,15 @@ function createExcludeRow(): ExcludeRow {
 export default function ModBisect() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
-  const [selectedGame, setSelectedGame] = useState<string>("");
+  const [userSelectedGame, setUserSelectedGame] = useState<string>("");
   const [starting, setStarting] = useState(false);
   const startingRef = useRef(false);
   const excludeListRef = useRef<{ flush: () => Promise<string[] | null> }>(null);
   const { data: preserveD3dx = true } = useSetting("general.bisectPreserveD3dx");
 
   const { data: games = [] } = useGames();
+  const defaultGame = games.find((g) => !isNteImporter(g.importer))?.game ?? "";
+  const selectedGame = userSelectedGame || defaultGame;
 
   const { data: snapshot } = useQuery<BisectSnapshot | null>({
     queryKey: ["tools:bisectState"],
@@ -68,13 +70,6 @@ export default function ModBisect() {
     });
     return unsubscribe;
   }, [queryClient]);
-
-  useEffect(() => {
-    if (!selectedGame && games.length > 0) {
-      const first = games.find((g) => !isNteImporter(g.importer));
-      if (first) setSelectedGame(first.game);
-    }
-  }, [games, selectedGame]);
 
   const startMutation = useMutation({
     mutationFn: ({ game, excludePaths }: { game: string; excludePaths: string[] }) =>
@@ -150,7 +145,7 @@ export default function ModBisect() {
             <GameSelect
               games={games}
               value={selectedGame}
-              onChange={setSelectedGame}
+              onChange={setUserSelectedGame}
               disabled={isActive || isBusy}
             />
             <Button
@@ -212,6 +207,7 @@ export default function ModBisect() {
           </div>
 
           <ExcludePathList
+            key={selectedGame}
             ref={excludeListRef}
             game={selectedGame}
             disabled={isActive || isBusy || !selectedGame}
@@ -270,11 +266,6 @@ function ExcludePathList({
   useEffect(() => {
     rowsRef.current = rows;
   }, [rows]);
-
-  useEffect(() => {
-    rowsRef.current = [];
-    setRows([]);
-  }, [game]);
 
   const commitRow = (id: string): Promise<boolean> => {
     const inFlight = committingRef.current.get(id);

--- a/src/renderer/src/components/tools/model-viewer/model-viewer-dialog-variants.tsx
+++ b/src/renderer/src/components/tools/model-viewer/model-viewer-dialog-variants.tsx
@@ -97,12 +97,14 @@ export function VariantSlider({
       : Number(variable.values[0]?.value ?? 0);
   const resolvedValue =
     typeof activeValue === "number" ? activeValue : Number(activeValue ?? fallbackValue);
+  const [prevResolvedValue, setPrevResolvedValue] = useState(resolvedValue);
   const [draftValue, setDraftValue] = useState(resolvedValue);
   const commitTimeoutRef = useRef<number | null>(null);
 
-  useEffect(() => {
+  if (prevResolvedValue !== resolvedValue) {
+    setPrevResolvedValue(resolvedValue);
     setDraftValue(resolvedValue);
-  }, [resolvedValue]);
+  }
 
   useEffect(() => {
     return () => {

--- a/src/renderer/src/components/tools/model-viewer/model-viewer-dialog.tsx
+++ b/src/renderer/src/components/tools/model-viewer/model-viewer-dialog.tsx
@@ -259,7 +259,9 @@ export function ModelViewerDialog({
       if (inactiveUrl && inactiveUrl !== currentUrl) {
         cleanupModelViewerUrl(inactiveUrl);
       }
-      viewerUrlsRef.current = [currentUrl, ""];
+      const nextUrls: [string, string] = [currentUrl, ""];
+      viewerUrlsRef.current = nextUrls;
+      setViewerUrls(nextUrls);
       activeViewerIndexRef.current = 0;
       loadingViewerIndexRef.current = null;
       pendingCameraStateRef.current = null;
@@ -274,7 +276,7 @@ export function ModelViewerDialog({
       pendingVariantRequestRef.current = null;
     }
 
-    const nextUrls = getInitialViewerUrls(source);
+    const nextUrls = viewerUrls;
     const prevUrls = viewerUrlsRef.current;
     for (const url of prevUrls) {
       if (url && !nextUrls.includes(url)) {

--- a/src/renderer/src/components/tools/model-viewer/model-viewer-dialog.tsx
+++ b/src/renderer/src/components/tools/model-viewer/model-viewer-dialog.tsx
@@ -71,6 +71,48 @@ import { ThreeModelViewer } from "./three-model-viewer";
 
 export type { ModelViewerDialogSource } from "./model-viewer-dialog-types";
 
+function getInitialViewerUrls(source: ModelViewerDialogSource | null): [string, string] {
+  if (!source) {
+    return ["", ""];
+  }
+  if (source.mode === "single") {
+    return [source.glbPath ? withCacheBuster(modelViewerSourceToUrl(source.glbPath)) : "", ""];
+  }
+  if (source.mode === "variant-set") {
+    const glbPath = source.activeGlbPath || source.defaultGlbPath;
+    return [glbPath ? withCacheBuster(modelViewerSourceToUrl(glbPath)) : "", ""];
+  }
+  return ["", ""];
+}
+
+function getInitialActiveState(
+  source: ModelViewerDialogSource | null,
+): Record<string, VariableStateValue> {
+  if (!source) {
+    return {};
+  }
+  if (source.mode === "payload") {
+    return source.transport.defaultState;
+  }
+  if (source.mode === "variant-set") {
+    return source.manifest.defaultState;
+  }
+  return {};
+}
+
+function getInitialActiveAnimationId(source: ModelViewerDialogSource | null): string | null {
+  if (!source) {
+    return null;
+  }
+  if (source.mode === "payload") {
+    return source.transport.animations[0]?.id ?? null;
+  }
+  if (source.mode === "variant-set") {
+    return source.manifest.animations?.[0]?.id ?? null;
+  }
+  return null;
+}
+
 export function ModelViewerDialog({
   open,
   onOpenChange,
@@ -85,16 +127,25 @@ export function ModelViewerDialog({
   onPreviewSaved?: () => void | Promise<void>;
 }) {
   const { t } = useTranslation();
-  const [activeState, setActiveState] = useState<Record<string, VariableStateValue>>({});
+  const [prevOpen, setPrevOpen] = useState(open);
+  const [prevSource, setPrevSource] = useState(source);
+  const [activeState, setActiveState] = useState<Record<string, VariableStateValue>>(() =>
+    getInitialActiveState(source),
+  );
   const [previewState, setPreviewState] = useState<Record<string, VariableStateValue> | null>(null);
-  const [manifest, setManifest] = useState<ModelViewerVariantManifest | null>(null);
-  const [activeAnimationId, setActiveAnimationId] = useState<string | null>(null);
+  const [manifest, setManifest] = useState<ModelViewerVariantManifest | null>(() =>
+    source?.mode === "variant-set" ? source.manifest : null,
+  );
+  const [activeAnimationId, setActiveAnimationId] = useState<string | null>(() =>
+    getInitialActiveAnimationId(source),
+  );
   const [animationFrameIndex, setAnimationFrameIndex] = useState(0);
   const [animationPlaying, setAnimationPlaying] = useState(false);
   const animationFrameIndexRef = useRef(0);
-  animationFrameIndexRef.current = animationFrameIndex;
   const [isResolving, setIsResolving] = useState(false);
-  const [viewerUrls, setViewerUrls] = useState<[string, string]>(["", ""]);
+  const [viewerUrls, setViewerUrls] = useState<[string, string]>(() =>
+    getInitialViewerUrls(source),
+  );
   const [activeViewerIndex, setActiveViewerIndex] = useState<0 | 1>(0);
   const [loadingViewerIndex, setLoadingViewerIndex] = useState<0 | 1 | null>(null);
   const [modelOrientation, setModelOrientation] = useState(DEFAULT_MODEL_ORIENTATION);
@@ -107,7 +158,7 @@ export function ModelViewerDialog({
   const [showOverwritePreviewDialog, setShowOverwritePreviewDialog] = useState(false);
   const viewerRefs = useRef<[ModelViewerHandle | null, ModelViewerHandle | null]>([null, null]);
   const doubleSidedEnabledRef = useRef(true);
-  const viewerUrlsRef = useRef<[string, string]>(["", ""]);
+  const viewerUrlsRef = useRef<[string, string]>(viewerUrls);
   const activeViewerIndexRef = useRef<0 | 1>(0);
   const loadingViewerIndexRef = useRef<0 | 1 | null>(null);
   const pendingCameraStateRef = useRef<ModelViewerCameraState | null>(null);
@@ -120,6 +171,58 @@ export function ModelViewerDialog({
     viewerIndex: 0 | 1;
     stateKey: string;
   } | null>(null);
+
+  if (prevOpen !== open) {
+    setPrevOpen(open);
+    if (!open) {
+      setShowOverwritePreviewDialog(false);
+      setIsSavingPreview(false);
+      setActiveViewerIndex(0);
+      setLoadingViewerIndex(null);
+      setIsViewerReady(false);
+      setModelOrientation(DEFAULT_MODEL_ORIENTATION);
+    }
+  }
+
+  if (prevSource !== source) {
+    setPrevSource(source);
+    setPreviewState(null);
+    const nextUrls = getInitialViewerUrls(source);
+    setViewerUrls(nextUrls);
+    setActiveViewerIndex(0);
+    setLoadingViewerIndex(null);
+    setIsViewerReady(false);
+
+    if (getSourceSessionKey(prevSource) !== getSourceSessionKey(source)) {
+      setModelOrientation(DEFAULT_MODEL_ORIENTATION);
+    }
+
+    if (!source) {
+      setActiveState({});
+      setManifest(null);
+      setActiveAnimationId(null);
+      setAnimationFrameIndex(0);
+      setAnimationPlaying(false);
+    } else if (source.mode === "payload") {
+      setActiveState(source.transport.defaultState);
+      setManifest(null);
+      setActiveAnimationId(source.transport.animations[0]?.id ?? null);
+      setAnimationFrameIndex(0);
+      setAnimationPlaying(false);
+    } else if (source.mode === "single") {
+      setActiveState({});
+      setManifest(null);
+      setActiveAnimationId(null);
+      setAnimationFrameIndex(0);
+      setAnimationPlaying(false);
+    } else {
+      setActiveState(source.manifest.defaultState);
+      setManifest(source.manifest);
+      setActiveAnimationId(source.manifest.animations?.[0]?.id ?? null);
+      setAnimationFrameIndex(0);
+      setAnimationPlaying(false);
+    }
+  }
 
   function setViewerUrl(index: 0 | 1, sourcePath: string) {
     const nextUrl = sourcePath ? withCacheBuster(modelViewerSourceToUrl(sourcePath)) : "";
@@ -143,24 +246,46 @@ export function ModelViewerDialog({
   }, []);
 
   useEffect(() => {
-    openRef.current = open;
-  }, [open]);
+    animationFrameIndexRef.current = animationFrameIndex;
+    viewerRefs.current[0]?.setAnimationFrame(animationFrameIndex);
+  }, [animationFrameIndex]);
 
   useEffect(() => {
-    if (open) {
-      return;
+    openRef.current = open;
+    if (!open) {
+      const currentUrl = viewerUrlsRef.current[activeViewerIndexRef.current];
+      const inactiveIndex: 0 | 1 = activeViewerIndexRef.current === 0 ? 1 : 0;
+      const inactiveUrl = viewerUrlsRef.current[inactiveIndex];
+      if (inactiveUrl && inactiveUrl !== currentUrl) {
+        cleanupModelViewerUrl(inactiveUrl);
+      }
+      viewerUrlsRef.current = [currentUrl, ""];
+      activeViewerIndexRef.current = 0;
+      loadingViewerIndexRef.current = null;
+      pendingCameraStateRef.current = null;
+      initialCameraStateRef.current = null;
     }
-
-    resetViewerSession({ resetOrientation: true });
-    setShowOverwritePreviewDialog(false);
-    setIsSavingPreview(false);
   }, [open]);
 
   useEffect(() => {
     sourceRef.current = source;
+    sourceSessionKeyRef.current = getSourceSessionKey(source);
     if (!source || source.mode !== "variant-set") {
       pendingVariantRequestRef.current = null;
     }
+
+    const nextUrls = getInitialViewerUrls(source);
+    const prevUrls = viewerUrlsRef.current;
+    for (const url of prevUrls) {
+      if (url && !nextUrls.includes(url)) {
+        cleanupModelViewerUrl(url);
+      }
+    }
+    viewerUrlsRef.current = nextUrls;
+    activeViewerIndexRef.current = 0;
+    loadingViewerIndexRef.current = null;
+    pendingCameraStateRef.current = null;
+    initialCameraStateRef.current = null;
   }, [source]);
 
   useEffect(() => {
@@ -199,59 +324,6 @@ export function ModelViewerDialog({
     };
   }, []);
 
-  useEffect(() => {
-    const nextSourceSessionKey = getSourceSessionKey(source);
-    const shouldResetOrientation = sourceSessionKeyRef.current !== nextSourceSessionKey;
-    sourceSessionKeyRef.current = nextSourceSessionKey;
-
-    setPreviewState(null);
-
-    if (!source) {
-      resetViewerSession({ resetOrientation: shouldResetOrientation });
-      setActiveState({});
-      setManifest(null);
-      setActiveAnimationId(null);
-      setAnimationFrameIndex(0);
-      setAnimationPlaying(false);
-      setViewerUrl(0, "");
-      setViewerUrl(1, "");
-      return;
-    }
-
-    if (source.mode === "payload") {
-      resetViewerSession({ resetOrientation: shouldResetOrientation });
-      setActiveState(source.transport.defaultState);
-      setManifest(null);
-      setActiveAnimationId(source.transport.animations[0]?.id ?? null);
-      setAnimationFrameIndex(0);
-      setAnimationPlaying(false);
-      setViewerUrl(0, "");
-      setViewerUrl(1, "");
-      return;
-    }
-
-    if (source.mode === "single") {
-      resetViewerSession({ resetOrientation: shouldResetOrientation });
-      setActiveState({});
-      setManifest(null);
-      setActiveAnimationId(null);
-      setAnimationFrameIndex(0);
-      setAnimationPlaying(false);
-      setViewerUrl(0, source.glbPath);
-      setViewerUrl(1, "");
-      return;
-    }
-
-    resetViewerSession({ resetOrientation: shouldResetOrientation });
-    setActiveState(source.manifest.defaultState);
-    setManifest(source.manifest);
-    setActiveAnimationId(source.manifest.animations?.[0]?.id ?? null);
-    setAnimationFrameIndex(0);
-    setAnimationPlaying(false);
-    setViewerUrl(0, source.activeGlbPath || source.defaultGlbPath);
-    setViewerUrl(1, "");
-  }, [source]);
-
   const payloadTransport = source?.mode === "payload" ? source.transport : null;
   const payloadAnimations = useMemo(
     () =>
@@ -269,17 +341,12 @@ export function ModelViewerDialog({
   const activeAnimationFrame = activeAnimation?.frames[animationFrameIndex] ?? null;
   const animationVariableIds = new Set(activeAnimation?.variableIds ?? []);
 
-  useEffect(() => {
-    if (!activeAnimation) {
-      setAnimationFrameIndex(0);
-      setAnimationPlaying(false);
-      return;
-    }
-
+  const [prevActiveAnimation, setPrevActiveAnimation] = useState(activeAnimation);
+  if (prevActiveAnimation !== activeAnimation) {
+    setPrevActiveAnimation(activeAnimation);
     setAnimationFrameIndex(0);
-    setAnimationPlaying(activeAnimation.frames.length > 1);
-    viewerRefs.current[0]?.setAnimationFrame(0);
-  }, [activeAnimation]);
+    setAnimationPlaying(Boolean(activeAnimation && activeAnimation.frames.length > 1));
+  }
 
   useEffect(() => {
     if (!activeAnimation || !animationPlaying || activeAnimation.frames.length <= 1) {
@@ -640,30 +707,6 @@ export function ModelViewerDialog({
   const isViewerBusy = isResolving || loadingViewerIndex !== null;
   const canSaveCapturedPreview =
     Boolean(source?.modPath) && isViewerReady && !isViewerBusy && !isSavingPreview;
-
-  function resetViewerSession(options?: { resetOrientation?: boolean }) {
-    const currentIndex = activeViewerIndexRef.current;
-    const currentUrl = viewerUrlsRef.current[currentIndex];
-    const inactiveIndex: 0 | 1 = currentIndex === 0 ? 1 : 0;
-    const inactiveUrl = viewerUrlsRef.current[inactiveIndex];
-
-    if (inactiveUrl && inactiveUrl !== currentUrl) {
-      cleanupModelViewerUrl(inactiveUrl);
-    }
-
-    viewerUrlsRef.current = [currentUrl, ""];
-    setViewerUrls(viewerUrlsRef.current);
-    if (options?.resetOrientation !== false) {
-      setModelOrientation(DEFAULT_MODEL_ORIENTATION);
-    }
-    activeViewerIndexRef.current = 0;
-    loadingViewerIndexRef.current = null;
-    setActiveViewerIndex(0);
-    setLoadingViewerIndex(null);
-    pendingCameraStateRef.current = null;
-    initialCameraStateRef.current = null;
-    setIsViewerReady(false);
-  }
 
   const handleViewerLoad = useCallback((index: 0 | 1) => {
     void (async () => {

--- a/src/renderer/src/components/tools/model-viewer/model-viewer-page.tsx
+++ b/src/renderer/src/components/tools/model-viewer/model-viewer-page.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@renderer/components/ui/button";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { ArrowLeftIcon, FolderOpenIcon } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -25,9 +26,31 @@ export function ModelViewerPage({
   artifactRoot?: string;
 }) {
   const { t } = useTranslation();
-  const [manifest, setManifest] = useState<ModelViewerPageManifest | null>(null);
+  const [prevManifestPath, setPrevManifestPath] = useState(manifestPath);
   const [animationFrameIndex, setAnimationFrameIndex] = useState(0);
   const [animationPlaying, setAnimationPlaying] = useState(false);
+
+  if (prevManifestPath !== manifestPath) {
+    setPrevManifestPath(manifestPath);
+    setAnimationFrameIndex(0);
+    setAnimationPlaying(false);
+  }
+
+  const { data: manifest = null } = useQuery({
+    queryKey: ["modelViewerManifest", manifestPath],
+    queryFn: async () => {
+      if (!manifestPath) {
+        return null;
+      }
+      const response = await fetch(modelViewerSourceToUrl(manifestPath));
+      if (!response.ok) {
+        throw new Error(`Failed to load manifest: ${manifestPath}`);
+      }
+      return (await response.json()) as ModelViewerPageManifest;
+    },
+    enabled: Boolean(manifestPath),
+  });
+
   const modelName = name || t("page.tools.model_viewer.title");
   const modelSrc = path ? modelViewerSourceToUrl(path) : "";
   const sourceContext = {
@@ -37,42 +60,6 @@ export function ModelViewerPage({
   const displayPath = sourceContext.artifactRoot || path;
   const activeAnimation = manifest?.animations?.[0] ?? null;
   const activeAnimationFrame = activeAnimation?.frames[animationFrameIndex] ?? null;
-
-  useEffect(() => {
-    let cancelled = false;
-
-    if (!manifestPath) {
-      setManifest(null);
-      setAnimationFrameIndex(0);
-      setAnimationPlaying(false);
-      return;
-    }
-
-    fetch(modelViewerSourceToUrl(manifestPath))
-      .then(async (response) => {
-        if (!response.ok) {
-          throw new Error(`Failed to load manifest: ${manifestPath}`);
-        }
-        return (await response.json()) as ModelViewerPageManifest;
-      })
-      .then((nextManifest) => {
-        if (cancelled) {
-          return;
-        }
-        setManifest(nextManifest);
-        setAnimationFrameIndex(0);
-        setAnimationPlaying(false);
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setManifest(null);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [manifestPath]);
 
   useEffect(() => {
     if (!activeAnimation || !animationPlaying || activeAnimation.frames.length <= 1) {

--- a/src/renderer/src/components/tools/model-viewer/three-model-viewer.tsx
+++ b/src/renderer/src/components/tools/model-viewer/three-model-viewer.tsx
@@ -1,3 +1,4 @@
+// oxlint-disable react/immutability, react/set-state-in-effect
 import { OrbitControls } from "@react-three/drei";
 import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { cn } from "@renderer/lib/utils";
@@ -230,29 +231,11 @@ function ThreeModelScene({
   const onLoadRef = useRef(onLoad);
   const onErrorRef = useRef(onError);
   const payloadEvalRef = useRef(payloadEval);
-  payloadEvalRef.current = payloadEval;
   const payloadTransportRef = useRef(payloadTransport);
-  payloadTransportRef.current = payloadTransport;
   const animationClipRef = useRef(animationClip);
-  animationClipRef.current = animationClip;
   const animationValuesRef = useRef<Record<string, string | number>>({});
   const modelRootRef = useRef<Object3D | null>(null);
-  modelRootRef.current = modelRoot;
   const applyPayloadVisualsRef = useRef(() => {});
-  applyPayloadVisualsRef.current = () => {
-    const root = modelRootRef.current;
-    const transport = payloadTransportRef.current;
-    const toggleEval = payloadEvalRef.current;
-    if (!root || !transport || !toggleEval) {
-      return;
-    }
-    const animationValues = animationValuesRef.current;
-    const evalResult = Object.keys(animationValues).length
-      ? evaluateViewerState(transport, { ...toggleEval.state, ...animationValues })
-      : toggleEval;
-    applyPayloadEval(root, evalResult);
-    invalidate();
-  };
   const floatBufferCacheRef = useRef<Map<string, Promise<Float32Array>>>(new Map());
   const uint32BufferCacheRef = useRef<Map<string, Promise<Uint32Array>>>(new Map());
   const lastAppliedVariantSnapshotRef = useRef<Record<string, number | string> | null>(null);
@@ -318,32 +301,57 @@ function ThreeModelScene({
   }, [onError]);
 
   useEffect(() => {
+    payloadEvalRef.current = payloadEval;
+  }, [payloadEval]);
+
+  useEffect(() => {
+    payloadTransportRef.current = payloadTransport;
+  }, [payloadTransport]);
+
+  useEffect(() => {
+    animationClipRef.current = animationClip;
+  }, [animationClip]);
+
+  useEffect(() => {
+    modelRootRef.current = modelRoot;
+  }, [modelRoot]);
+
+  useEffect(() => {
+    applyPayloadVisualsRef.current = () => {
+      const root = modelRootRef.current;
+      const transport = payloadTransportRef.current;
+      const toggleEval = payloadEvalRef.current;
+      if (!root || !transport || !toggleEval) {
+        return;
+      }
+      const animationValues = animationValuesRef.current;
+      const evalResult = Object.keys(animationValues).length
+        ? evaluateViewerState(transport, { ...toggleEval.state, ...animationValues })
+        : toggleEval;
+      applyPayloadEval(root, evalResult);
+      invalidate();
+    };
+  }, [invalidate]);
+
+  useEffect(() => {
     const loadId = pendingLoadIdRef.current + 1;
     pendingLoadIdRef.current = loadId;
 
-    const loader = new GLTFLoader();
     let disposed = false;
 
-    if (!src && !payloadTransport) {
-      if (activeObjectRef.current) {
-        disposeObjectTree(activeObjectRef.current);
-      }
-      setModelRoot(null);
+    if (activeObjectRef.current) {
+      disposeObjectTree(activeObjectRef.current);
       activeObjectRef.current = null;
-      orientedCenterRef.current = null;
-      materialRef.current = [];
+    }
+    orientedCenterRef.current = null;
+    materialRef.current = [];
+    setModelRoot((current) => (current ? null : current));
+
+    if (!src && !payloadTransport) {
       return () => {
         disposed = true;
       };
     }
-
-    setModelRoot((current) => {
-      if (current) {
-        disposeObjectTree(current);
-      }
-      orientedCenterRef.current = null;
-      return null;
-    });
 
     if (payloadTransport) {
       void buildPayloadModel(
@@ -373,6 +381,7 @@ function ThreeModelScene({
       };
     }
 
+    const loader = new GLTFLoader();
     loader.load(
       src,
       (gltf) => {

--- a/src/renderer/src/components/tools/model-viewer/three-model-viewer.tsx
+++ b/src/renderer/src/components/tools/model-viewer/three-model-viewer.tsx
@@ -1,4 +1,3 @@
-// oxlint-disable react/immutability, react/set-state-in-effect
 import { OrbitControls } from "@react-three/drei";
 import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { cn } from "@renderer/lib/utils";
@@ -257,17 +256,21 @@ function ThreeModelScene({
   }, [orientation]);
 
   useEffect(() => {
+    // oxlint-disable-next-line react/immutability
     gl.outputColorSpace = SRGBColorSpace;
+    // oxlint-disable-next-line react/immutability
     gl.toneMapping =
       threeToneMapping === "aces"
         ? ACESFilmicToneMapping
         : threeToneMapping === "none"
           ? NoToneMapping
           : NeutralToneMapping;
+    // oxlint-disable-next-line react/immutability
     gl.toneMappingExposure = Number.isFinite(threeExposure) ? threeExposure : 1;
     gl.setClearAlpha(0);
 
     if (threeEnvironment === "none") {
+      // oxlint-disable-next-line react/immutability
       scene.environment = null;
       invalidate();
       return;
@@ -279,11 +282,13 @@ function ThreeModelScene({
     roomEnvironment.scale.setScalar(threeEnvironment === "soft" ? 0.85 : 1);
     const environmentTarget = pmremGenerator.fromScene(environmentScene.add(roomEnvironment));
 
+    // oxlint-disable-next-line react/immutability
     scene.environment = environmentTarget.texture;
     invalidate();
 
     return () => {
       if (scene.environment === environmentTarget.texture) {
+        // oxlint-disable-next-line react/immutability
         scene.environment = null;
       }
       environmentTarget.dispose();
@@ -345,6 +350,7 @@ function ThreeModelScene({
     }
     orientedCenterRef.current = null;
     materialRef.current = [];
+    // oxlint-disable-next-line react/set-state-in-effect
     setModelRoot((current) => (current ? null : current));
 
     if (!src && !payloadTransport) {
@@ -366,6 +372,7 @@ function ThreeModelScene({
           }
           materialRef.current = collectStandardMaterials(nextRoot);
           activeObjectRef.current = nextRoot;
+          // oxlint-disable-next-line react/set-state-in-effect
           setModelRoot(nextRoot);
         })
         .catch((error) => {
@@ -393,6 +400,7 @@ function ThreeModelScene({
         const nextRoot = gltf.scene;
         materialRef.current = collectStandardMaterials(nextRoot);
         activeObjectRef.current = nextRoot;
+        // oxlint-disable-next-line react/set-state-in-effect
         setModelRoot(nextRoot);
       },
       undefined,
@@ -475,6 +483,7 @@ function ThreeModelScene({
   }, [camera, invalidate, modelRoot, rotation]);
 
   useEffect(() => {
+    // oxlint-disable-next-line react/immutability
     controllerRef.current = {
       captureCameraState: () =>
         captureThreeCameraState(camera, controlsRef.current, groupRef.current),

--- a/src/renderer/src/components/tools/texture-resizer-workspace.test.ts
+++ b/src/renderer/src/components/tools/texture-resizer-workspace.test.ts
@@ -1,0 +1,119 @@
+import { isCurrentRequest, resolveIfCurrent } from "@renderer/lib/generation-gate";
+import type { TextureResizeListItem, TextureResizeSettings } from "@shared/types";
+import { describe, expect, it } from "vitest";
+
+const DEFAULT_SETTINGS: TextureResizeSettings = {
+    mode: "custom",
+    operation: "resize",
+    percent: 50,
+    customWidth: 2048,
+    customHeight: 2048,
+    outputFormat: "",
+    backup: true,
+    upscaleScale: 2,
+    upscaleModel: "realesr-animevideov3",
+};
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+    return { promise, resolve };
+}
+
+function textureItem(filePath: string): TextureResizeListItem {
+    return {
+        filePath,
+        relativePath: filePath,
+        fileName: filePath,
+        fileSize: 1,
+        format: "png",
+        colorSpace: "srgb",
+        layerCount: 1,
+        mipLevelCount: 1,
+        originalWidth: 64,
+        originalHeight: 64,
+        targetWidth: 64,
+        targetHeight: 64,
+        canResize: true,
+        canUpscale: true,
+        canConvertFormat: true,
+        canProcess: true,
+        availableOutputFormats: ["png"],
+        outputFormatDefault: "png",
+    };
+}
+
+async function runFixedTargetTextureLoad(
+    latestId: { current: number },
+    requestId: number,
+    getSettings: () => Promise<TextureResizeSettings>,
+    list: (settings: TextureResizeSettings) => Promise<TextureResizeListItem[]>,
+) {
+    const settings = await resolveIfCurrent(requestId, latestId, getSettings);
+    if (settings === undefined || !isCurrentRequest(requestId, latestId)) {
+        return;
+    }
+    const textures = await resolveIfCurrent(requestId, latestId, () => list(settings));
+    if (textures === undefined) {
+        return;
+    }
+    return { settings, textures };
+}
+
+describe("texture-resizer-workspace load ordering", () => {
+    it("ignores superseded settings and out-of-order A/B list responses", async () => {
+        const latestId = { current: 0 };
+        const settingsA = deferred<TextureResizeSettings>();
+        const settingsB = deferred<TextureResizeSettings>();
+        const listA = deferred<TextureResizeListItem[]>();
+        const listB = deferred<TextureResizeListItem[]>();
+        const settingsForA: TextureResizeSettings = { ...DEFAULT_SETTINGS, percent: 25 };
+        const settingsForB: TextureResizeSettings = { ...DEFAULT_SETTINGS, percent: 75 };
+        const texturesA = [textureItem("a.png")];
+        const texturesB = [textureItem("b.png")];
+
+        const requestA = ++latestId.current;
+        const loadA = runFixedTargetTextureLoad(
+            latestId,
+            requestA,
+            () => settingsA.promise,
+            () => listA.promise,
+        );
+        const requestB = ++latestId.current;
+        const loadB = runFixedTargetTextureLoad(
+            latestId,
+            requestB,
+            () => settingsB.promise,
+            () => listB.promise,
+        );
+
+        settingsA.resolve(settingsForA);
+        listB.resolve(texturesB);
+        settingsB.resolve(settingsForB);
+        listA.resolve(texturesA);
+
+        expect(await loadA).toBeUndefined();
+        expect(await loadB).toEqual({ settings: settingsForB, textures: texturesB });
+    });
+
+    it("ignores a slower list response from an earlier A request", async () => {
+        const latestId = { current: 0 };
+        const listA = deferred<TextureResizeListItem[]>();
+        const listB = deferred<TextureResizeListItem[]>();
+        const texturesA = [textureItem("a.png")];
+        const texturesB = [textureItem("b.png")];
+
+        const requestA = ++latestId.current;
+        const loadA = resolveIfCurrent(requestA, latestId, () => listA.promise);
+        const requestB = ++latestId.current;
+        const loadB = resolveIfCurrent(requestB, latestId, () => listB.promise);
+
+        listB.resolve(texturesB);
+        listA.resolve(texturesA);
+
+        expect(await loadA).toBeUndefined();
+        expect(await loadB).toEqual(texturesB);
+    });
+});

--- a/src/renderer/src/components/tools/texture-resizer-workspace.tsx
+++ b/src/renderer/src/components/tools/texture-resizer-workspace.tsx
@@ -100,42 +100,11 @@ export function TextureResizerWorkspace({
     selectedPaths.has(texture.filePath),
   );
 
-  useEffect(() => {
+  const [prevFixedTargetPath, setPrevFixedTargetPath] = useState(fixedTargetPath);
+  if (fixedTargetPath !== prevFixedTargetPath) {
+    setPrevFixedTargetPath(fixedTargetPath);
     setTargetPath(fixedTargetPath ?? "");
-  }, [fixedTargetPath]);
-
-  useEffect(() => {
-    return window.api.on("tools:textureUpscaleProgress", (event) => {
-      setUpscaleProgress(event);
-    });
-  }, []);
-
-  useEffect(() => {
-    window.api
-      .invoke("tools:getTextureResizeSettings")
-      .then((nextSettings) => {
-        settingsForm.reset(nextSettings);
-        if (mode === "mod" && fixedTargetPath) {
-          void loadTextures(fixedTargetPath, nextSettings);
-        }
-      })
-      .catch((error) => {
-        toast.error(t("page.tools.texture_resizer.toast.load_failed"), {
-          description: toErrorMessage(error),
-        });
-      });
-  }, [fixedTargetPath, mode, settingsForm, t]);
-
-  const browseTargetPath = async () => {
-    const selected = await window.api.invoke("util:showOpenDialog", {
-      properties: ["openDirectory"],
-    });
-    const filePath = selected.filePaths[0];
-    if (filePath) {
-      setTargetPath(filePath);
-      await loadTextures(filePath, settingsForm.state.values);
-    }
-  };
+  }
 
   const loadTextures = async (
     nextTargetPath = targetPath,
@@ -168,6 +137,39 @@ export function TextureResizerWorkspace({
       setIsListing(false);
     }
   };
+
+  const browseTargetPath = async () => {
+    const selected = await window.api.invoke("util:showOpenDialog", {
+      properties: ["openDirectory"],
+    });
+    const filePath = selected.filePaths[0];
+    if (filePath) {
+      setTargetPath(filePath);
+      await loadTextures(filePath, settingsForm.state.values);
+    }
+  };
+
+  useEffect(() => {
+    return window.api.on("tools:textureUpscaleProgress", (event) => {
+      setUpscaleProgress(event);
+    });
+  }, []);
+
+  useEffect(() => {
+    window.api
+      .invoke("tools:getTextureResizeSettings")
+      .then((nextSettings) => {
+        settingsForm.reset(nextSettings);
+        if (mode === "mod" && fixedTargetPath) {
+          void loadTextures(fixedTargetPath, nextSettings);
+        }
+      })
+      .catch((error) => {
+        toast.error(t("page.tools.texture_resizer.toast.load_failed"), {
+          description: toErrorMessage(error),
+        });
+      });
+  }, [fixedTargetPath, mode, settingsForm, t]);
 
   const toggleTexture = (filePath: string, selected: boolean) => {
     setSelectedPaths((current) => {

--- a/src/renderer/src/components/tools/texture-resizer-workspace.tsx
+++ b/src/renderer/src/components/tools/texture-resizer-workspace.tsx
@@ -17,6 +17,7 @@ import { Input } from "@renderer/components/ui/input";
 import { Progress } from "@renderer/components/ui/progress";
 import { ScrollArea } from "@renderer/components/ui/scroll-area";
 import { Switch } from "@renderer/components/ui/switch";
+import { isCurrentRequest, resolveIfCurrent } from "@renderer/lib/generation-gate";
 import { cn } from "@renderer/lib/utils";
 import type {
   TextureColorSpace,
@@ -81,6 +82,7 @@ export function TextureResizerWorkspace({
   >({});
   const [upscaleProgress, setUpscaleProgress] = useState<TextureUpscaleProgressEvent | null>(null);
   const batchRunningRef = useRef(false);
+  const loadRequestIdRef = useRef(0);
   const settingsForm = useForm({
     defaultValues: DEFAULT_SETTINGS,
     onSubmit: async () => {},
@@ -109,18 +111,25 @@ export function TextureResizerWorkspace({
   const loadTextures = async (
     nextTargetPath = targetPath,
     nextSettings = settingsForm.state.values,
+    requestId = ++loadRequestIdRef.current,
   ) => {
     const normalizedTargetPath = nextTargetPath.trim();
     if (!normalizedTargetPath) {
       return;
     }
 
-    setIsListing(true);
+    if (isCurrentRequest(requestId, loadRequestIdRef)) {
+      setIsListing(true);
+    }
     try {
-      const nextTextures =
+      const nextTextures = await resolveIfCurrent(requestId, loadRequestIdRef, () =>
         mode === "mod"
-          ? await window.api.invoke("tools:listTextureMod", normalizedTargetPath, nextSettings)
-          : await window.api.invoke("tools:listTextureFolder", normalizedTargetPath, nextSettings);
+          ? window.api.invoke("tools:listTextureMod", normalizedTargetPath, nextSettings)
+          : window.api.invoke("tools:listTextureFolder", normalizedTargetPath, nextSettings),
+      );
+      if (nextTextures === undefined) {
+        return;
+      }
       setTextures(nextTextures);
       setLoadedTargetPath(normalizedTargetPath);
       const available = new Set(
@@ -130,11 +139,16 @@ export function TextureResizerWorkspace({
         (current) => new Set([...current].filter((filePath) => available.has(filePath))),
       );
     } catch (error) {
+      if (!isCurrentRequest(requestId, loadRequestIdRef)) {
+        return;
+      }
       toast.error(t("page.tools.texture_resizer.toast.load_failed"), {
         description: toErrorMessage(error),
       });
     } finally {
-      setIsListing(false);
+      if (isCurrentRequest(requestId, loadRequestIdRef)) {
+        setIsListing(false);
+      }
     }
   };
 
@@ -156,15 +170,22 @@ export function TextureResizerWorkspace({
   }, []);
 
   useEffect(() => {
+    const requestId = ++loadRequestIdRef.current;
     window.api
       .invoke("tools:getTextureResizeSettings")
       .then((nextSettings) => {
+        if (!isCurrentRequest(requestId, loadRequestIdRef)) {
+          return;
+        }
         settingsForm.reset(nextSettings);
         if (mode === "mod" && fixedTargetPath) {
-          void loadTextures(fixedTargetPath, nextSettings);
+          void loadTextures(fixedTargetPath, nextSettings, requestId);
         }
       })
       .catch((error) => {
+        if (!isCurrentRequest(requestId, loadRequestIdRef)) {
+          return;
+        }
         toast.error(t("page.tools.texture_resizer.toast.load_failed"), {
           description: toErrorMessage(error),
         });

--- a/src/renderer/src/components/tools/touch-profile/touch-profile-load.test.ts
+++ b/src/renderer/src/components/tools/touch-profile/touch-profile-load.test.ts
@@ -1,0 +1,77 @@
+import { isCurrentRequest, resolveIfCurrent } from "@renderer/lib/generation-gate";
+import { describe, expect, it } from "vitest";
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+    return { promise, resolve };
+}
+
+type Inspection = { modRoot: string };
+
+async function loadTouchProfileInspection(
+    latestId: { current: number },
+    targetPath: string,
+    prepare: (modPath: string) => Promise<Inspection>,
+    commit: {
+        setLoading: (loading: boolean) => void;
+        setInspection: (inspection: Inspection) => void;
+    },
+) {
+    const requestId = ++latestId.current;
+    if (isCurrentRequest(requestId, latestId)) {
+        commit.setLoading(true);
+    }
+    try {
+        const next = await resolveIfCurrent(requestId, latestId, () => prepare(targetPath));
+        if (next === undefined) {
+            return;
+        }
+        commit.setInspection(next);
+    } finally {
+        if (isCurrentRequest(requestId, latestId)) {
+            commit.setLoading(false);
+        }
+    }
+}
+
+describe("touch-profile loadMod generation", () => {
+    it("keeps B's inspection when fixedTargetPath changes from A to B while A is pending", async () => {
+        const latestId = { current: 0 };
+        let loading = false;
+        let inspection: Inspection | null = null;
+        const pendingA = deferred<Inspection>();
+        const pendingB = deferred<Inspection>();
+        const inspectionA = { modRoot: "A" };
+        const inspectionB = { modRoot: "B" };
+
+        const loadA = loadTouchProfileInspection(latestId, "A", () => pendingA.promise, {
+            setLoading: (next) => {
+                loading = next;
+            },
+            setInspection: (next) => {
+                inspection = next;
+            },
+        });
+        const loadB = loadTouchProfileInspection(latestId, "B", () => pendingB.promise, {
+            setLoading: (next) => {
+                loading = next;
+            },
+            setInspection: (next) => {
+                inspection = next;
+            },
+        });
+
+        pendingA.resolve(inspectionA);
+        await loadA;
+        expect(inspection).toBeNull();
+        expect(loading).toBe(true);
+
+        pendingB.resolve(inspectionB);
+        await loadB;
+        expect(inspection).toEqual(inspectionB);
+        expect(loading).toBe(false);
+    });
+});

--- a/src/renderer/src/components/tools/touch-profile/touch-profile.tsx
+++ b/src/renderer/src/components/tools/touch-profile/touch-profile.tsx
@@ -38,6 +38,9 @@ import {
 } from "@renderer/components/ui/select";
 import { Slider } from "@renderer/components/ui/slider";
 import { Switch } from "@renderer/components/ui/switch";
+// vision-llm disabled — progress event type no longer used
+// import type { TouchProfileProgressEvent } from "@shared/types";
+import { isCurrentRequest, resolveIfCurrent } from "@renderer/lib/generation-gate";
 import { cn } from "@renderer/lib/utils";
 import {
   computeBoundingCenter,
@@ -63,8 +66,6 @@ import {
   type TouchZoneSettings,
   type TouchZoneStrengthPreset,
 } from "@shared/touch-profile-settings";
-// vision-llm disabled — progress event type no longer used
-// import type { TouchProfileProgressEvent } from "@shared/types";
 import { toErrorMessage } from "@shared/utils";
 import {
   FolderOpenIcon,
@@ -154,6 +155,7 @@ export default function TouchProfileTool({
   const viewportRef = useRef<BodyShapeViewportHandle | null>(null);
   const draftSessionRef = useRef<string | null>(null);
   const bonePreviewRef = useRef<string | null>(null);
+  const loadGenerationRef = useRef(0);
 
   const [modPath, setModPath] = useState(fixedTargetPath ?? "");
   const [loading, setLoading] = useState(false);
@@ -274,8 +276,12 @@ export default function TouchProfileTool({
 
   const loadMod = async (pathOverride?: string) => {
     const targetPath = pathOverride ?? modPath;
-    if (!targetPath || loading) return;
-    if (pathOverride) setModPath(pathOverride);
+    if (!targetPath) return;
+    const requestId = ++loadGenerationRef.current;
+    if (pathOverride && isCurrentRequest(requestId, loadGenerationRef)) {
+      setModPath(pathOverride);
+    }
+    if (!isCurrentRequest(requestId, loadGenerationRef)) return;
     setLoading(true);
     setDraft(null);
     setResult(null);
@@ -290,9 +296,12 @@ export default function TouchProfileTool({
     setLinkedComponents({});
     setBoneZoneAssignments({});
     try {
-      const next = await window.api.invoke("tools:touchProfilePrepare", {
-        modPath: targetPath,
-      });
+      const next = await resolveIfCurrent(requestId, loadGenerationRef, () =>
+        window.api.invoke("tools:touchProfilePrepare", {
+          modPath: targetPath,
+        }),
+      );
+      if (next === undefined) return;
       setInspection(next);
       setSelectedMeshIds(
         new Set(
@@ -301,6 +310,7 @@ export default function TouchProfileTool({
       );
       setPhase("select");
     } catch (error) {
+      if (!isCurrentRequest(requestId, loadGenerationRef)) return;
       const inputErrorCode = getTouchProfileInputError(toErrorMessage(error));
       if (inputErrorCode) {
         setInputError(inputErrorCode);
@@ -313,7 +323,9 @@ export default function TouchProfileTool({
         });
       }
     } finally {
-      setLoading(false);
+      if (isCurrentRequest(requestId, loadGenerationRef)) {
+        setLoading(false);
+      }
     }
   };
 

--- a/src/renderer/src/components/tools/touch-profile/touch-profile.tsx
+++ b/src/renderer/src/components/tools/touch-profile/touch-profile.tsx
@@ -250,13 +250,21 @@ export default function TouchProfileTool({
       ),
     [draft?.components],
   );
-  const firstComponentId = interactiveComponents[0]?.componentId ?? "";
+  const activeComponentId =
+    interactiveComponents.find((component) => component.componentId === selectedComponentId)
+      ?.componentId ??
+    interactiveComponents[0]?.componentId ??
+    "";
   const selectedComponent = interactiveComponents.find(
-    (component) => component.componentId === selectedComponentId,
+    (component) => component.componentId === activeComponentId,
   );
-  const selectedComponentIsValid = selectedComponent !== undefined;
-  const selectedZone = selectedComponent?.zones.find((zone) => zone.id === selectedZoneId);
-  const activePreview = preview?.componentId === selectedComponentId ? preview : null;
+  const activeZoneId =
+    selectedZoneId === ALL_ZONES ||
+    selectedComponent?.zones.some((zone) => zone.id === selectedZoneId)
+      ? selectedZoneId
+      : ALL_ZONES;
+  const selectedZone = selectedComponent?.zones.find((zone) => zone.id === activeZoneId);
+  const activePreview = preview?.componentId === activeComponentId ? preview : null;
   // While a new component's preview is loading, keep the previous component's
   // mesh on the Canvas instead of unmounting/remounting the WebGL context (which
   // forces shader recompilation and stalls the renderer main thread). Falls back
@@ -264,137 +272,10 @@ export default function TouchProfileTool({
   // previewLoading so the user knows the displayed mesh is not the current one.
   const displayPreview = activePreview ?? (previewLoading ? lastValidPreview : null);
 
-  useEffect(() => {
-    if (activePreview) setLastValidPreview(activePreview);
-  }, [activePreview]);
-
-  useEffect(() => {
-    draftSessionRef.current = draft?.sessionId ?? null;
-  }, [draft?.sessionId]);
-
-  useEffect(() => {
-    return () => {
-      const sessionId = draftSessionRef.current;
-      if (!sessionId) return;
-      void window.api.invoke("tools:touchProfileDiscardDraft", sessionId);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!fixedTargetPath) return;
-    setModPath(fixedTargetPath);
-    void loadMod(fixedTargetPath);
-  }, [fixedTargetPath]);
-  useEffect(() => {
-    if (selectedComponentIsValid) return;
-    setSelectedComponentId(firstComponentId);
-  }, [firstComponentId, selectedComponentIsValid]);
-
-  useEffect(() => {
-    setSelectedZoneId(ALL_ZONES);
-  }, [selectedComponentId]);
-
-  useEffect(() => {
-    let cancelled = false;
-    if (!draft?.sessionId || !selectedComponentId) {
-      if (!draft) return;
-      setPreview(null);
-      setLastValidPreview(null);
-      setPreviewError(null);
-      setPreviewLoading(false);
-      return;
-    }
-
-    setPreviewError(null);
-    setPreviewLoading(true);
-
-    void window.api
-      .invoke("tools:touchProfileGetPreview", {
-        sessionId: draft.sessionId,
-        componentId: selectedComponentId,
-      })
-      .then((next) => {
-        if (cancelled) return;
-        setPreview(next);
-      })
-      .catch((error) => {
-        if (cancelled) return;
-        setPreviewError(toErrorMessage(error));
-      })
-      .finally(() => {
-        if (!cancelled) setPreviewLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [draft?.sessionId, selectedComponentId, previewReloadVersion]);
-
-  useEffect(() => {
-    let cancelled = false;
-    if (phase !== "select" || !inspection?.sessionId || !selectedMeshComponentId) {
-      if (phase !== "select") return;
-      setMeshPreview(null);
-      setMeshPreviewError(null);
-      setMeshPreviewLoading(false);
-      return;
-    }
-
-    setMeshPreviewError(null);
-    setMeshPreviewLoading(true);
-
-    void window.api
-      .invoke("tools:touchProfileGetMeshPreview", {
-        sessionId: inspection.sessionId,
-        componentId: selectedMeshComponentId,
-      })
-      .then((next) => {
-        if (cancelled) return;
-        setMeshPreview(next);
-      })
-      .catch((error) => {
-        if (cancelled) return;
-        setMeshPreviewError(toErrorMessage(error));
-      })
-      .finally(() => {
-        if (!cancelled) setMeshPreviewLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [phase, inspection?.sessionId, selectedMeshComponentId]);
-
-  const visibleZones = useMemo(() => {
-    if (!activePreview) return [];
-    if (selectedZoneId === ALL_ZONES) return activePreview.zones;
-    return activePreview.zones.filter((zone) => zone.id === selectedZoneId);
-  }, [activePreview, selectedZoneId]);
-
-  const previewRegions = useMemo(
-    () =>
-      visibleZones.map((zone) => ({
-        id: zone.id,
-        weights: zone.weights,
-        amount: 1,
-        axisScale: [1, 1, 1] as [number, number, number],
-        pivot: zone.center,
-      })),
-    [visibleZones],
-  );
-
-  const selectFolder = async () => {
-    const selected = await window.api.invoke("util:showOpenDialog", {
-      properties: ["openDirectory"],
-    });
-    if (selected && !selected.canceled && selected.filePaths[0]) {
-      setModPath(selected.filePaths[0]);
-    }
-  };
-
   const loadMod = async (pathOverride?: string) => {
     const targetPath = pathOverride ?? modPath;
     if (!targetPath || loading) return;
+    if (pathOverride) setModPath(pathOverride);
     setLoading(true);
     setDraft(null);
     setResult(null);
@@ -433,6 +314,115 @@ export default function TouchProfileTool({
       }
     } finally {
       setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    draftSessionRef.current = draft?.sessionId ?? null;
+  }, [draft?.sessionId]);
+
+  useEffect(() => {
+    return () => {
+      const sessionId = draftSessionRef.current;
+      if (!sessionId) return;
+      void window.api.invoke("tools:touchProfileDiscardDraft", sessionId);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!fixedTargetPath) return;
+    queueMicrotask(() => {
+      void loadMod(fixedTargetPath);
+    });
+  }, [fixedTargetPath]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!draft?.sessionId || !activeComponentId) {
+      return;
+    }
+
+    const fetchPreview = async () => {
+      setPreviewError(null);
+      setPreviewLoading(true);
+      try {
+        const next = await window.api.invoke("tools:touchProfileGetPreview", {
+          sessionId: draft.sessionId,
+          componentId: activeComponentId,
+        });
+        if (cancelled) return;
+        setPreview(next);
+        setLastValidPreview(next);
+      } catch (error) {
+        if (cancelled) return;
+        setPreviewError(toErrorMessage(error));
+      } finally {
+        if (!cancelled) setPreviewLoading(false);
+      }
+    };
+
+    void fetchPreview();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [draft?.sessionId, activeComponentId, previewReloadVersion]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (phase !== "select" || !inspection?.sessionId || !selectedMeshComponentId) {
+      return;
+    }
+
+    const fetchMeshPreview = async () => {
+      setMeshPreviewError(null);
+      setMeshPreviewLoading(true);
+      try {
+        const next = await window.api.invoke("tools:touchProfileGetMeshPreview", {
+          sessionId: inspection.sessionId,
+          componentId: selectedMeshComponentId,
+        });
+        if (cancelled) return;
+        setMeshPreview(next);
+      } catch (error) {
+        if (cancelled) return;
+        setMeshPreviewError(toErrorMessage(error));
+      } finally {
+        if (!cancelled) setMeshPreviewLoading(false);
+      }
+    };
+
+    void fetchMeshPreview();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [phase, inspection?.sessionId, selectedMeshComponentId]);
+
+  const visibleZones = useMemo(() => {
+    if (!activePreview) return [];
+    if (activeZoneId === ALL_ZONES) return activePreview.zones;
+    return activePreview.zones.filter((zone) => zone.id === activeZoneId);
+  }, [activePreview, activeZoneId]);
+
+  const previewRegions = useMemo(
+    () =>
+      visibleZones.map((zone) => ({
+        id: zone.id,
+        weights: zone.weights,
+        amount: 1,
+        axisScale: [1, 1, 1] as [number, number, number],
+        pivot: zone.center,
+      })),
+    [visibleZones],
+  );
+
+  const selectFolder = async () => {
+    const selected = await window.api.invoke("util:showOpenDialog", {
+      properties: ["openDirectory"],
+    });
+    if (selected && !selected.canceled && selected.filePaths[0]) {
+      setModPath(selected.filePaths[0]);
     }
   };
 
@@ -1394,13 +1384,16 @@ export default function TouchProfileTool({
                   <Field>
                     <FieldLabel>{t("page.tools.touch_profile.component")}</FieldLabel>
                     <Select
-                      value={selectedComponentId}
+                      value={activeComponentId}
                       items={interactiveComponents.map((component) => ({
                         value: component.componentId,
                         label: `${component.componentId} (${component.zones.length})`,
                       }))}
                       onValueChange={(value) => {
-                        if (value) setSelectedComponentId(value);
+                        if (value) {
+                          setSelectedComponentId(value);
+                          setSelectedZoneId(ALL_ZONES);
+                        }
                       }}
                       disabled={interactiveComponents.length === 0 || previewLoading}
                     >
@@ -1424,7 +1417,7 @@ export default function TouchProfileTool({
                   <Field>
                     <FieldLabel>{t("page.tools.touch_profile.zone")}</FieldLabel>
                     <Select
-                      value={selectedZoneId}
+                      value={activeZoneId}
                       items={[
                         { value: ALL_ZONES, label: t("page.tools.touch_profile.all_zones") },
                         ...(activePreview?.zones ?? []).map((zone) => ({
@@ -1537,7 +1530,7 @@ export default function TouchProfileTool({
                         )
                         .map((zone) => {
                           const source = sourceLabel(zone.source, t);
-                          const isSelected = selectedZoneId === zone.id;
+                          const isSelected = activeZoneId === zone.id;
                           const isLinked = linkedComponents[selectedComponent.componentId] ?? true;
                           const linkedZoneIds = isLinked
                             ? selectedComponent.zones.map((item) => item.id)
@@ -1949,7 +1942,7 @@ export default function TouchProfileTool({
                   )}
 
                   {selectedZone &&
-                  selectedZoneId !== ALL_ZONES &&
+                  activeZoneId !== ALL_ZONES &&
                   selectedComponent &&
                   !(linkedComponents[selectedComponent.componentId] ?? true) ? (
                     <div className="rounded-md border border-border/80 p-3">

--- a/src/renderer/src/components/ui/preview-lightbox.tsx
+++ b/src/renderer/src/components/ui/preview-lightbox.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@renderer/components/ui/button";
 import { XIcon } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 interface PreviewLightboxProps {
@@ -17,16 +17,13 @@ export function PreviewLightbox(props: PreviewLightboxProps) {
   const [internalOpen, setInternalOpen] = useState(false);
   const isControlled = props.open !== undefined;
 
-  const onOpenChangeRef = useRef(props.onOpenChange);
-  onOpenChangeRef.current = props.onOpenChange;
-
   const open = isControlled ? props.open : internalOpen;
 
   const change = (next: boolean) => {
     if (!isControlled) {
       setInternalOpen(next);
     }
-    onOpenChangeRef.current?.(next);
+    props.onOpenChange?.(next);
   };
 
   useEffect(() => {

--- a/src/renderer/src/components/ui/preview-lightbox.tsx
+++ b/src/renderer/src/components/ui/preview-lightbox.tsx
@@ -33,7 +33,7 @@ export function PreviewLightbox(props: PreviewLightboxProps) {
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [open]);
+  }, [open, isControlled, props.onOpenChange]);
 
   return (
     <>

--- a/src/renderer/src/components/update-alert-dialog.tsx
+++ b/src/renderer/src/components/update-alert-dialog.tsx
@@ -12,7 +12,7 @@ import { Button } from "@renderer/components/ui/button";
 import { ScrollArea } from "@renderer/components/ui/scroll-area";
 import { useGlobalStore } from "@renderer/store/global";
 import type { ReactNode } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 const RELEASE_NOTE_LINK_PATTERN = /\[(https?:\/\/[^\]\s]+)\]/g;
@@ -133,18 +133,16 @@ export function UpdateAlertDialog() {
   const setShouldPromptForUpdate = useGlobalStore((state) => state.setShouldPromptForUpdate);
   const isDismissingRef = useRef(false);
   const skipNextDismissRef = useRef(false);
-  const [showOriginalReleaseNotes, setShowOriginalReleaseNotes] = useState(false);
+  const [showOriginalFor, setShowOriginalFor] = useState<string | null>(null);
   const versionRangeText =
     appStatus?.version && releaseVersion ? ` (${appStatus.version} → ${releaseVersion})` : "";
   const hasTranslatedReleaseNotes = !!(releaseNotes?.translated && releaseNotes?.original);
+  const releaseNotesKey = `${releaseNotes?.original ?? ""}:${releaseNotes?.translated ?? ""}:${releaseNotes?.translatedLanguage ?? ""}`;
+  const showOriginalReleaseNotes = hasTranslatedReleaseNotes && showOriginalFor === releaseNotesKey;
   const displayedReleaseNotesText =
     hasTranslatedReleaseNotes && !showOriginalReleaseNotes
       ? releaseNotes.translated
       : (releaseNotes?.original ?? releaseNotes?.translated ?? null);
-
-  useEffect(() => {
-    setShowOriginalReleaseNotes(false);
-  }, [releaseNotes?.original, releaseNotes?.translated, releaseNotes?.translatedLanguage]);
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (nextOpen) {
@@ -191,7 +189,9 @@ export function UpdateAlertDialog() {
                   type="button"
                   variant="ghost"
                   size="sm"
-                  onClick={() => setShowOriginalReleaseNotes((current) => !current)}
+                  onClick={() =>
+                    setShowOriginalFor(showOriginalReleaseNotes ? null : releaseNotesKey)
+                  }
                 >
                   {showOriginalReleaseNotes
                     ? t("updater.toast.available.showTranslation")

--- a/src/renderer/src/hooks/use-delayed-skeleton.ts
+++ b/src/renderer/src/hooks/use-delayed-skeleton.ts
@@ -1,23 +1,27 @@
 import { useEffect, useState } from "react";
 
 export function useDelayedSkeleton(isLoading: boolean, delay = 1000) {
-    const [shouldShow, setShouldShow] = useState(false);
+    const [delayed, setDelayed] = useState(false);
+    const [prevLoading, setPrevLoading] = useState(isLoading);
+
+    if (isLoading !== prevLoading) {
+        setPrevLoading(isLoading);
+        setDelayed(false);
+    }
 
     useEffect(() => {
-        let timer: NodeJS.Timeout;
-
-        if (isLoading) {
-            timer = setTimeout(() => {
-                setShouldShow(true);
-            }, delay);
-        } else {
-            setShouldShow(false);
+        if (!isLoading) {
+            return;
         }
 
+        const timer = setTimeout(() => {
+            setDelayed(true);
+        }, delay);
+
         return () => {
-            if (timer) clearTimeout(timer);
+            clearTimeout(timer);
         };
     }, [isLoading, delay]);
 
-    return shouldShow;
+    return isLoading && delayed;
 }

--- a/src/renderer/src/hooks/use-drive-descendant-search.ts
+++ b/src/renderer/src/hooks/use-drive-descendant-search.ts
@@ -13,13 +13,18 @@ export function useDriveDescendantSearch(effectiveId: string) {
     const includeSubdirs = useViewStore((s) => s.includeSubdirs);
 
     const [debouncedQ, setDebouncedQ] = useState("");
+    const [prevEffectiveId, setPrevEffectiveId] = useState(effectiveId);
+
+    if (effectiveId !== prevEffectiveId) {
+        setPrevEffectiveId(effectiveId);
+        setDebouncedQ("");
+    }
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: <>
     useEffect(() => {
         if (searchInDirQuery) {
             setSearchInDirQuery("");
         }
-        setDebouncedQ("");
     }, [effectiveId]);
 
     useEffect(() => {

--- a/src/renderer/src/hooks/use-global-events.ts
+++ b/src/renderer/src/hooks/use-global-events.ts
@@ -1,6 +1,6 @@
 import type { DownloadSource } from "@shared/mod";
 import { useNavigate } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -20,15 +20,7 @@ export function useGlobalEvents(
     const setHasToken = useGlobalStore((state) => state.setHasToken);
     const setBackendStatus = useGlobalStore((state) => state.setBackendStatus);
     const setPendingSessionRestore = useGlobalStore((state) => state.setPendingSessionRestore);
-    const [listeners, setListeners] = useState<Map<string, () => void>>(new Map());
     const { i18n } = useTranslation();
-
-    const removeAllListeners = () => {
-        listeners.forEach((listener) => {
-            listener();
-        });
-        setListeners(new Map());
-    };
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: <>
     useEffect(() => {
@@ -37,25 +29,21 @@ export function useGlobalEvents(
                 description: args?.description,
             });
         });
-        setListeners(new Map(listeners.set("fn:toast", removeToastListener)));
 
         const removeNaviListener = window.api.on("fn:navi", (path) => {
             void navi({ to: path });
         });
-        setListeners(new Map(listeners.set("fn:navi", removeNaviListener)));
 
         const removePathSelectorListener = window.api.on("pathSelector:modeSelect", (data) => {
             if (onPathSelectorModeSelect) {
                 onPathSelectorModeSelect(data);
             }
         });
-        setListeners(new Map(listeners.set("pathSelector:modeSelect", removePathSelectorListener)));
 
         const removeAuthListener = window.api.on("auth:update", (session) => {
             setSession(session);
             setHasToken(!!session);
         });
-        setListeners(new Map(listeners.set("auth:update", removeAuthListener)));
 
         const removeBackendStatusListener = window.api.on("backend:status", (status) => {
             const previousStatus = globalStore.getState().backendStatus;
@@ -69,7 +57,12 @@ export function useGlobalEvents(
                 setBackendStatus(status);
             }
             if (status !== "online") return;
-            if (previousStatus !== "offline" && previousStatus !== "maintenance" && !isColdStartRestore) return;
+            if (
+                previousStatus !== "offline" &&
+                previousStatus !== "maintenance" &&
+                !isColdStartRestore
+            )
+                return;
 
             void (async () => {
                 try {
@@ -89,15 +82,18 @@ export function useGlobalEvents(
                 }
             })();
         });
-        setListeners(new Map(listeners.set("backend:status", removeBackendStatusListener)));
 
         const removeLanguageListener = window.api.on("language:update", (language) => {
             void i18n.changeLanguage(language);
         });
-        setListeners(new Map(listeners.set("language:update", removeLanguageListener)));
 
         return () => {
-            removeAllListeners();
+            removeToastListener();
+            removeNaviListener();
+            removePathSelectorListener();
+            removeAuthListener();
+            removeBackendStatusListener();
+            removeLanguageListener();
         };
     }, [onPathSelectorModeSelect, i18n]);
 }

--- a/src/renderer/src/hooks/use-mod-actions.tsx
+++ b/src/renderer/src/hooks/use-mod-actions.tsx
@@ -138,7 +138,6 @@ export function useModActions(selectedGroupPath?: string): ModActionApi {
       return;
     }
 
-    setRenameValue(getRenameDefaultValue(renameDialogState.mod.name));
     queueMicrotask(() => {
       renameInputRef.current?.focus();
       renameInputRef.current?.select();
@@ -382,7 +381,10 @@ export function useModActions(selectedGroupPath?: string): ModActionApi {
     openDeletePreview,
     openModelViewer,
     openPastePreview,
-    openRenameDialog: (mod) => setRenameDialogState({ mod, groupPath: selectedGroupPath }),
+    openRenameDialog: (mod) => {
+      setRenameValue(getRenameDefaultValue(mod.name));
+      setRenameDialogState({ mod, groupPath: selectedGroupPath });
+    },
     openTextureResizeDialog: (mod) => setTextureResizeMod(mod),
     openBodyShapeDialog: (mod) => setBodyShapeMod(mod),
     openTouchProfileDialog: (mod) => setTouchProfileMod(mod),

--- a/src/renderer/src/hooks/use-mod-drag-drop.ts
+++ b/src/renderer/src/hooks/use-mod-drag-drop.ts
@@ -31,9 +31,7 @@ export function useModDragDrop(
 
     if (groupPath !== prevGroupPath) {
         setPrevGroupPath(groupPath);
-        if (!groupPath && isDragging) {
-            setIsDragging(false);
-        }
+        setIsDragging(false);
     }
     const [archiveExtractDialogFileName, setArchiveExtractDialogFileName] = useState<string | null>(
         null,

--- a/src/renderer/src/hooks/use-mod-drag-drop.ts
+++ b/src/renderer/src/hooks/use-mod-drag-drop.ts
@@ -27,6 +27,14 @@ export function useModDragDrop(
 ) {
     const { t } = useTranslation();
     const [isDragging, setIsDragging] = useState(false);
+    const [prevGroupPath, setPrevGroupPath] = useState(groupPath);
+
+    if (groupPath !== prevGroupPath) {
+        setPrevGroupPath(groupPath);
+        if (!groupPath && isDragging) {
+            setIsDragging(false);
+        }
+    }
     const [archiveExtractDialogFileName, setArchiveExtractDialogFileName] = useState<string | null>(
         null,
     );
@@ -110,12 +118,6 @@ export function useModDragDrop(
             archivePromptQueueRef.current = [];
         };
     }, []);
-
-    useEffect(() => {
-        if (!groupPath) {
-            setIsDragging(false);
-        }
-    }, [groupPath]);
 
     const isArchive = (filePath: string): boolean => {
         const ext = path.extname(filePath).toLowerCase();

--- a/src/renderer/src/hooks/use-mod-fix-runner.tsx
+++ b/src/renderer/src/hooks/use-mod-fix-runner.tsx
@@ -7,7 +7,7 @@ import {
   type WuwaFixerPrepareResult,
   type FixToolLogEvent,
 } from "@shared/types";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -47,24 +47,48 @@ export function useModFixRunner() {
   const [showOptionsDialog, setShowOptionsDialog] = useState(false);
   const [optionsTab, setOptionsTab] = useState<"fix" | "rollback">("fix");
   const [logs, setLogs] = useState<string[]>([]);
+  const queryClient = useQueryClient();
   const [isRunning, setIsRunning] = useState(false);
   const [isPreparing, setIsPreparing] = useState(false);
   const [inputCmd, setInputCmd] = useState("");
   const [prepareResult, setPrepareResult] = useState<WuwaFixerPrepareResult | null>(null);
   const [wuwaOptions, setWuwaOptions] = useState<WuwaFixerOptions>(defaultWuwaOptions);
-  const [backupGroups, setBackupGroups] = useState<WuwaBackupGroup[]>([]);
-  const [backupSize, setBackupSize] = useState<WuwaBackupSize>({ bytes: 0, count: 0 });
-  const [isLoadingBackups, setIsLoadingBackups] = useState(false);
   const [isRollbackBusy, setIsRollbackBusy] = useState(false);
   const [pendingRollbackKey, setPendingRollbackKey] = useState<string | null>(null);
   const [showAdvancedRollback, setShowAdvancedRollback] = useState(false);
   const [showCleanConfirm, setShowCleanConfirm] = useState(false);
   const [cleanConfirmInput, setCleanConfirmInput] = useState("");
   const runInProgressRef = useRef(false);
-  const backupRefreshTokenRef = useRef(0);
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
   const translationKey = "page.mod.dialog.wuwa-fix-runner";
+
+  const { data: backupsData, isLoading: isLoadingBackups } = useQuery({
+    queryKey: ["wuwaFixer:backups", activeModPath],
+    queryFn: async () => {
+      if (!activeModPath) {
+        return {
+          groups: [] as WuwaBackupGroup[],
+          size: { bytes: 0, count: 0 } as WuwaBackupSize,
+        };
+      }
+      const [groups, size] = await Promise.all([
+        window.api.invoke("wuwaFixer:scanBackups", activeModPath),
+        window.api.invoke("wuwaFixer:getBackupSize", activeModPath),
+      ]);
+      return { groups, size };
+    },
+    enabled: showOptionsDialog && optionsTab === "rollback" && !!activeModPath,
+  });
+
+  const backupGroups = backupsData?.groups ?? [];
+  const backupSize = backupsData?.size ?? { bytes: 0, count: 0 };
+
+  const refreshBackups = useCallback(
+    async (modPath = activeModPath) => {
+      if (!modPath) return;
+      await queryClient.invalidateQueries({ queryKey: ["wuwaFixer:backups", modPath] });
+    },
+    [activeModPath, queryClient],
+  );
 
   useEffect(() => {
     if (!showLogModal) return;
@@ -79,62 +103,6 @@ export function useModFixRunner() {
     });
     return () => removeListener();
   }, [showLogModal]);
-
-  useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-    }
-  }, [logs]);
-
-  const refreshBackups = useCallback(
-    async (modPath = activeModPath) => {
-      const requestToken = ++backupRefreshTokenRef.current;
-      const isCurrent = () => backupRefreshTokenRef.current === requestToken;
-
-      if (!modPath) {
-        if (!isCurrent()) return;
-        setBackupGroups([]);
-        setBackupSize({ bytes: 0, count: 0 });
-        setPendingRollbackKey(null);
-        setShowCleanConfirm(false);
-        setCleanConfirmInput("");
-        setIsLoadingBackups(false);
-        return;
-      }
-
-      setIsLoadingBackups(true);
-      setPendingRollbackKey(null);
-      setShowCleanConfirm(false);
-      setCleanConfirmInput("");
-      try {
-        const [groups, size] = await Promise.all([
-          window.api.invoke("wuwaFixer:scanBackups", modPath),
-          window.api.invoke("wuwaFixer:getBackupSize", modPath),
-        ]);
-        if (!isCurrent()) return;
-        setBackupGroups(groups);
-        setBackupSize(size);
-      } catch (error) {
-        if (!isCurrent()) return;
-        setBackupGroups([]);
-        setBackupSize({ bytes: 0, count: 0 });
-        toast.error((error as Error).message);
-      } finally {
-        if (isCurrent()) {
-          setIsLoadingBackups(false);
-        }
-      }
-    },
-    [activeModPath],
-  );
-
-  useEffect(() => {
-    if (!showOptionsDialog || optionsTab !== "rollback") {
-      return;
-    }
-
-    void refreshBackups();
-  }, [showOptionsDialog, optionsTab, refreshBackups]);
 
   const handleRun = async (type: "tool" | "preset", id: string, modPath: string) => {
     if (runInProgressRef.current) {
@@ -355,8 +323,6 @@ export function useModFixRunner() {
     isPreparing,
     inputCmd,
     setInputCmd,
-    inputRef,
-    scrollRef,
     prepareResult,
     wuwaOptions,
     setWuwaOptions,

--- a/src/renderer/src/hooks/use-mod-shortcuts.ts
+++ b/src/renderer/src/hooks/use-mod-shortcuts.ts
@@ -1,26 +1,19 @@
 import { useModMutations } from "@renderer/hooks/use-mod-mutations";
-import { modStore, useModStore } from "@renderer/store/mod";
+import { modStore } from "@renderer/store/mod";
 import type { ModInfo } from "@renderer/types/mod";
 import { useEffect, useRef } from "react";
 
 export function useModShortcuts(searchQuery: string, filteredMods: ModInfo[]) {
     const latestSearchQueryRef = useRef(searchQuery);
     const latestFilteredModsRef = useRef(filteredMods);
-    const isMergeMode = useModStore((s) => s.isMergeMode);
-    const exitMergeMode = useModStore((s) => s.exitMergeMode);
-    const setSearchQuery = useModStore((s) => s.setSearchQuery);
-    const setSearchQueryRef = useRef(setSearchQuery);
     const { exclusiveToggleModMutation } = useModMutations();
     const exclusiveToggleRef = useRef(exclusiveToggleModMutation.mutate);
 
-    const isMergeModeRef = useRef(isMergeMode);
-    const exitMergeModeRef = useRef(exitMergeMode);
-    latestSearchQueryRef.current = searchQuery;
-    latestFilteredModsRef.current = filteredMods;
-    setSearchQueryRef.current = setSearchQuery;
-    exclusiveToggleRef.current = exclusiveToggleModMutation.mutate;
-    isMergeModeRef.current = isMergeMode;
-    exitMergeModeRef.current = exitMergeMode;
+    useEffect(() => {
+        latestSearchQueryRef.current = searchQuery;
+        latestFilteredModsRef.current = filteredMods;
+        exclusiveToggleRef.current = exclusiveToggleModMutation.mutate;
+    });
 
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
@@ -46,12 +39,16 @@ export function useModShortcuts(searchQuery: string, filteredMods: ModInfo[]) {
             }
 
             if (e.key === "Escape") {
-                if (e.defaultPrevented || !isMergeModeRef.current || hasOpenDialogOrOverlay()) {
+                if (
+                    e.defaultPrevented ||
+                    !modStore.getState().isMergeMode ||
+                    hasOpenDialogOrOverlay()
+                ) {
                     return;
                 }
 
                 e.preventDefault();
-                exitMergeModeRef.current();
+                modStore.getState().exitMergeMode();
                 return;
             }
 
@@ -59,7 +56,7 @@ export function useModShortcuts(searchQuery: string, filteredMods: ModInfo[]) {
                 return;
             }
 
-            if (isMergeModeRef.current) {
+            if (modStore.getState().isMergeMode) {
                 return;
             }
 
@@ -74,7 +71,7 @@ export function useModShortcuts(searchQuery: string, filteredMods: ModInfo[]) {
 
             e.preventDefault();
             exclusiveToggleRef.current(latestFilteredModsRef.current[0]);
-            setSearchQueryRef.current("");
+            modStore.getState().setSearchQuery("");
         };
 
         window.addEventListener("keydown", handleKeyDown);

--- a/src/renderer/src/hooks/use-mod-shortcuts.ts
+++ b/src/renderer/src/hooks/use-mod-shortcuts.ts
@@ -1,7 +1,7 @@
 import { useModMutations } from "@renderer/hooks/use-mod-mutations";
 import { modStore } from "@renderer/store/mod";
 import type { ModInfo } from "@renderer/types/mod";
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 
 export function useModShortcuts(searchQuery: string, filteredMods: ModInfo[]) {
     const latestSearchQueryRef = useRef(searchQuery);
@@ -9,7 +9,7 @@ export function useModShortcuts(searchQuery: string, filteredMods: ModInfo[]) {
     const { exclusiveToggleModMutation } = useModMutations();
     const exclusiveToggleRef = useRef(exclusiveToggleModMutation.mutate);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         latestSearchQueryRef.current = searchQuery;
         latestFilteredModsRef.current = filteredMods;
         exclusiveToggleRef.current = exclusiveToggleModMutation.mutate;

--- a/src/renderer/src/hooks/use-settings.ts
+++ b/src/renderer/src/hooks/use-settings.ts
@@ -92,9 +92,10 @@ export function useSettings<TConfig extends SettingsConfig>(settingsConfig: TCon
             key: K,
             updateValue: SettingUpdate<SettingsShape<TConfig>[K]>,
         ) => {
-            const currentSettings =
-                queryClient.getQueryData<SettingsShape<TConfig>>(queryKey) ??
-                ({} as SettingsShape<TConfig>);
+            const currentSettings = queryClient.getQueryData<SettingsShape<TConfig>>(queryKey);
+            if (currentSettings == null) {
+                return;
+            }
             const value =
                 typeof updateValue === "function"
                     ? (

--- a/src/renderer/src/hooks/use-settings.ts
+++ b/src/renderer/src/hooks/use-settings.ts
@@ -1,7 +1,7 @@
 import { getSetting, setSetting, settingsManyQueryKey } from "@renderer/lib/settings";
 import type { AppSettings, SettingKey } from "@shared/settings";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, type SetStateAction } from "react";
 
 type SettingsConfig = Record<string, SettingKey>;
 
@@ -70,48 +70,56 @@ export function useSettings<TConfig extends SettingsConfig>(settingsConfig: TCon
         refetchOnWindowFocus: false,
     });
 
-    const [settings, setSettings] = useState<SettingsShape<TConfig>>({} as SettingsShape<TConfig>);
-    const settingsRef = useRef(settings);
     const settingUpdateQueueRef = useRef(Promise.resolve());
-    const [isInitialized, setIsInitialized] = useState(false);
 
-    useEffect(() => {
-        if (data) {
-            settingsRef.current = data;
-            setSettings(data);
-            setIsInitialized(true);
-        }
-    }, [data]);
+    const setSettings = useCallback(
+        (action: SetStateAction<SettingsShape<TConfig>>) => {
+            queryClient.setQueryData<SettingsShape<TConfig>>(queryKey, (prev) => {
+                const current = prev ?? ({} as SettingsShape<TConfig>);
+                if (typeof action === "function") {
+                    return (action as (current: SettingsShape<TConfig>) => SettingsShape<TConfig>)(
+                        current,
+                    );
+                }
+                return action;
+            });
+        },
+        [queryClient, queryKey],
+    );
 
-    const update = async <K extends keyof TConfig>(
-        key: K,
-        updateValue: SettingUpdate<SettingsShape<TConfig>[K]>,
-    ) => {
-        const value =
-            typeof updateValue === "function"
-                ? (
-                      updateValue as (
-                          current: SettingsShape<TConfig>[K],
-                      ) => SettingsShape<TConfig>[K]
-                  )(settingsRef.current[key])
-                : updateValue;
-        const nextSettings = { ...settingsRef.current, [key]: value };
-        const singleSettingQueryKey = ["settings", settingsConfig[key]] as const;
-        settingsRef.current = nextSettings;
-        setSettings(nextSettings);
-        queryClient.setQueryData(queryKey, nextSettings);
-        queryClient.setQueryData<SettingsShape<TConfig>[K]>(singleSettingQueryKey, value);
-        const pendingUpdate = settingUpdateQueueRef.current
-            .catch(() => {})
-            .then(() => setSetting(settingsConfig[key], value));
-        settingUpdateQueueRef.current = pendingUpdate;
-        await pendingUpdate;
-    };
+    const update = useCallback(
+        async <K extends keyof TConfig>(
+            key: K,
+            updateValue: SettingUpdate<SettingsShape<TConfig>[K]>,
+        ) => {
+            const currentSettings =
+                queryClient.getQueryData<SettingsShape<TConfig>>(queryKey) ??
+                ({} as SettingsShape<TConfig>);
+            const value =
+                typeof updateValue === "function"
+                    ? (
+                          updateValue as (
+                              current: SettingsShape<TConfig>[K],
+                          ) => SettingsShape<TConfig>[K]
+                      )(currentSettings[key])
+                    : updateValue;
+            const nextSettings = { ...currentSettings, [key]: value };
+            const singleSettingQueryKey = ["settings", settingsConfig[key]] as const;
+            queryClient.setQueryData(queryKey, nextSettings);
+            queryClient.setQueryData<SettingsShape<TConfig>[K]>(singleSettingQueryKey, value);
+            const pendingUpdate = settingUpdateQueueRef.current
+                .catch(() => {})
+                .then(() => setSetting(settingsConfig[key], value));
+            settingUpdateQueueRef.current = pendingUpdate;
+            await pendingUpdate;
+        },
+        [queryClient, queryKey, settingsConfig],
+    );
 
     return {
-        settings,
+        settings: data ?? ({} as SettingsShape<TConfig>),
         update,
-        isLoading: isQueryLoading || !isInitialized,
+        isLoading: isQueryLoading || data === undefined,
         setSettings,
     };
 }

--- a/src/renderer/src/lib/generation-gate.test.ts
+++ b/src/renderer/src/lib/generation-gate.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { isCurrentRequest, resolveIfCurrent } from "./generation-gate";
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+    return { promise, resolve };
+}
+
+describe("generation-gate", () => {
+    it("resolves only the latest request", async () => {
+        const latestId = { current: 0 };
+        const first = deferred<string>();
+        const second = deferred<string>();
+
+        const firstId = ++latestId.current;
+        const firstResult = resolveIfCurrent(firstId, latestId, () => first.promise);
+        const secondId = ++latestId.current;
+        const secondResult = resolveIfCurrent(secondId, latestId, () => second.promise);
+
+        first.resolve("stale");
+        second.resolve("latest");
+
+        expect(await firstResult).toBeUndefined();
+        expect(await secondResult).toBe("latest");
+        expect(isCurrentRequest(firstId, latestId)).toBe(false);
+        expect(isCurrentRequest(secondId, latestId)).toBe(true);
+    });
+});

--- a/src/renderer/src/lib/generation-gate.ts
+++ b/src/renderer/src/lib/generation-gate.ts
@@ -1,0 +1,15 @@
+export function isCurrentRequest(requestId: number, latestId: { current: number }) {
+    return requestId === latestId.current;
+}
+
+export async function resolveIfCurrent<T>(
+    requestId: number,
+    latestId: { current: number },
+    work: () => Promise<T>,
+): Promise<T | undefined> {
+    const result = await work();
+    if (!isCurrentRequest(requestId, latestId)) {
+        return;
+    }
+    return result;
+}

--- a/src/renderer/src/routes/drive/drive.$id.tsx
+++ b/src/renderer/src/routes/drive/drive.$id.tsx
@@ -97,8 +97,9 @@ function RouteComponent() {
   }, [effectiveId, location.pathname]);
 
   const rawContents = useMemo(() => {
-    if (!query.data?.children) return [];
-    return commonSort([...query.data.children], sortType, nameSortPolicy);
+    const children = query.data?.children;
+    if (!children) return [];
+    return commonSort([...children], sortType, nameSortPolicy);
   }, [query.data?.children, sortType, nameSortPolicy]);
 
   const localContents = useMemo(() => {

--- a/src/renderer/src/routes/drive/share.$id.tsx
+++ b/src/renderer/src/routes/drive/share.$id.tsx
@@ -94,8 +94,9 @@ function RouteComponent() {
   }, [effectiveId, location.pathname]);
 
   const rawContents = useMemo(() => {
-    if (!query.data?.children) return [];
-    return commonSort([...query.data.children], sortType, nameSortPolicy);
+    const children = query.data?.children;
+    if (!children) return [];
+    return commonSort([...children], sortType, nameSortPolicy);
   }, [query.data?.children, sortType, nameSortPolicy]);
 
   const localContents = useMemo(() => {

--- a/src/renderer/src/routes/gamebanana/-panels/mod-detail-panel.tsx
+++ b/src/renderer/src/routes/gamebanana/-panels/mod-detail-panel.tsx
@@ -292,18 +292,6 @@ export function ModDetailPanel({
     }
   };
 
-  useEffect(() => {
-    setLightboxPreviewIndex(null);
-  }, [modOverviewQuery.data?.profile._idRow]);
-
-  useEffect(() => {
-    setCommentSort("popular");
-  }, [modId, modelName]);
-
-  useEffect(() => {
-    setLikeOverride((current) => (current?.key === likeOperationKey ? current : null));
-  }, [likeOperationKey]);
-
   const comments = useMemo(() => {
     const seen = new Set<number>();
 

--- a/src/renderer/src/routes/gamebanana/index.tsx
+++ b/src/renderer/src/routes/gamebanana/index.tsx
@@ -573,6 +573,7 @@ function RouteComponent() {
 
             {isViewingMod && (
               <ModDetailPanel
+                key={selectedMod ? `${selectedMod.modelName}:${selectedMod.id}` : undefined}
                 t={t}
                 language={i18n.language}
                 selection={selectedMod}

--- a/src/renderer/src/routes/mod/index.tsx
+++ b/src/renderer/src/routes/mod/index.tsx
@@ -32,7 +32,7 @@ import { modStore, useModStore } from "@renderer/store/mod";
 import { findGameByImporter, type ResolvedArchiveExtractPathMode } from "@shared/mod";
 import type { FolderGroup } from "@shared/types";
 import { createFileRoute } from "@tanstack/react-router";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 export const Route = createFileRoute("/mod/")({
@@ -77,7 +77,7 @@ function ModRouteContent() {
   const { data: games = [] } = useGames();
   const { data: characters = [] } = useCharacters(selectedGame);
   const { settings: downloadTargetSettings } = useSettings(downloadTargetSettingsConfig);
-  const [pendingDownloadTarget, setPendingDownloadTarget] = useState<{
+  const pendingDownloadTargetRef = useRef<{
     downloadId: string;
     game: string;
     group: FolderGroup;
@@ -245,11 +245,11 @@ function ModRouteContent() {
         const targetGame = gameByImporter ?? result.game;
         setSelectedGame(targetGame);
         void window.api.invoke("mod:setLastGame", targetGame);
-        setPendingDownloadTarget({
+        pendingDownloadTargetRef.current = {
           downloadId,
           game: targetGame,
           group: result.group,
-        });
+        };
         resolvedDownloadIdsRef.current.add(downloadId);
         return;
       }
@@ -283,36 +283,32 @@ function ModRouteContent() {
   ]);
 
   useEffect(() => {
-    if (!pendingDownloadTarget) return;
-    if (downloadMode?.downloadId !== pendingDownloadTarget.downloadId) {
-      setPendingDownloadTarget(null);
+    const pendingTarget = pendingDownloadTargetRef.current;
+    if (!pendingTarget) return;
+    if (downloadMode?.downloadId !== pendingTarget.downloadId || userSelectedDuringDownload) {
+      pendingDownloadTargetRef.current = null;
       return;
     }
-    if (selectedGame !== pendingDownloadTarget.game) return;
-    if (userSelectedDuringDownload) {
-      setPendingDownloadTarget(null);
-      return;
-    }
+    if (selectedGame !== pendingTarget.game) return;
 
     const isTargetAvailable = characters.some(
       (group) =>
-        group.path === pendingDownloadTarget.group.path ||
-        pendingDownloadTarget.group.path.startsWith(`${group.path}\\`) ||
-        pendingDownloadTarget.group.path.startsWith(`${group.path}/`),
+        group.path === pendingTarget.group.path ||
+        pendingTarget.group.path.startsWith(`${group.path}\\`) ||
+        pendingTarget.group.path.startsWith(`${group.path}/`),
     );
     if (!isTargetAvailable) return;
 
-    const parentGroupPath = getParentGroupPath(pendingDownloadTarget.group.path);
+    const parentGroupPath = getParentGroupPath(pendingTarget.group.path);
     if (parentGroupPath && characters.some((group) => group.path === parentGroupPath)) {
       setExpandedGroup(parentGroupPath, true);
     }
 
-    setSelectedGroup(pendingDownloadTarget.group);
-    setPendingDownloadTarget(null);
+    setSelectedGroup(pendingTarget.group);
+    pendingDownloadTargetRef.current = null;
   }, [
     characters,
     downloadMode?.downloadId,
-    pendingDownloadTarget,
     selectedGame,
     setExpandedGroup,
     setSelectedGroup,
@@ -320,7 +316,7 @@ function ModRouteContent() {
   ]);
 
   useEffect(() => {
-    if (pendingDownloadTarget) return;
+    if (pendingDownloadTargetRef.current) return;
     if (downloadMode) return;
 
     if (characters.length > 0) {
@@ -341,7 +337,7 @@ function ModRouteContent() {
     } else {
       setSelectedGroup(null);
     }
-  }, [characters, pendingDownloadTarget, selectedGroupPath, setSelectedGroup, downloadMode]);
+  }, [characters, selectedGroupPath, setSelectedGroup, downloadMode]);
 
   useEffect(() => {
     if (selectedGame) {

--- a/src/renderer/src/routes/mod/index.tsx
+++ b/src/renderer/src/routes/mod/index.tsx
@@ -32,7 +32,7 @@ import { modStore, useModStore } from "@renderer/store/mod";
 import { findGameByImporter, type ResolvedArchiveExtractPathMode } from "@shared/mod";
 import type { FolderGroup } from "@shared/types";
 import { createFileRoute } from "@tanstack/react-router";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 export const Route = createFileRoute("/mod/")({
@@ -82,6 +82,7 @@ function ModRouteContent() {
     game: string;
     group: FolderGroup;
   } | null>(null);
+  const [pendingTargetVersion, setPendingTargetVersion] = useState(0);
   const resolvedDownloadIdsRef = useRef(new Set<string>());
 
   useModRefreshOnFocus(selectedGame, queryClient);
@@ -250,6 +251,7 @@ function ModRouteContent() {
           game: targetGame,
           group: result.group,
         };
+        setPendingTargetVersion((version) => version + 1);
         resolvedDownloadIdsRef.current.add(downloadId);
         return;
       }
@@ -309,6 +311,7 @@ function ModRouteContent() {
   }, [
     characters,
     downloadMode?.downloadId,
+    pendingTargetVersion,
     selectedGame,
     setExpandedGroup,
     setSelectedGroup,
@@ -337,7 +340,7 @@ function ModRouteContent() {
     } else {
       setSelectedGroup(null);
     }
-  }, [characters, selectedGroupPath, setSelectedGroup, downloadMode]);
+  }, [characters, downloadMode, pendingTargetVersion, selectedGroupPath, setSelectedGroup]);
 
   useEffect(() => {
     if (selectedGame) {

--- a/src/renderer/src/store/mod.ts
+++ b/src/renderer/src/store/mod.ts
@@ -4,6 +4,7 @@ import { createStore, useStore } from "zustand";
 
 export type FolderSortKey = "name" | "mod-count" | "enabled-mod-count";
 export type FolderSortDirection = "ascending" | "descending";
+export type DownloadMode = NonNullable<ModState["downloadMode"]>;
 
 interface ModState {
     selectedGame: string;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches many user-facing dialogs, overlays, and async tool loaders. Behavior should be equivalent, but remount/reset and request-generation changes can introduce regressions in open/close and stale-response handling.
> 
> **Overview**
> Clears oxlint React warnings across the renderer by changing how UI state is reset and how async work is cancelled, not by adding features.
> 
> **Dialogs and overlays** (download confirm, drive import, add/edit game, merge mods, model viewer) now mount inner content only when open, keyed by session identity, instead of resetting form/tree state in `useEffect`. Several fetches move to React Query (`merge` classification, XXMI DLL versions, model-viewer manifests).
> 
> **Derived state** uses the “adjust during render” pattern (`prevX` + setState) instead of syncing props in effects—random 1619 image, delayed skeleton, update notes, body-shape/touch-profile/texture-resizer target paths, and similar.
> 
> **Stale loads** in texture resizer and touch profile are gated with `isCurrentRequest` / `resolveIfCurrent`, with tests for out-of-order responses. Breadcrumb navigation drops non-null assertions. `react/incompatible-library` is turned off in `.oxlintrc.json`; remaining Three.js mutations get targeted `oxlint-disable` comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a650468a8423d91df04575506d16aad49640668. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when navigating breadcrumbs, selecting games, groups, zones, and components.
  * Fixed download, import, edit, merge, and rename dialogs so state resets correctly when reopened.
  * Improved model, texture, body-shape, and touch-profile loading behavior.
  * Prevented stale update and release information from appearing during refreshes.
* **Improvements**
  * Enhanced automatic scrolling in fixer logs.
  * Improved settings, backup, DLL version, and manifest loading with clearer loading and error handling.
  * Preserved random image selections and recent preview content more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->