### PR TITLE
feat(xxmi): prompt before disabling GIMI DCR

### DIFF
--- a/frontend/src/components/mod/game-preset-selector.tsx
+++ b/frontend/src/components/mod/game-preset-selector.tsx
@@ -10,6 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@renderer/components/ui/select";
+import { useGimiDCRLaunch } from "@renderer/hooks/use-gimi-dcr-launch";
 import { useEnabledImporters, usePresets } from "@renderer/hooks/use-mod-data";
 import { useModStore } from "@renderer/store/mod";
 import { isNteImporter } from "@shared/mod";
@@ -80,6 +81,7 @@ export const GamePresetSelector = memo(function GamePresetSelector({
 
   const { data: presets = [] } = usePresets(selectedGame);
   const { data: enabledImporters = [] } = useEnabledImporters();
+  const { startImporter, gimiDCRDialog } = useGimiDCRLaunch();
   const { data: xxmiData } = useQuery({
     queryKey: ["xxmi:getXXMIData"],
     queryFn: () => XXMI.GetXXMIData(),
@@ -140,8 +142,8 @@ export const GamePresetSelector = memo(function GamePresetSelector({
       return;
     }
 
-    await XXMI.StartGame(selectedImporter).catch((err) => {
-      toast.error(err.toString());
+    await startImporter(selectedImporter).catch((err) => {
+      toast.error(toErrorMessage(err));
     });
   };
 
@@ -251,6 +253,7 @@ export const GamePresetSelector = memo(function GamePresetSelector({
       />
 
       <NteLaunchDialog />
+      {gimiDCRDialog}
     </div>
   );
 });

--- a/frontend/src/components/setting/xxmi/xxmi-importers.tsx
+++ b/frontend/src/components/setting/xxmi/xxmi-importers.tsx
@@ -1,7 +1,8 @@
-import { XXMI } from "@bindings/xxmi";
 import { GameIcon } from "@renderer/components/game-icon";
+import { useGimiDCRLaunch } from "@renderer/hooks/use-gimi-dcr-launch";
 import { cn } from "@renderer/lib/utils";
 import type { XXMIData } from "@renderer/routes/setting/xxmi";
+import { toErrorMessage } from "@shared/utils";
 import { Loader2Icon } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -10,6 +11,7 @@ import { toast } from "sonner";
 export function XXMIImporters({ xxmiData }: { xxmiData?: XXMIData }) {
   const { t } = useTranslation();
   const [processingKey, setProcessingKey] = useState<string | null>(null);
+  const { startImporter, gimiDCRDialog } = useGimiDCRLaunch();
 
   if (!xxmiData?.xxmiConfig) {
     return null;
@@ -20,9 +22,9 @@ export function XXMIImporters({ xxmiData }: { xxmiData?: XXMIData }) {
 
     setProcessingKey(key);
     try {
-      await XXMI.StartGame(key);
+      await startImporter(key);
     } catch (error) {
-      toast.error((error as Error).toString());
+      toast.error(toErrorMessage(error));
     } finally {
       setProcessingKey(null);
     }
@@ -63,6 +65,7 @@ export function XXMIImporters({ xxmiData }: { xxmiData?: XXMIData }) {
           );
         })}
       </div>
+      {gimiDCRDialog}
     </div>
   );
 }

--- a/frontend/src/hooks/use-gimi-dcr-launch.tsx
+++ b/frontend/src/hooks/use-gimi-dcr-launch.tsx
@@ -1,0 +1,90 @@
+import { XXMI } from "@bindings/xxmi";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@renderer/components/ui/alert-dialog";
+import { toErrorMessage } from "@shared/utils";
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+const GIMI_DCR_ENABLED = "GIMI_DCR_ENABLED";
+
+export function useGimiDCRLaunch() {
+  const { t } = useTranslation();
+  const [pendingImporter, setPendingImporter] = useState<string | null>(null);
+  const [isConfirming, setIsConfirming] = useState(false);
+
+  const startImporter = useCallback(async (importer: string) => {
+    try {
+      await XXMI.StartGame(importer);
+    } catch (error) {
+      if (toErrorMessage(error).includes(GIMI_DCR_ENABLED)) {
+        setPendingImporter(importer);
+        return;
+      }
+      throw error;
+    }
+  }, []);
+
+  const closeDialog = useCallback(() => {
+    if (isConfirming) {
+      return;
+    }
+    setPendingImporter(null);
+  }, [isConfirming]);
+
+  const handleConfirm = useCallback(async () => {
+    if (!pendingImporter) {
+      return;
+    }
+    const importer = pendingImporter;
+    setIsConfirming(true);
+    try {
+      await XXMI.DisableGenshinDynamicCharacterResolution();
+      await XXMI.StartGame(importer);
+      setPendingImporter(null);
+    } catch (error) {
+      toast.error(toErrorMessage(error));
+    } finally {
+      setIsConfirming(false);
+    }
+  }, [pendingImporter]);
+
+  const dialog = useMemo(
+    () => (
+      <AlertDialog
+        open={pendingImporter !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            closeDialog();
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("page.mod.dialog.gimi-dcr.title")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("page.mod.dialog.gimi-dcr.description")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isConfirming}>{t("g.cancel")}</AlertDialogCancel>
+            <AlertDialogAction disabled={isConfirming} onClickPromise={handleConfirm}>
+              {t("page.mod.dialog.gimi-dcr.confirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    ),
+    [closeDialog, handleConfirm, isConfirming, pendingImporter, t],
+  );
+
+  return { startImporter, gimiDCRDialog: dialog };
+}

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -437,6 +437,11 @@
           "path_required": "Please select a launcher path.",
           "launch": "Save and launch launcher"
         },
+        "gimi-dcr": {
+          "title": "Dynamic Character Resolution is on",
+          "description": "Mods in Genshin Impact will not apply correctly unless Dynamic Character Resolution is off. Turn it off and start the game?",
+          "confirm": "Turn off and start"
+        },
         "preset-management": {
           "legacy-badge": "Legacy",
           "legacy-description": "This preset uses the old format and cannot be applied. Delete and recreate it."

--- a/frontend/src/lib/i18n/locales/ja.json
+++ b/frontend/src/lib/i18n/locales/ja.json
@@ -418,6 +418,11 @@
           "path_required": "ランチャーのパスを選択してください。",
           "launch": "保存してランチャーを起動"
         },
+        "gimi-dcr": {
+          "title": "キャラクター動的解像度がオンです",
+          "description": "原神でMODを正常に適用するには、キャラクター動的解像度をオフにする必要があります。オフにしてゲームを起動しますか？",
+          "confirm": "オフにして起動"
+        },
         "preset-management": {
           "description": "このプリセットには {{length}} 個のMODが保存されています。",
           "legacy-badge": "旧形式",

--- a/frontend/src/lib/i18n/locales/ko.json
+++ b/frontend/src/lib/i18n/locales/ko.json
@@ -420,6 +420,11 @@
           "path_required": "런처 경로를 선택해 주세요.",
           "launch": "저장 후 런처 실행"
         },
+        "gimi-dcr": {
+          "title": "캐릭터 동적 해상도가 켜져 있습니다",
+          "description": "원신에서 모드가 정상적으로 적용되려면 캐릭터 동적 해상도가 꺼져 있어야 합니다. 끄고 게임을 실행할까요?",
+          "confirm": "끄고 실행"
+        },
         "preset-management": {
           "description": "이 프리셋에는 {{length}}개의 모드가 저장되어 있습니다.",
           "legacy-badge": "레거시",

--- a/frontend/src/lib/i18n/locales/zh.json
+++ b/frontend/src/lib/i18n/locales/zh.json
@@ -417,6 +417,11 @@
           "path_required": "请选择启动器路径。",
           "launch": "保存并启动启动器"
         },
+        "gimi-dcr": {
+          "title": "动态角色分辨率已开启",
+          "description": "要在原神中正常应用模组，需要关闭动态角色分辨率。要关闭并启动游戏吗？",
+          "confirm": "关闭并启动"
+        },
         "preset-management": {
           "description": "此预设包含 {{length}} 个模组。",
           "legacy-badge": "旧版",

--- a/internal/xxmi/dcr.go
+++ b/internal/xxmi/dcr.go
@@ -96,6 +96,9 @@ func (x *XXMI) rejectEnabledGimiDCR(ctx context.Context, importer string) error 
 		return err
 	}
 	if data.dcrEnabled() {
+		if x.log != nil {
+			x.log.Info(fmt.Sprintf("Rejected StartGame at DCR check for importer %s", importer), xxmiCheckDCRWhere)
+		}
 		return errGimiDCREnabled
 	}
 	return nil

--- a/internal/xxmi/dcr.go
+++ b/internal/xxmi/dcr.go
@@ -1,0 +1,289 @@
+package xxmi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	genshinDCRSettingKey     = 21
+	genshinDCREnabledValue   = 2
+	genshinDCRDisabledValue  = 1
+	genshinDCREnabledIndex   = 1
+	genshinDCRDisabledIndex  = 0
+	genshinDCRItemVersion    = "OSRELWin5.0.0"
+	genshinGraphicsDataKey   = "graphicsData"
+	genshinGlobalPerfDataKey = "globalPerfData"
+	genshinVolatileGradesKey = "customVolatileGrades"
+	genshinSaveItemsKey      = "saveItems"
+	xxmiCheckDCRWhere        = "XXMI.checkDCR"
+	xxmiDisableDCRWhere      = "XXMI.disableDCR"
+	gimiImporterKey          = "GIMI"
+)
+
+var errGimiDCREnabled = errors.New("GIMI_DCR_ENABLED")
+
+type volatileGrade struct {
+	Key   int `json:"key"`
+	Value int `json:"value"`
+}
+
+type saveItem struct {
+	EntryType   int    `json:"entryType"`
+	Index       int    `json:"index"`
+	ItemVersion string `json:"itemVersion"`
+}
+
+type genshinGeneralData struct {
+	settings       map[string]json.RawMessage
+	graphicsData   map[string]json.RawMessage
+	globalPerfData map[string]json.RawMessage
+	grades         []volatileGrade
+	saveItems      []saveItem
+}
+
+func (x *XXMI) DisableGenshinDynamicCharacterResolution(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	raw, err := readGenshinRegistryGeneralData()
+	if err != nil {
+		x.logDCRError(fmt.Sprintf("Failed to read Genshin Impact graphics settings: %v", err), xxmiDisableDCRWhere)
+		return err
+	}
+	data, err := parseGenshinGeneralData(raw)
+	if err != nil {
+		x.logDCRError(fmt.Sprintf("Failed to parse Genshin Impact graphics settings: %v", err), xxmiDisableDCRWhere)
+		return err
+	}
+	if !data.disableDCR() {
+		return nil
+	}
+	encoded, err := data.encode()
+	if err != nil {
+		x.logDCRError(fmt.Sprintf("Failed to encode Genshin Impact graphics settings: %v", err), xxmiDisableDCRWhere)
+		return err
+	}
+	if x.log != nil {
+		x.log.Info("Disabling Genshin Impact Dynamic Character Resolution", xxmiDisableDCRWhere)
+	}
+	if err := writeGenshinRegistryGeneralData(encoded); err != nil {
+		x.logDCRError(fmt.Sprintf("Failed to write Genshin Impact graphics settings: %v", err), xxmiDisableDCRWhere)
+		return err
+	}
+	return nil
+}
+
+func (x *XXMI) rejectEnabledGimiDCR(ctx context.Context, importer string) error {
+	if !strings.EqualFold(importer, gimiImporterKey) {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	raw, err := readGenshinRegistryGeneralData()
+	if err != nil {
+		x.logDCRError(fmt.Sprintf("Failed to read Genshin Impact graphics settings: %v", err), xxmiCheckDCRWhere)
+		return err
+	}
+	data, err := parseGenshinGeneralData(raw)
+	if err != nil {
+		x.logDCRError(fmt.Sprintf("Failed to parse Genshin Impact graphics settings: %v", err), xxmiCheckDCRWhere)
+		return err
+	}
+	if data.dcrEnabled() {
+		return errGimiDCREnabled
+	}
+	return nil
+}
+
+func (x *XXMI) logDCRError(message, where string) {
+	if x != nil && x.log != nil {
+		x.log.Error(message, where)
+	}
+}
+
+func parseGenshinGeneralData(raw []byte) (*genshinGeneralData, error) {
+	payload := stripNullTerminator(raw)
+	if len(payload) == 0 {
+		return nil, errors.New("genshin impact graphics settings are empty")
+	}
+	if !isASCII(payload) {
+		return nil, errors.New("genshin impact graphics settings are not ASCII")
+	}
+	var settings map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &settings); err != nil {
+		return nil, fmt.Errorf("genshin impact graphics settings are not JSON: %w", err)
+	}
+	graphicsData, err := unmarshalNestedObject(settings, genshinGraphicsDataKey)
+	if err != nil {
+		return nil, err
+	}
+	grades, err := unmarshalObjectSlice[volatileGrade](graphicsData, genshinGraphicsDataKey, genshinVolatileGradesKey)
+	if err != nil {
+		return nil, err
+	}
+	globalPerfData, err := unmarshalNestedObject(settings, genshinGlobalPerfDataKey)
+	if err != nil {
+		return nil, err
+	}
+	saveItems, err := unmarshalObjectSlice[saveItem](globalPerfData, genshinGlobalPerfDataKey, genshinSaveItemsKey)
+	if err != nil {
+		return nil, err
+	}
+	return &genshinGeneralData{
+		settings:       settings,
+		graphicsData:   graphicsData,
+		globalPerfData: globalPerfData,
+		grades:         grades,
+		saveItems:      saveItems,
+	}, nil
+}
+
+func (d *genshinGeneralData) dcrEnabled() bool {
+	for _, entry := range d.grades {
+		if entry.Key == genshinDCRSettingKey && entry.Value == genshinDCREnabledValue {
+			return true
+		}
+	}
+	for _, entry := range d.saveItems {
+		if entry.EntryType == genshinDCRSettingKey && entry.Index == genshinDCREnabledIndex {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *genshinGeneralData) disableDCR() bool {
+	updated := false
+	foundGrade := false
+	for i, entry := range d.grades {
+		if entry.Key != genshinDCRSettingKey {
+			continue
+		}
+		foundGrade = true
+		if entry.Value == genshinDCREnabledValue {
+			d.grades[i].Value = genshinDCRDisabledValue
+			updated = true
+		}
+	}
+	if !foundGrade {
+		d.grades = append(d.grades, volatileGrade{Key: genshinDCRSettingKey, Value: genshinDCRDisabledValue})
+		updated = true
+	}
+	foundItem := false
+	for i, entry := range d.saveItems {
+		if entry.EntryType != genshinDCRSettingKey {
+			continue
+		}
+		foundItem = true
+		if entry.Index == genshinDCREnabledIndex {
+			d.saveItems[i].Index = genshinDCRDisabledIndex
+			d.saveItems[i].ItemVersion = genshinDCRItemVersion
+			updated = true
+		}
+	}
+	if !foundItem {
+		d.saveItems = append(d.saveItems, saveItem{
+			EntryType:   genshinDCRSettingKey,
+			Index:       genshinDCRDisabledIndex,
+			ItemVersion: genshinDCRItemVersion,
+		})
+		updated = true
+	}
+	return updated
+}
+
+func (d *genshinGeneralData) encode() ([]byte, error) {
+	gradesRaw, err := marshalCompact(d.grades)
+	if err != nil {
+		return nil, err
+	}
+	d.graphicsData[genshinVolatileGradesKey] = gradesRaw
+	itemsRaw, err := marshalCompact(d.saveItems)
+	if err != nil {
+		return nil, err
+	}
+	d.globalPerfData[genshinSaveItemsKey] = itemsRaw
+	graphicsJSON, err := marshalCompact(d.graphicsData)
+	if err != nil {
+		return nil, err
+	}
+	perfJSON, err := marshalCompact(d.globalPerfData)
+	if err != nil {
+		return nil, err
+	}
+	graphicsString, err := json.Marshal(string(graphicsJSON))
+	if err != nil {
+		return nil, err
+	}
+	perfString, err := json.Marshal(string(perfJSON))
+	if err != nil {
+		return nil, err
+	}
+	d.settings[genshinGraphicsDataKey] = graphicsString
+	d.settings[genshinGlobalPerfDataKey] = perfString
+	outer, err := marshalCompact(d.settings)
+	if err != nil {
+		return nil, err
+	}
+	return append(outer, 0), nil
+}
+
+func unmarshalNestedObject(settings map[string]json.RawMessage, key string) (map[string]json.RawMessage, error) {
+	raw, ok := settings[key]
+	if !ok {
+		return nil, fmt.Errorf("unknown graphics settings format: %q key not found", key)
+	}
+	var encoded string
+	if err := json.Unmarshal(raw, &encoded); err != nil {
+		return nil, fmt.Errorf("unknown graphics settings format: %q is not a JSON string", key)
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(encoded), &object); err != nil {
+		return nil, fmt.Errorf("unknown graphics settings format: %q is not JSON: %w", key, err)
+	}
+	return object, nil
+}
+
+func unmarshalObjectSlice[T any](object map[string]json.RawMessage, parent, key string) ([]T, error) {
+	raw, ok := object[key]
+	if !ok {
+		return nil, fmt.Errorf("unknown graphics settings format: %q.%s key not found", parent, key)
+	}
+	var items []T
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil, fmt.Errorf("unknown graphics settings format: %q.%s is not an array", parent, key)
+	}
+	return items, nil
+}
+
+func stripNullTerminator(raw []byte) []byte {
+	if i := bytes.IndexByte(raw, 0); i >= 0 {
+		return raw[:i]
+	}
+	return raw
+}
+
+func isASCII(raw []byte) bool {
+	for _, b := range raw {
+		if b > 127 {
+			return false
+		}
+	}
+	return true
+}
+
+func marshalCompact(value any) ([]byte, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return nil, err
+	}
+	return bytes.TrimSuffix(buf.Bytes(), []byte("\n")), nil
+}

--- a/internal/xxmi/dcr_test.go
+++ b/internal/xxmi/dcr_test.go
@@ -1,0 +1,209 @@
+package xxmi
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestParseGenshinGeneralDataDetectsDCR(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		grades  []volatileGrade
+		items   []saveItem
+		enabled bool
+	}{
+		{
+			name:    "enabled in both records",
+			grades:  []volatileGrade{{Key: 21, Value: 2}},
+			items:   []saveItem{{EntryType: 21, Index: 1, ItemVersion: "OSRELWin5.0.0"}},
+			enabled: true,
+		},
+		{
+			name:    "enabled only in volatile grades",
+			grades:  []volatileGrade{{Key: 1, Value: 1}, {Key: 21, Value: 2}},
+			items:   []saveItem{{EntryType: 21, Index: 0, ItemVersion: "OSRELWin5.0.0"}},
+			enabled: true,
+		},
+		{
+			name:    "enabled only in save items",
+			grades:  []volatileGrade{{Key: 21, Value: 1}},
+			items:   []saveItem{{EntryType: 7, Index: 0}, {EntryType: 21, Index: 1}},
+			enabled: true,
+		},
+		{
+			name:    "already disabled",
+			grades:  []volatileGrade{{Key: 21, Value: 1}},
+			items:   []saveItem{{EntryType: 21, Index: 0, ItemVersion: "OSRELWin5.0.0"}},
+			enabled: false,
+		},
+		{
+			name:    "dcr keys absent",
+			grades:  []volatileGrade{{Key: 1, Value: 1}},
+			items:   []saveItem{{EntryType: 7, Index: 0}},
+			enabled: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			data, err := parseGenshinGeneralData(mustEncodeGeneralData(t, tc.grades, tc.items))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if enabled := data.dcrEnabled(); enabled != tc.enabled {
+				t.Fatalf("dcrEnabled = %v, want %v", enabled, tc.enabled)
+			}
+		})
+	}
+}
+
+func TestParseGenshinGeneralDataStripsNullTerminator(t *testing.T) {
+	t.Parallel()
+	raw := mustEncodeGeneralData(t,
+		[]volatileGrade{{Key: 21, Value: 1}},
+		[]saveItem{{EntryType: 21, Index: 0}},
+	)
+	if !bytes.HasSuffix(raw, []byte{0}) {
+		t.Fatal("fixture is not null-terminated")
+	}
+	if _, err := parseGenshinGeneralData(raw); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseGenshinGeneralData(bytes.TrimSuffix(raw, []byte{0})); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseGenshinGeneralDataRejectsUnknownShape(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "empty", raw: nil},
+		{name: "non ascii", raw: []byte("{\"graphicsData\":\"\xff\"}\x00")},
+		{name: "not json", raw: []byte("not-json\x00")},
+		{name: "missing graphicsData", raw: []byte(`{"globalPerfData":"{}"}`)},
+		{name: "missing globalPerfData", raw: []byte(`{"graphicsData":"{}"}`)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := parseGenshinGeneralData(tc.raw); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestDisableDCRMutatesEnabledSettings(t *testing.T) {
+	t.Parallel()
+	data, err := parseGenshinGeneralData(mustEncodeGeneralData(t,
+		[]volatileGrade{{Key: 21, Value: 2}, {Key: 3, Value: 4}},
+		[]saveItem{{EntryType: 21, Index: 1, ItemVersion: "old"}},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated := data.disableDCR(); !updated {
+		t.Fatal("disableDCR = false, want true")
+	}
+	if data.dcrEnabled() {
+		t.Fatal("dcrEnabled after disable")
+	}
+	encoded, err := data.encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.HasSuffix(encoded, []byte{0}) {
+		t.Fatal("encoded settings are not null-terminated")
+	}
+	roundTrip, err := parseGenshinGeneralData(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if roundTrip.dcrEnabled() {
+		t.Fatal("round-trip dcrEnabled")
+	}
+	if len(roundTrip.grades) != 2 || roundTrip.grades[0].Value != genshinDCRDisabledValue {
+		t.Fatalf("grades = %+v", roundTrip.grades)
+	}
+	if roundTrip.saveItems[0].Index != genshinDCRDisabledIndex || roundTrip.saveItems[0].ItemVersion != genshinDCRItemVersion {
+		t.Fatalf("save item = %+v", roundTrip.saveItems[0])
+	}
+}
+
+func TestDisableDCRAppendsMissingEntries(t *testing.T) {
+	t.Parallel()
+	data, err := parseGenshinGeneralData(mustEncodeGeneralData(t,
+		[]volatileGrade{{Key: 1, Value: 1}},
+		[]saveItem{{EntryType: 7, Index: 0}},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated := data.disableDCR(); !updated {
+		t.Fatal("disableDCR = false, want true")
+	}
+	if data.dcrEnabled() {
+		t.Fatal("dcrEnabled after append")
+	}
+	encoded, err := data.encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	roundTrip, err := parseGenshinGeneralData(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roundTrip.grades) != 2 {
+		t.Fatalf("grades = %+v", roundTrip.grades)
+	}
+	last := roundTrip.grades[1]
+	if last.Key != genshinDCRSettingKey || last.Value != genshinDCRDisabledValue {
+		t.Fatalf("appended grade = %+v", last)
+	}
+}
+
+func TestDisableDCRSkipsAlreadyDisabledSettings(t *testing.T) {
+	t.Parallel()
+	data, err := parseGenshinGeneralData(mustEncodeGeneralData(t,
+		[]volatileGrade{{Key: 21, Value: 1}},
+		[]saveItem{{EntryType: 21, Index: 0, ItemVersion: genshinDCRItemVersion}},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated := data.disableDCR(); updated {
+		t.Fatal("disableDCR = true, want false")
+	}
+}
+
+func TestRejectEnabledGimiDCRSkipsNonGIMI(t *testing.T) {
+	t.Parallel()
+	if err := New().rejectEnabledGimiDCR(t.Context(), "WWMI"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustEncodeGeneralData(t *testing.T, grades []volatileGrade, items []saveItem) []byte {
+	t.Helper()
+	graphics, err := json.Marshal(map[string]any{genshinVolatileGradesKey: grades})
+	if err != nil {
+		t.Fatal(err)
+	}
+	perf, err := json.Marshal(map[string]any{genshinSaveItemsKey: items})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outer, err := json.Marshal(map[string]any{
+		genshinGraphicsDataKey:   string(graphics),
+		genshinGlobalPerfDataKey: string(perf),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append(outer, 0)
+}

--- a/internal/xxmi/dcr_windows.go
+++ b/internal/xxmi/dcr_windows.go
@@ -1,0 +1,66 @@
+//go:build windows
+
+package xxmi
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+const genshinGeneralDataValue = "GENERAL_DATA_h2389025596"
+
+var genshinRegistryKeys = []string{
+	`SOFTWARE\miHoYo\Genshin Impact`,
+	`SOFTWARE\miHoYo\原神`,
+}
+
+func readGenshinRegistryGeneralData() ([]byte, error) {
+	key, err := openGenshinSettingsKey(registry.QUERY_VALUE)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = key.Close() }()
+	raw, valueType, err := key.GetBinaryValue(genshinGeneralDataValue)
+	if err != nil {
+		if errors.Is(err, registry.ErrNotExist) {
+			return nil, errors.New("graphics settings record is not found in genshin impact registry")
+		}
+		if errors.Is(err, registry.ErrUnexpectedType) {
+			return nil, fmt.Errorf("unknown settings format: data type %d is not REG_BINARY", valueType)
+		}
+		return nil, fmt.Errorf("read Genshin Impact graphics settings: %w", err)
+	}
+	return raw, nil
+}
+
+func writeGenshinRegistryGeneralData(raw []byte) error {
+	key, err := openGenshinSettingsKey(registry.SET_VALUE)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = key.Close() }()
+	if err := key.SetBinaryValue(genshinGeneralDataValue, raw); err != nil {
+		return fmt.Errorf("write Genshin Impact graphics settings: %w", err)
+	}
+	return nil
+}
+
+func openGenshinSettingsKey(access uint32) (registry.Key, error) {
+	var lastErr error
+	for _, path := range genshinRegistryKeys {
+		key, err := registry.OpenKey(registry.CURRENT_USER, path, access)
+		if err == nil {
+			return key, nil
+		}
+		lastErr = err
+	}
+	if lastErr != nil && errors.Is(lastErr, registry.ErrNotExist) {
+		return 0, errors.New("genshin impact registry key is not found")
+	}
+	if lastErr != nil {
+		return 0, fmt.Errorf("open Genshin Impact registry key: %w", lastErr)
+	}
+	return 0, errors.New("genshin impact registry key is not found")
+}

--- a/internal/xxmi/start_game.go
+++ b/internal/xxmi/start_game.go
@@ -15,6 +15,9 @@ func (x *XXMI) StartGame(ctx context.Context, importer string) error {
 	if importer == "" {
 		return errors.New("importer is required")
 	}
+	if err := x.rejectEnabledGimiDCR(ctx, importer); err != nil {
+		return err
+	}
 	x.mu.Lock()
 	if x.busy {
 		x.mu.Unlock()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> User-confirmed writes to Genshin Impact graphics settings in the Windows registry; incorrect parsing or encoding could affect in-game graphics, though changes are scoped to DCR and covered by tests.
> 
> **Overview**
> **GIMI launches** now go through shared `useGimiDCRLaunch` logic in the mod play button and XXMI importer settings, instead of calling `XXMI.StartGame` directly. Launch errors use `toErrorMessage` for consistent toasts.
> 
> When **Genshin Impact’s Dynamic Character Resolution (DCR)** is on, `StartGame` for the **GIMI** importer fails with `GIMI_DCR_ENABLED` before launch. The UI shows a localized confirm dialog; accepting runs `DisableGenshinDynamicCharacterResolution` and retries launch.
> 
> The **backend** adds Windows registry read/write for Genshin `GENERAL_DATA` graphics JSON (detect/disable DCR in volatile grades and save items), hooks the check into `StartGame`, and includes unit tests for parsing and mutation. Dialog copy is added for **en, ja, ko, and zh**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 576219d40023e4fb25235870c9873328c300a722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warning when Genshin Impact’s Dynamic Character Resolution is enabled.
  * Users can disable the setting directly from the warning dialog before launching an importer.
  * Added localized dialog text in English, Japanese, Korean, and Chinese.

* **Bug Fixes**
  * Improved launch error messages for clearer, more consistent feedback.
  * Prevented mod launches when Dynamic Character Resolution would interfere with proper mod application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->