### PR TITLE
perf(model-viewer): bound position memory usage

### DIFF
--- a/frontend/src/components/tools/model-viewer/model-viewer-payload.test.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-payload.test.ts
@@ -52,6 +52,24 @@ function evalState(shapeWeights: Record<string, number>): EvaluatedViewerState {
     };
 }
 
+function variantEval(positionVariantIndex: number | null): EvaluatedViewerState {
+    return {
+        state: {},
+        meshes: [
+            {
+                id: "mesh",
+                visible: true,
+                texKey: null,
+                normalMapKey: null,
+                lightMapKey: null,
+                materialMapKey: null,
+                shapeWeights: {},
+                positionVariantIndex,
+            },
+        ],
+    };
+}
+
 describe("applyPayloadEval midpoint targets", () => {
     it("excludes malformed midpoint endpoints from the deformation divisor", () => {
         const mesh = meshWithTargets(
@@ -275,6 +293,43 @@ describe("lazy payload position variants", () => {
         expect(visible.userData.normalCache).toHaveLength(1);
     });
 
+    it("does not mutate geometry when loading the requested variant fails", async () => {
+        const mesh = meshWithTargets([1, 2, 3], []);
+        mesh.userData.positionVariants = [
+            { conditions: [], sourceUrl: "/broken.buf", stride: 40, sourceBytes: 40 },
+        ];
+        const root = new Group();
+        root.add(mesh);
+        const loader: PositionVariantLoader = {
+            load: async () => {
+                throw new Error("decode failed");
+            },
+        };
+
+        await expect(preparePayloadEval(root, variantEval(0), loader)).rejects.toThrow(
+            "decode failed",
+        );
+        expect(Array.from(mesh.geometry.attributes.position.array)).toEqual([1, 2, 3]);
+        expect(mesh.userData.lastPositionVariantIndex).toBeUndefined();
+    });
+
+    it("ignores prepared positions whose length does not match the geometry", () => {
+        const mesh = meshWithTargets([1, 2, 3], []);
+        const root = new Group();
+        root.add(mesh);
+
+        commitPayloadEval(root, {
+            evalResult: variantEval(0),
+            positions: new Map([
+                ["mesh", { variantIndex: 0, positions: new Float32Array([9, 8]) }],
+            ]),
+        });
+
+        expect(Array.from(mesh.geometry.attributes.position.array)).toEqual([1, 2, 3]);
+        expect(mesh.userData.lastPositionVariantIndex).toBeUndefined();
+        expect(mesh.userData.normalCache).toHaveLength(0);
+    });
+
     it("bounds each mesh normal cache to the current and previous position", () => {
         const mesh = meshWithTargets([0, 0, 0], []);
         mesh.userData.positionVariants = [
@@ -286,21 +341,7 @@ describe("lazy payload position variants", () => {
         root.add(mesh);
         for (let variantIndex = 0; variantIndex < 3; variantIndex++) {
             commitPayloadEval(root, {
-                evalResult: {
-                    state: {},
-                    meshes: [
-                        {
-                            id: "mesh",
-                            visible: true,
-                            texKey: null,
-                            normalMapKey: null,
-                            lightMapKey: null,
-                            materialMapKey: null,
-                            shapeWeights: {},
-                            positionVariantIndex: variantIndex,
-                        },
-                    ],
-                },
+                evalResult: variantEval(variantIndex),
                 positions: new Map([
                     [
                         "mesh",

--- a/frontend/src/components/tools/model-viewer/model-viewer-payload.test.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-payload.test.ts
@@ -1,8 +1,15 @@
 import type { EvaluatedViewerState } from "@shared/mod-viewer/types";
 import { BufferAttribute, BufferGeometry, Group, Mesh, MeshStandardMaterial, Texture } from "three";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { applyPayloadEval } from "./model-viewer-payload";
+import type { PositionVariantLoader } from "./model-viewer-position-loader";
+
+import {
+    applyPayloadEval,
+    clearPayloadModelData,
+    commitPayloadEval,
+    preparePayloadEval,
+} from "./model-viewer-payload";
 
 function meshWithTargets(
     base: number[],
@@ -22,7 +29,7 @@ function meshWithTargets(
         basePositions: new Float32Array(base),
         shapeTargets,
         positionVariants: [],
-        normalCache: new Map(),
+        normalCache: [],
     };
     return mesh;
 }
@@ -131,7 +138,7 @@ describe("applyPayloadEval packed maps", () => {
             basePositions: new Float32Array(9),
             shapeTargets: [],
             positionVariants: [],
-            normalCache: new Map(),
+            normalCache: [],
             materialProfile: "zzmi",
         };
         const diffuse = new Texture();
@@ -207,5 +214,132 @@ describe("applyPayloadEval packed maps", () => {
         });
 
         expect((mesh.material as MeshStandardMaterial).normalMap).toBeNull();
+    });
+});
+
+describe("lazy payload position variants", () => {
+    it("requests only the active variant of visible meshes and commits atomically", async () => {
+        const visible = meshWithTargets([0, 0, 0], []);
+        visible.userData.meshId = "visible";
+        visible.userData.positionVariants = [
+            { conditions: [], sourceUrl: "/visible.buf", stride: 40, sourceBytes: 40 },
+        ];
+        const hidden = meshWithTargets([0, 0, 0], []);
+        hidden.userData.meshId = "hidden";
+        hidden.userData.positionVariants = [
+            { conditions: [], sourceUrl: "/hidden.buf", stride: 40, sourceBytes: 40 },
+        ];
+        const root = new Group();
+        root.add(visible, hidden);
+        const requested: string[] = [];
+        const loader: PositionVariantLoader = {
+            load: async (variant) => {
+                requested.push(variant.sourceUrl);
+                return new Float32Array([9, 8, 7]);
+            },
+        };
+        const evaluated: EvaluatedViewerState = {
+            state: {},
+            meshes: [
+                {
+                    id: "visible",
+                    visible: true,
+                    texKey: null,
+                    normalMapKey: null,
+                    lightMapKey: null,
+                    materialMapKey: null,
+                    shapeWeights: {},
+                    positionVariantIndex: 0,
+                },
+                {
+                    id: "hidden",
+                    visible: false,
+                    texKey: null,
+                    normalMapKey: null,
+                    lightMapKey: null,
+                    materialMapKey: null,
+                    shapeWeights: {},
+                    positionVariantIndex: 0,
+                },
+            ],
+        };
+
+        const prepared = await preparePayloadEval(root, evaluated, loader);
+        expect(requested).toEqual(["/visible.buf"]);
+        expect(Array.from(visible.geometry.attributes.position.array)).toEqual([0, 0, 0]);
+        expect(hidden.visible).toBe(true);
+
+        commitPayloadEval(root, prepared);
+        expect(Array.from(visible.geometry.attributes.position.array)).toEqual([9, 8, 7]);
+        expect(hidden.visible).toBe(false);
+        expect(visible.userData.normalCache).toHaveLength(1);
+    });
+
+    it("bounds each mesh normal cache to the current and previous position", () => {
+        const mesh = meshWithTargets([0, 0, 0], []);
+        mesh.userData.positionVariants = [
+            { conditions: [], sourceUrl: "/0.buf", stride: 40, sourceBytes: 40 },
+            { conditions: [], sourceUrl: "/1.buf", stride: 40, sourceBytes: 40 },
+            { conditions: [], sourceUrl: "/2.buf", stride: 40, sourceBytes: 40 },
+        ];
+        const root = new Group();
+        root.add(mesh);
+        for (let variantIndex = 0; variantIndex < 3; variantIndex++) {
+            commitPayloadEval(root, {
+                evalResult: {
+                    state: {},
+                    meshes: [
+                        {
+                            id: "mesh",
+                            visible: true,
+                            texKey: null,
+                            normalMapKey: null,
+                            lightMapKey: null,
+                            materialMapKey: null,
+                            shapeWeights: {},
+                            positionVariantIndex: variantIndex,
+                        },
+                    ],
+                },
+                positions: new Map([
+                    [
+                        "mesh",
+                        {
+                            variantIndex,
+                            positions: new Float32Array([variantIndex, 0, 0]),
+                        },
+                    ],
+                ]),
+            });
+        }
+        expect(mesh.userData.normalCache).toHaveLength(2);
+        expect(mesh.userData.normalCache.map((entry: { key: number }) => entry.key)).toEqual([
+            2, 1,
+        ]);
+    });
+
+    it("clears payload arrays, caches, and every root texture during disposal", () => {
+        const mesh = meshWithTargets(
+            [1, 2, 3],
+            [{ var: "shape", positions: new Float32Array([4, 5, 6]) }],
+        );
+        mesh.userData.positionVariants = [
+            { conditions: [], sourceUrl: "/0.buf", stride: 40, sourceBytes: 40 },
+        ];
+        mesh.userData.normalCache = [{ key: 0, normal: new Float32Array(3) }];
+        const texture = new Texture();
+        const dispose = vi.spyOn(texture, "dispose");
+        const root = new Group();
+        root.userData.payloadTextures = new Map([["unused-variant", texture]]);
+        root.add(mesh);
+
+        clearPayloadModelData(root);
+
+        expect(dispose).toHaveBeenCalledOnce();
+        expect(root.userData.payloadTextures).toBeUndefined();
+        expect(mesh.userData.basePositions).toHaveLength(0);
+        expect(mesh.userData.shapeTargets).toHaveLength(0);
+        expect(mesh.userData.positionVariants).toHaveLength(0);
+        expect(mesh.userData.normalCache).toHaveLength(0);
     });
 });

--- a/frontend/src/components/tools/model-viewer/model-viewer-payload.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-payload.ts
@@ -19,6 +19,8 @@ import {
 } from "three";
 import type { WebGLProgramParametersWithUniforms } from "three";
 
+import type { PositionVariantLoader } from "./model-viewer-position-loader";
+
 type PayloadMeshUserData = {
     meshId: string;
     basePositions: Float32Array;
@@ -28,8 +30,9 @@ type PayloadMeshUserData = {
         mode?: "midpoint_pair";
         lowPositions?: Float32Array;
     }>;
-    positionVariants: Float32Array[];
-    normalCache: Map<number, Float32Array>;
+    positionVariants: ViewerMeshTransport["positionVariants"];
+    sourceIndicesUrl?: string;
+    normalCache: Array<{ key: number; normal: Float32Array }>;
     materialProfile?: ModViewerTransport["materialProfile"];
     lastPositionVariantIndex?: number | null;
     lastMaps?: {
@@ -42,10 +45,16 @@ type PayloadMeshUserData = {
 
 const textureLoader = new TextureLoader();
 
+export type PreparedPayloadEval = {
+    evalResult: EvaluatedViewerState;
+    positions: Map<string, { variantIndex: number; positions: Float32Array }>;
+};
+
 export async function buildPayloadModel(
     transport: ModViewerTransport,
     evalResult: EvaluatedViewerState,
     doubleSided: boolean,
+    positionLoader: PositionVariantLoader,
 ): Promise<Group> {
     const textureCache = new Map<string, Promise<Texture | null>>();
     const textures = new Map<string, Texture>();
@@ -63,47 +72,97 @@ export async function buildPayloadModel(
     const group = new Group();
     group.userData.payloadTextures = textures;
     const evalById = new Map(evalResult.meshes.map((mesh) => [mesh.id, mesh]));
-    for (const mesh of transport.meshes) {
-        const geometry = await buildGeometry(mesh);
-        const material = new MeshStandardMaterial({
-            color: 0xffffff,
-            metalness: 0.05,
-            roughness: 0.65,
-            side: doubleSided ? DoubleSide : undefined,
-        });
-        const object = new Mesh(geometry, material);
-        object.name = mesh.id;
-        const evaluated = evalById.get(mesh.id);
-        object.visible = evaluated?.visible ?? true;
-        object.userData = {
-            meshId: mesh.id,
-            basePositions: new Float32Array(geometry.attributes.position.array as Float32Array),
-            shapeTargets: await Promise.all(
-                mesh.shapeTargets.map(async (target) => ({
-                    var: target.var,
-                    positions: await fetchFloat32(target.positionsUrl),
-                    mode: target.mode,
-                    lowPositions: target.lowPositionsUrl
-                        ? await fetchFloat32(target.lowPositionsUrl)
-                        : undefined,
-                })),
-            ),
-            positionVariants: await Promise.all(
-                mesh.positionVariants.map((variant) => fetchFloat32(variant.positionsUrl)),
-            ),
-            normalCache: new Map(),
-            materialProfile: transport.materialProfile,
-            lastPositionVariantIndex: null,
-        } satisfies PayloadMeshUserData;
-        applyEvaluatedMesh(object, evaluated, textures);
-        group.add(object);
+    try {
+        for (const mesh of transport.meshes) {
+            const geometry = await buildGeometry(mesh);
+            const material = new MeshStandardMaterial({
+                color: 0xffffff,
+                metalness: 0.05,
+                roughness: 0.65,
+                side: doubleSided ? DoubleSide : undefined,
+            });
+            const object = new Mesh(geometry, material);
+            object.name = mesh.id;
+            const evaluated = evalById.get(mesh.id);
+            object.visible = evaluated?.visible ?? true;
+            group.add(object);
+            object.userData = {
+                meshId: mesh.id,
+                basePositions: new Float32Array(geometry.attributes.position.array as Float32Array),
+                shapeTargets: await Promise.all(
+                    mesh.shapeTargets.map(async (target) => ({
+                        var: target.var,
+                        positions: await fetchFloat32(target.positionsUrl),
+                        mode: target.mode,
+                        lowPositions: target.lowPositionsUrl
+                            ? await fetchFloat32(target.lowPositionsUrl)
+                            : undefined,
+                    })),
+                ),
+                positionVariants: [...mesh.positionVariants],
+                sourceIndicesUrl: mesh.sourceIndicesUrl,
+                normalCache: [],
+                materialProfile: transport.materialProfile,
+            } satisfies PayloadMeshUserData;
+        }
+        commitPayloadEval(group, await preparePayloadEval(group, evalResult, positionLoader));
+        return group;
+    } catch (error) {
+        disposeIncompletePayloadModel(group);
+        throw error;
     }
-    return group;
 }
 
 export function applyPayloadEval(root: Object3D, evalResult: EvaluatedViewerState): void {
+    commitPayloadEval(root, { evalResult, positions: new Map() });
+}
+
+export async function preparePayloadEval(
+    root: Object3D,
+    evalResult: EvaluatedViewerState,
+    positionLoader: PositionVariantLoader,
+    signal?: AbortSignal,
+    forcePositions = false,
+): Promise<PreparedPayloadEval> {
+    const evaluatedById = new Map(evalResult.meshes.map((mesh) => [mesh.id, mesh]));
+    const requests: Array<Promise<[string, { variantIndex: number; positions: Float32Array }]>> =
+        [];
+    root.traverse((object) => {
+        if (!(object instanceof Mesh)) {
+            return;
+        }
+        const userData = object.userData as PayloadMeshUserData;
+        const evaluated = evaluatedById.get(userData.meshId);
+        const variantIndex = evaluated?.positionVariantIndex;
+        if (
+            !evaluated?.visible ||
+            variantIndex === null ||
+            variantIndex === undefined ||
+            (!forcePositions && userData.lastPositionVariantIndex === variantIndex)
+        ) {
+            return;
+        }
+        const descriptor = userData.positionVariants[variantIndex];
+        if (!descriptor) {
+            return;
+        }
+        requests.push(
+            positionLoader
+                .load(
+                    descriptor,
+                    userData.sourceIndicesUrl,
+                    userData.basePositions.length / 3,
+                    signal,
+                )
+                .then((positions) => [userData.meshId, { variantIndex, positions }]),
+        );
+    });
+    return { evalResult, positions: new Map(await Promise.all(requests)) };
+}
+
+export function commitPayloadEval(root: Object3D, prepared: PreparedPayloadEval): void {
     const textures = root.userData.payloadTextures as Map<string, Texture> | undefined;
-    const evalById = new Map(evalResult.meshes.map((mesh) => [mesh.id, mesh]));
+    const evalById = new Map(prepared.evalResult.meshes.map((mesh) => [mesh.id, mesh]));
     root.traverse((object) => {
         if (!(object instanceof Mesh)) {
             return;
@@ -112,14 +171,56 @@ export function applyPayloadEval(root: Object3D, evalResult: EvaluatedViewerStat
         if (!meshId) {
             return;
         }
-        applyEvaluatedMesh(object, evalById.get(meshId), textures);
+        applyEvaluatedMesh(object, evalById.get(meshId), textures, prepared.positions.get(meshId));
     });
+}
+
+export function clearPayloadModelData(root: Object3D): void {
+    const textures = root.userData.payloadTextures as Map<string, Texture> | undefined;
+    for (const texture of textures?.values() ?? []) {
+        texture.dispose();
+    }
+    textures?.clear();
+    delete root.userData.payloadTextures;
+    root.traverse((object) => {
+        if (!(object instanceof Mesh) || !object.userData.meshId) {
+            return;
+        }
+        const userData = object.userData as PayloadMeshUserData;
+        userData.basePositions = new Float32Array();
+        userData.shapeTargets.length = 0;
+        userData.positionVariants.length = 0;
+        userData.normalCache.length = 0;
+        userData.lastMaps = undefined;
+        userData.lastPositionVariantIndex = undefined;
+    });
+}
+
+function disposeIncompletePayloadModel(root: Object3D): void {
+    root.traverse((object) => {
+        if (!(object instanceof Mesh)) {
+            return;
+        }
+        object.geometry.dispose();
+        for (const material of Array.isArray(object.material)
+            ? object.material
+            : [object.material]) {
+            for (const value of Object.values(material)) {
+                if (value instanceof Texture) {
+                    value.dispose();
+                }
+            }
+            material.dispose();
+        }
+    });
+    clearPayloadModelData(root);
 }
 
 function applyEvaluatedMesh(
     object: Mesh,
     evaluated: EvaluatedViewerState["meshes"][number] | undefined,
     textures?: Map<string, Texture>,
+    preparedPosition?: { variantIndex: number; positions: Float32Array },
 ): void {
     if (!evaluated) {
         return;
@@ -129,7 +230,7 @@ function applyEvaluatedMesh(
         return;
     }
     const userData = object.userData as PayloadMeshUserData;
-    applyPositionVariant(object, userData, evaluated.positionVariantIndex);
+    applyPositionVariant(object, userData, evaluated.positionVariantIndex, preparedPosition);
     const material = object.material;
     if (material instanceof MeshStandardMaterial && textures) {
         applyEvaluatedMaps(material, object, userData, evaluated, textures);
@@ -221,6 +322,7 @@ function applyPositionVariant(
     object: Mesh,
     userData: PayloadMeshUserData,
     variantIndex: number | null,
+    prepared?: { variantIndex: number; positions: Float32Array },
 ): void {
     if (userData.lastPositionVariantIndex === variantIndex) {
         return;
@@ -228,14 +330,19 @@ function applyPositionVariant(
     const next =
         variantIndex === null
             ? userData.basePositions
-            : (userData.positionVariants[variantIndex] ?? userData.basePositions);
+            : prepared?.variantIndex === variantIndex
+              ? prepared.positions
+              : undefined;
+    if (!next || next.length !== userData.basePositions.length) {
+        return;
+    }
     const position = object.geometry.attributes.position;
-    position.array.set(next.length === position.array.length ? next : userData.basePositions);
+    position.array.set(next);
     position.needsUpdate = true;
     userData.lastPositionVariantIndex = variantIndex;
 
     const cacheKey = variantIndex ?? -1;
-    const cached = userData.normalCache.get(cacheKey);
+    const cached = userData.normalCache.find((entry) => entry.key === cacheKey)?.normal;
     const normal = object.geometry.attributes.normal;
     if (cached && normal) {
         normal.array.set(cached);
@@ -245,7 +352,10 @@ function applyPositionVariant(
     // Animation frames reuse these meshes; cache normals instead of recomputing every tick.
     object.geometry.computeVertexNormals();
     if (normal) {
-        userData.normalCache.set(cacheKey, new Float32Array(normal.array as Float32Array));
+        userData.normalCache = [
+            { key: cacheKey, normal: new Float32Array(normal.array as Float32Array) },
+            ...userData.normalCache.filter((entry) => entry.key !== cacheKey),
+        ].slice(0, 2);
     }
 }
 

--- a/frontend/src/components/tools/model-viewer/model-viewer-position-codec.test.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-position-codec.test.ts
@@ -31,6 +31,14 @@ describe("model viewer position decoder", () => {
         ]);
     });
 
+    it("rejects source indices beyond the available records", () => {
+        const source = positionSource([[1, 2, 3]], 40);
+
+        expect(() => decodeModelViewerPositions(source, 40, new Uint32Array([1]), 1)).toThrow(
+            RangeError,
+        );
+    });
+
     it("keeps the combined raw cache within its byte limit", () => {
         const cache = new ModelViewerByteLRU(10);
         cache.set("first", new ArrayBuffer(6));

--- a/frontend/src/components/tools/model-viewer/model-viewer-position-codec.test.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-position-codec.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { decodeModelViewerPositions, ModelViewerByteLRU } from "./model-viewer-position-codec";
+
+function positionSource(values: Array<[number, number, number]>, stride: number) {
+    const buffer = new ArrayBuffer(values.length * stride);
+    const view = new DataView(buffer);
+    for (const [index, value] of values.entries()) {
+        view.setFloat32(index * stride, value[0], true);
+        view.setFloat32(index * stride + 4, value[1], true);
+        view.setFloat32(index * stride + 8, value[2], true);
+    }
+    return buffer;
+}
+
+describe("model viewer position decoder", () => {
+    it("applies the source stride and compact source-index mapping", () => {
+        const source = positionSource(
+            [
+                [1, 2, 3],
+                [4, 5, 6],
+                [7, 8, 9],
+            ],
+            40,
+        );
+        expect(
+            Array.from(decodeModelViewerPositions(source, 40, new Uint32Array([2, 0]), 2)),
+        ).toEqual([7, 8, 9, 1, 2, 3]);
+        expect(Array.from(decodeModelViewerPositions(source, 40, undefined, 3))).toEqual([
+            1, 2, 3, 4, 5, 6, 7, 8, 9,
+        ]);
+    });
+
+    it("keeps the combined raw cache within its byte limit", () => {
+        const cache = new ModelViewerByteLRU(10);
+        cache.set("first", new ArrayBuffer(6));
+        cache.set("second", new ArrayBuffer(6));
+        expect(cache.sizeBytes).toBe(6);
+        expect(cache.get("first")).toBeUndefined();
+        expect(cache.get("second")?.byteLength).toBe(6);
+
+        cache.set("oversized", new ArrayBuffer(11));
+        expect(cache.sizeBytes).toBe(6);
+        expect(cache.get("oversized")).toBeUndefined();
+    });
+});

--- a/frontend/src/components/tools/model-viewer/model-viewer-position-codec.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-position-codec.ts
@@ -19,7 +19,9 @@ export function decodeModelViewerPositions(
         const sourceIndex = sourceIndices?.[outputIndex] ?? outputIndex;
         const offset = sourceIndex * stride;
         if (offset + 12 > source.byteLength) {
-            continue;
+            throw new RangeError(
+                `Model viewer position source index ${sourceIndex} exceeds the available source records`,
+            );
         }
         positions[outputIndex * 3] = view.getFloat32(offset, true);
         positions[outputIndex * 3 + 1] = view.getFloat32(offset + 4, true);

--- a/frontend/src/components/tools/model-viewer/model-viewer-position-codec.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-position-codec.ts
@@ -1,0 +1,80 @@
+export const MODEL_VIEWER_POSITION_CACHE_BYTES = 64 * 1024 * 1024;
+
+export function decodeModelViewerPositions(
+    source: ArrayBuffer,
+    stride: number,
+    sourceIndices: Uint32Array | undefined,
+    vertexCount: number,
+): Float32Array {
+    if (!Number.isInteger(stride) || stride < 12) {
+        throw new RangeError(`Invalid model viewer position stride: ${stride}`);
+    }
+    const count = sourceIndices?.length ?? vertexCount;
+    if (!Number.isInteger(count) || count < 0) {
+        throw new RangeError(`Invalid model viewer vertex count: ${count}`);
+    }
+    const view = new DataView(source);
+    const positions = new Float32Array(count * 3);
+    for (let outputIndex = 0; outputIndex < count; outputIndex++) {
+        const sourceIndex = sourceIndices?.[outputIndex] ?? outputIndex;
+        const offset = sourceIndex * stride;
+        if (offset + 12 > source.byteLength) {
+            continue;
+        }
+        positions[outputIndex * 3] = view.getFloat32(offset, true);
+        positions[outputIndex * 3 + 1] = view.getFloat32(offset + 4, true);
+        positions[outputIndex * 3 + 2] = view.getFloat32(offset + 8, true);
+    }
+    return positions;
+}
+
+export class ModelViewerByteLRU {
+    readonly limit: number;
+    private readonly entries = new Map<string, ArrayBuffer>();
+    private bytes = 0;
+
+    constructor(limit = MODEL_VIEWER_POSITION_CACHE_BYTES) {
+        this.limit = limit;
+    }
+
+    get sizeBytes(): number {
+        return this.bytes;
+    }
+
+    get(key: string): ArrayBuffer | undefined {
+        const value = this.entries.get(key);
+        if (!value) {
+            return undefined;
+        }
+        this.entries.delete(key);
+        this.entries.set(key, value);
+        return value;
+    }
+
+    set(key: string, value: ArrayBuffer): void {
+        const previous = this.entries.get(key);
+        if (previous) {
+            this.bytes -= previous.byteLength;
+            this.entries.delete(key);
+        }
+        if (value.byteLength > this.limit) {
+            return;
+        }
+        while (this.bytes + value.byteLength > this.limit) {
+            const oldest = this.entries.keys().next().value as string | undefined;
+            if (oldest === undefined) {
+                break;
+            }
+            const removed = this.entries.get(oldest);
+            this.entries.delete(oldest);
+            this.bytes -= removed?.byteLength ?? 0;
+        }
+        this.entries.set(key, value);
+        this.bytes += value.byteLength;
+    }
+
+    clear(): void {
+        this.entries.clear();
+        this.bytes = 0;
+    }
+}

--- a/frontend/src/components/tools/model-viewer/model-viewer-position-loader.test.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-position-loader.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ModelViewerPositionLoader } from "./model-viewer-position-loader";
+
+class FakeWorker {
+    onmessage: Worker["onmessage"] = null;
+    onerror: Worker["onerror"] = null;
+    messages: unknown[] = [];
+    terminate = vi.fn();
+
+    postMessage(message: unknown) {
+        this.messages.push(message);
+    }
+}
+
+const descriptor = {
+    conditions: [],
+    sourceUrl: "/source.buf",
+    stride: 40,
+    sourceBytes: 80,
+};
+
+describe("ModelViewerPositionLoader", () => {
+    it("cancels pending work and ignores a late worker result", async () => {
+        const worker = new FakeWorker();
+        const loader = new ModelViewerPositionLoader(worker);
+        const controller = new AbortController();
+        const request = loader.load(descriptor, "/indices", 2, controller.signal);
+        controller.abort();
+
+        await expect(request).rejects.toMatchObject({ name: "AbortError" });
+        expect(worker.messages).toEqual([
+            expect.objectContaining({ type: "decode", sourceUrl: "/source.buf" }),
+            expect.objectContaining({ type: "cancel" }),
+        ]);
+        worker.onmessage?.(
+            new MessageEvent("message", {
+                data: { type: "decoded", id: 1, positions: new Float32Array(6).buffer },
+            }),
+        );
+        loader.dispose();
+        expect(worker.terminate).toHaveBeenCalledOnce();
+    });
+
+    it("terminates the worker and rejects every pending request on dispose", async () => {
+        const worker = new FakeWorker();
+        const loader = new ModelViewerPositionLoader(worker);
+        const request = loader.load(descriptor, undefined, 2);
+        loader.dispose();
+
+        await expect(request).rejects.toMatchObject({ name: "AbortError" });
+        expect(worker.terminate).toHaveBeenCalledOnce();
+    });
+
+    it("becomes terminal when the worker itself fails", async () => {
+        const worker = new FakeWorker();
+        const loader = new ModelViewerPositionLoader(worker);
+        const pending = loader.load(descriptor, undefined, 2);
+        worker.onerror?.(new ErrorEvent("error", { message: "worker initialization failed" }));
+
+        await expect(pending).rejects.toThrow("worker initialization failed");
+        await expect(loader.load(descriptor, undefined, 2)).rejects.toThrow(
+            "Model viewer position loader is disposed",
+        );
+        expect(worker.terminate).toHaveBeenCalledOnce();
+    });
+});

--- a/frontend/src/components/tools/model-viewer/model-viewer-position-loader.test.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-position-loader.test.ts
@@ -21,6 +21,23 @@ const descriptor = {
 };
 
 describe("ModelViewerPositionLoader", () => {
+    it("resolves the request matching the decoded worker message id", async () => {
+        const worker = new FakeWorker();
+        const loader = new ModelViewerPositionLoader(worker);
+        const request = loader.load(descriptor, undefined, 2);
+        const message = worker.messages[0] as { id: number };
+        const positions = new Float32Array([1, 2, 3, 4, 5, 6]);
+
+        worker.onmessage?.(
+            new MessageEvent("message", {
+                data: { type: "decoded", id: message.id, positions: positions.buffer },
+            }),
+        );
+
+        await expect(request).resolves.toEqual(positions);
+        loader.dispose();
+    });
+
     it("cancels pending work and ignores a late worker result", async () => {
         const worker = new FakeWorker();
         const loader = new ModelViewerPositionLoader(worker);

--- a/frontend/src/components/tools/model-viewer/model-viewer-position-loader.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-position-loader.ts
@@ -1,0 +1,122 @@
+import type { ViewerMeshTransport } from "@shared/mod-viewer/types";
+
+type PositionDescriptor = ViewerMeshTransport["positionVariants"][number];
+
+type PositionWorker = Pick<Worker, "onmessage" | "onerror" | "postMessage" | "terminate">;
+
+type PendingRequest = {
+    resolve: (positions: Float32Array) => void;
+    reject: (error: Error) => void;
+    removeAbortListener?: () => void;
+};
+
+export interface PositionVariantLoader {
+    load(
+        descriptor: PositionDescriptor,
+        sourceIndicesUrl: string | undefined,
+        vertexCount: number,
+        signal?: AbortSignal,
+    ): Promise<Float32Array>;
+}
+
+export class ModelViewerPositionLoader implements PositionVariantLoader {
+    private readonly worker: PositionWorker;
+    private readonly pending = new Map<number, PendingRequest>();
+    private nextId = 1;
+    private disposed = false;
+
+    constructor(
+        worker: PositionWorker = new Worker(
+            new URL("./model-viewer-position.worker.ts", import.meta.url),
+            { type: "module" },
+        ),
+    ) {
+        this.worker = worker;
+        this.worker.onmessage = (event: MessageEvent) => {
+            const message = event.data as
+                | { type: "decoded"; id: number; positions: ArrayBuffer }
+                | { type: "error"; id: number; message: string };
+            const request = this.pending.get(message.id);
+            if (!request) {
+                return;
+            }
+            this.pending.delete(message.id);
+            request.removeAbortListener?.();
+            if (message.type === "decoded") {
+                request.resolve(new Float32Array(message.positions));
+            } else {
+                request.reject(new Error(message.message));
+            }
+        };
+        this.worker.onerror = (event) => {
+            if (this.disposed) {
+                return;
+            }
+            this.disposed = true;
+            this.rejectAll(new Error(event.message || "Model viewer position worker failed"));
+            this.worker.terminate();
+        };
+    }
+
+    load(
+        descriptor: PositionDescriptor,
+        sourceIndicesUrl: string | undefined,
+        vertexCount: number,
+        signal?: AbortSignal,
+    ): Promise<Float32Array> {
+        if (this.disposed) {
+            return Promise.reject(new Error("Model viewer position loader is disposed"));
+        }
+        if (signal?.aborted) {
+            return Promise.reject(abortError());
+        }
+        const id = this.nextId++;
+        return new Promise<Float32Array>((resolve, reject) => {
+            const abort = () => {
+                if (!this.pending.delete(id)) {
+                    return;
+                }
+                this.worker.postMessage({ type: "cancel", id });
+                reject(abortError());
+            };
+            this.pending.set(id, {
+                resolve,
+                reject,
+                removeAbortListener: signal
+                    ? () => signal.removeEventListener("abort", abort)
+                    : undefined,
+            });
+            signal?.addEventListener("abort", abort, { once: true });
+            this.worker.postMessage({
+                type: "decode",
+                id,
+                sourceUrl: descriptor.sourceUrl,
+                sourceBytes: descriptor.sourceBytes,
+                sourceIndicesUrl,
+                stride: descriptor.stride,
+                vertexCount,
+            });
+        });
+    }
+
+    dispose(): void {
+        if (this.disposed) {
+            return;
+        }
+        this.disposed = true;
+        this.rejectAll(abortError());
+        this.worker.terminate();
+    }
+
+    private rejectAll(error: Error): void {
+        for (const request of this.pending.values()) {
+            request.removeAbortListener?.();
+            request.reject(error);
+        }
+        this.pending.clear();
+    }
+}
+
+function abortError(): Error {
+    return new DOMException("Model viewer position request was cancelled", "AbortError");
+}

--- a/frontend/src/components/tools/model-viewer/model-viewer-position.worker.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-position.worker.ts
@@ -1,0 +1,100 @@
+import { decodeModelViewerPositions, ModelViewerByteLRU } from "./model-viewer-position-codec";
+
+type DecodeRequest = {
+    type: "decode";
+    id: number;
+    sourceUrl: string;
+    sourceBytes: number;
+    sourceIndicesUrl?: string;
+    stride: number;
+    vertexCount: number;
+};
+
+type CancelRequest = { type: "cancel"; id: number };
+
+type WorkerScope = {
+    onmessage: ((event: MessageEvent<DecodeRequest | CancelRequest>) => void) | null;
+    postMessage(message: unknown, transfer?: Transferable[]): void;
+};
+
+const scope = self as unknown as WorkerScope;
+const cache = new ModelViewerByteLRU();
+const cancelled = new Set<number>();
+const queued = new Set<number>();
+let active: { id: number; controller: AbortController } | undefined;
+let queue = Promise.resolve();
+
+scope.onmessage = (event) => {
+    const message = event.data;
+    if (message.type === "cancel") {
+        if (active?.id === message.id) {
+            active.controller.abort();
+            return;
+        }
+        if (queued.has(message.id)) {
+            cancelled.add(message.id);
+        }
+        return;
+    }
+    queued.add(message.id);
+    queue = queue.then(() => decodeRequest(message));
+};
+
+async function decodeRequest(request: DecodeRequest): Promise<void> {
+    queued.delete(request.id);
+    if (cancelled.delete(request.id)) {
+        return;
+    }
+    const controller = new AbortController();
+    active = { id: request.id, controller };
+    try {
+        const source = await fetchCached(request.sourceUrl, controller.signal);
+        if (source.byteLength !== request.sourceBytes) {
+            throw new Error(
+                `Position source size changed: expected ${request.sourceBytes}, received ${source.byteLength}`,
+            );
+        }
+        const sourceIndices = request.sourceIndicesUrl
+            ? new Uint32Array(await fetchCached(request.sourceIndicesUrl, controller.signal))
+            : undefined;
+        if (cancelled.delete(request.id)) {
+            return;
+        }
+        const positions = decodeModelViewerPositions(
+            source,
+            request.stride,
+            sourceIndices,
+            request.vertexCount,
+        );
+        scope.postMessage({ type: "decoded", id: request.id, positions: positions.buffer }, [
+            positions.buffer,
+        ]);
+    } catch (error) {
+        if (!controller.signal.aborted && !cancelled.delete(request.id)) {
+            scope.postMessage({
+                type: "error",
+                id: request.id,
+                message: error instanceof Error ? error.message : String(error),
+            });
+        }
+    } finally {
+        if (active?.id === request.id) {
+            active = undefined;
+        }
+        cancelled.delete(request.id);
+    }
+}
+
+async function fetchCached(url: string, signal: AbortSignal): Promise<ArrayBuffer> {
+    const cached = cache.get(url);
+    if (cached) {
+        return cached;
+    }
+    const response = await fetch(url, { cache: "no-store", signal });
+    if (!response.ok) {
+        throw new Error(`Failed to load model viewer position source (${response.status})`);
+    }
+    const buffer = await response.arrayBuffer();
+    cache.set(url, buffer);
+    return buffer;
+}

--- a/frontend/src/components/tools/model-viewer/model-viewer-transport.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-transport.ts
@@ -83,6 +83,7 @@ export function normalizeModelViewerTransport(
             tangentsUrl: mesh.tangentsUrl,
             uvsUrl: mesh.uvsUrl,
             indicesUrl: mesh.indicesUrl,
+            sourceIndicesUrl: mesh.sourceIndicesUrl,
             conditions: normalizeDNF(mesh.conditions),
             texKey: mesh.texKey,
             textureVariants: (mesh.textureVariants ?? []).map((variant) => ({
@@ -112,7 +113,9 @@ export function normalizeModelViewerTransport(
             })),
             positionVariants: (mesh.positionVariants ?? []).map((variant) => ({
                 conditions: normalizeDNF(variant.conditions),
-                positionsUrl: variant.positionsUrl,
+                sourceUrl: variant.sourceUrl,
+                stride: variant.stride,
+                sourceBytes: variant.sourceBytes,
             })),
         })),
         textures,

--- a/frontend/src/components/tools/model-viewer/three-model-viewer.tsx
+++ b/frontend/src/components/tools/model-viewer/three-model-viewer.tsx
@@ -52,7 +52,14 @@ import type {
 } from "./model-viewer-contract";
 
 import { parseOrientation } from "./model-viewer-contract";
-import { applyPayloadEval, buildPayloadModel } from "./model-viewer-payload";
+import {
+  buildPayloadModel,
+  clearPayloadModelData,
+  commitPayloadEval,
+  type PreparedPayloadEval,
+  preparePayloadEval,
+} from "./model-viewer-payload";
+import { ModelViewerPositionLoader } from "./model-viewer-position-loader";
 import { modelViewerSourceToUrl } from "./model-viewer-session";
 import { MODEL_VIEWER_UPRIGHT_ROTATION, needsUprightCorrection } from "./model-viewer-upright";
 
@@ -237,6 +244,13 @@ function ThreeModelScene({
   const animationValuesRef = useRef<Record<string, string | number>>({});
   const modelRootRef = useRef<Object3D | null>(null);
   const applyPayloadVisualsRef = useRef(() => {});
+  const positionLoaderRef = useRef<ModelViewerPositionLoader | null>(null);
+  const payloadEvalAbortRef = useRef<AbortController | null>(null);
+  const payloadEvalGenerationRef = useRef(0);
+  const animationFrameIndexRef = useRef<number | null>(null);
+  const preparedAnimationRingRef = useRef<
+    Array<{ signature: string; prepared: PreparedPayloadEval }>
+  >([]);
   const floatBufferCacheRef = useRef<Map<string, Promise<Float32Array>>>(new Map());
   const uint32BufferCacheRef = useRef<Map<string, Promise<Uint32Array>>>(new Map());
   const lastAppliedVariantSnapshotRef = useRef<Record<string, number | string> | null>(null);
@@ -335,8 +349,54 @@ function ThreeModelScene({
       const evalResult = Object.keys(animationValues).length
         ? evaluateViewerState(transport, { ...toggleEval.state, ...animationValues })
         : toggleEval;
-      applyPayloadEval(root, evalResult);
-      invalidate();
+      const loader = positionLoaderRef.current;
+      if (!loader) {
+        return;
+      }
+      payloadEvalAbortRef.current?.abort();
+      const controller = new AbortController();
+      payloadEvalAbortRef.current = controller;
+      const generation = ++payloadEvalGenerationRef.current;
+      const signature = payloadEvalSignature(evalResult);
+      const cachedIndex = preparedAnimationRingRef.current.findIndex(
+        (entry) => entry.signature === signature,
+      );
+      const cached =
+        cachedIndex < 0 ? undefined : preparedAnimationRingRef.current.splice(cachedIndex, 1)[0];
+      const commitLatest = (prepared: PreparedPayloadEval) => {
+        if (
+          controller.signal.aborted ||
+          generation !== payloadEvalGenerationRef.current ||
+          root !== modelRootRef.current
+        ) {
+          return;
+        }
+        commitPayloadEval(root, prepared);
+        invalidate();
+        // Defined below to keep the state-transition path together; refs make this
+        // independent of render-time initialization order.
+        // oxlint-disable-next-line react/immutability
+        prefetchAnimationPositions({
+          controller,
+          generation,
+          loader,
+          root,
+          toggleEval,
+          transport,
+        });
+      };
+      if (cached) {
+        commitLatest(cached.prepared);
+        return;
+      }
+      void preparePayloadEval(root, evalResult, loader, controller.signal)
+        .then(commitLatest)
+        .catch((error: unknown) => {
+          if (error instanceof DOMException && error.name === "AbortError") {
+            return;
+          }
+          onErrorRef.current?.(error);
+        });
     };
   }, [invalidate]);
 
@@ -345,6 +405,11 @@ function ThreeModelScene({
     pendingLoadIdRef.current = loadId;
 
     let disposed = false;
+    payloadEvalAbortRef.current?.abort();
+    payloadEvalAbortRef.current = null;
+    preparedAnimationRingRef.current = [];
+    positionLoaderRef.current?.dispose();
+    positionLoaderRef.current = null;
 
     if (activeObjectRef.current) {
       disposeObjectTree(activeObjectRef.current);
@@ -362,10 +427,13 @@ function ThreeModelScene({
     }
 
     if (payloadTransport) {
+      const positionLoader = new ModelViewerPositionLoader();
+      positionLoaderRef.current = positionLoader;
       void buildPayloadModel(
         payloadTransport,
         payloadEvalRef.current ?? { state: {}, meshes: [] },
         true,
+        positionLoader,
       )
         .then((nextRoot) => {
           if (disposed || pendingLoadIdRef.current !== loadId) {
@@ -390,6 +458,10 @@ function ThreeModelScene({
         });
       return () => {
         disposed = true;
+        if (positionLoaderRef.current === positionLoader) {
+          positionLoaderRef.current = null;
+          positionLoader.dispose();
+        }
       };
     }
 
@@ -524,9 +596,12 @@ function ThreeModelScene({
         const clip = animationClipRef.current;
         if (!clip?.frames.length) {
           animationValuesRef.current = {};
+          animationFrameIndexRef.current = null;
         } else {
-          const frame = clip.frames[Math.min(Math.max(index, 0), clip.frames.length - 1)];
+          const frameIndex = Math.min(Math.max(index, 0), clip.frames.length - 1);
+          const frame = clip.frames[frameIndex];
           animationValuesRef.current = frame?.values ?? {};
+          animationFrameIndexRef.current = frameIndex;
         }
         applyPayloadVisualsRef.current();
       },
@@ -621,6 +696,14 @@ function ThreeModelScene({
 
   useEffect(() => {
     return () => {
+      payloadEvalAbortRef.current?.abort();
+      payloadEvalAbortRef.current = null;
+      positionLoaderRef.current?.dispose();
+      positionLoaderRef.current = null;
+      preparedAnimationRingRef.current = [];
+      floatBufferCacheRef.current.clear();
+      uint32BufferCacheRef.current.clear();
+      gl.renderLists.dispose();
       if (activeObjectRef.current) {
         disposeObjectTree(activeObjectRef.current);
         activeObjectRef.current = null;
@@ -631,7 +714,69 @@ function ThreeModelScene({
       lastAppliedShapeKeysRef.current = undefined;
       lastAppliedAnimationSignatureRef.current = null;
     };
-  }, []);
+  }, [gl]);
+
+  function prefetchAnimationPositions({
+    controller,
+    generation,
+    loader,
+    root,
+    toggleEval,
+    transport,
+  }: {
+    controller: AbortController;
+    generation: number;
+    loader: ModelViewerPositionLoader;
+    root: Object3D;
+    toggleEval: NonNullable<typeof payloadEval>;
+    transport: NonNullable<typeof payloadTransport>;
+  }) {
+    const clip = animationClipRef.current;
+    const currentIndex = animationFrameIndexRef.current;
+    if (!clip?.frames.length || currentIndex === null) {
+      preparedAnimationRingRef.current = [];
+      return;
+    }
+    const upcoming = [1, 2].flatMap((offset) => {
+      const candidate = currentIndex + offset;
+      const index =
+        candidate < clip.frames.length
+          ? candidate
+          : clip.loop
+            ? candidate % clip.frames.length
+            : -1;
+      const frame = index < 0 ? undefined : clip.frames[index];
+      if (!frame) {
+        return [];
+      }
+      const evaluated = evaluateViewerState(transport, {
+        ...toggleEval.state,
+        ...frame.values,
+      });
+      return [{ evaluated, signature: payloadEvalSignature(evaluated) }];
+    });
+    for (const { evaluated, signature } of upcoming) {
+      void preparePayloadEval(root, evaluated, loader, controller.signal, true)
+        .then((prepared) => {
+          if (
+            controller.signal.aborted ||
+            generation !== payloadEvalGenerationRef.current ||
+            root !== modelRootRef.current
+          ) {
+            return;
+          }
+          preparedAnimationRingRef.current = [
+            ...preparedAnimationRingRef.current.filter((entry) => entry.signature !== signature),
+            { signature, prepared },
+          ].slice(-2);
+        })
+        .catch((error: unknown) => {
+          if (!(error instanceof DOMException && error.name === "AbortError")) {
+            onErrorRef.current?.(error);
+          }
+        });
+    }
+  }
 
   useEffect(() => {
     if (!modelRoot) {
@@ -1618,6 +1763,21 @@ function waitForNextFrame(): Promise<void> {
   });
 }
 
+function payloadEvalSignature(evalResult: NonNullable<ModelViewerSurfaceProps["payloadEval"]>) {
+  return JSON.stringify(
+    evalResult.meshes.map((mesh) => ({
+      id: mesh.id,
+      visible: mesh.visible,
+      texKey: mesh.texKey,
+      normalMapKey: mesh.normalMapKey,
+      lightMapKey: mesh.lightMapKey,
+      materialMapKey: mesh.materialMapKey,
+      shapeWeights: mesh.shapeWeights,
+      positionVariantIndex: mesh.positionVariantIndex,
+    })),
+  );
+}
+
 function getPerspectiveCameraDistance(
   camera: Camera,
   controls: OrbitControlsImpl | null,
@@ -1644,6 +1804,7 @@ function disposeObjectTree(root: Object3D) {
       material.dispose();
     }
   });
+  clearPayloadModelData(root);
 }
 
 function disposeMaterialTextures(material: MeshStandardMaterial) {

--- a/frontend/src/components/tools/model-viewer/three-model-viewer.tsx
+++ b/frontend/src/components/tools/model-viewer/three-model-viewer.tsx
@@ -452,6 +452,10 @@ function ThreeModelScene({
           if (disposed || pendingLoadIdRef.current !== loadId) {
             return;
           }
+          if (positionLoaderRef.current === positionLoader) {
+            positionLoaderRef.current = null;
+          }
+          positionLoader.dispose();
           activeObjectRef.current = null;
           materialRef.current = [];
           onErrorRef.current?.(error);

--- a/frontend/src/shared/mod-viewer/types.ts
+++ b/frontend/src/shared/mod-viewer/types.ts
@@ -177,13 +177,16 @@ export type ViewerMeshTransport = Omit<ViewerEvalMesh, "shapeTargets" | "positio
     tangentsUrl?: string;
     uvsUrl?: string;
     indicesUrl: string;
+    sourceIndicesUrl?: string;
     shapeTargets: Array<{
         var: string;
         positionsUrl: string;
         mode?: "midpoint_pair";
         lowPositionsUrl?: string;
     }>;
-    positionVariants: Array<PositionVariant & { positionsUrl: string }>;
+    positionVariants: Array<
+        PositionVariant & { sourceUrl: string; stride: number; sourceBytes: number }
+    >;
 };
 
 export type ModViewerTransport = {

--- a/internal/tools/model_viewer.go
+++ b/internal/tools/model_viewer.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -36,8 +37,10 @@ type ModelViewerShapeTarget struct {
 }
 
 type ModelViewerPositionVariant struct {
-	Conditions   ModelViewerDNF `json:"conditions"`
-	PositionsURL string         `json:"positionsUrl"`
+	Conditions  ModelViewerDNF `json:"conditions"`
+	SourceURL   string         `json:"sourceUrl"`
+	Stride      int            `json:"stride"`
+	SourceBytes int64          `json:"sourceBytes"`
 }
 
 type ModelViewerMeshTransport struct {
@@ -48,6 +51,7 @@ type ModelViewerMeshTransport struct {
 	TangentsURL         string                       `json:"tangentsUrl,omitempty"`
 	UVsURL              string                       `json:"uvsUrl,omitempty"`
 	IndicesURL          string                       `json:"indicesUrl"`
+	SourceIndicesURL    string                       `json:"sourceIndicesUrl,omitempty"`
 	Conditions          ModelViewerDNF               `json:"conditions"`
 	TexKey              *string                      `json:"texKey"`
 	TextureVariants     []ModelViewerTextureVariant  `json:"textureVariants"`
@@ -151,9 +155,10 @@ type modelViewerDirectTextureAssignment struct {
 }
 
 type modelViewerDirectPositionAssignment struct {
-	conditions ModelViewerDNF
-	file       string
-	positions  []float32
+	conditions  ModelViewerDNF
+	sourcePath  string
+	stride      int
+	sourceBytes int64
 }
 
 type modelViewerSession struct {
@@ -173,15 +178,18 @@ type modelViewerTexturePayload struct {
 }
 
 type modelViewerMeshPayload struct {
-	Positions            []float32
-	Normals              []float32
-	Tangents             []float32
-	UVs                  []float32
-	Indices              []uint32
-	ShapePositions       [][]float32
-	ShapeLowPositions    [][]float32
-	PositionVariantBytes [][]float32
+	Positions         []float32
+	Normals           []float32
+	Tangents          []float32
+	UVs               []float32
+	Indices           []uint32
+	ShapePositions    [][]float32
+	ShapeLowPositions [][]float32
+	SourceIndices     []uint32
+	PositionSources   []modelViewerDirectPositionAssignment
 }
+
+var modelViewerFreeOSMemory = debug.FreeOSMemory
 
 func (t *Tools) LoadModViewer(ctx context.Context, modPath string) (transport ModelViewerTransport, err error) {
 	startedAt := time.Now()
@@ -311,6 +319,11 @@ func (t *Tools) LoadModViewer(ctx context.Context, modPath string) (transport Mo
 			jobs:     collectModelViewerTextureJobs(len(textureWorks), folder, resources, textureBindings, meshes),
 		})
 	}
+	// Mesh payloads own the extracted attributes from this point onward. Drop
+	// interleaved vertex buffers and geometry caches before texture encoding so
+	// the two peak-memory phases do not overlap.
+	bufferCache.releaseGeometryScratch()
+	runtime.GC()
 	textureJobs := make([]modelViewerTextureJob, 0)
 	for _, work := range textureWorks {
 		textureJobs = append(textureJobs, work.jobs...)
@@ -330,6 +343,8 @@ func (t *Tools) LoadModViewer(ctx context.Context, modPath string) (transport Mo
 			meshPayloads = append(meshPayloads, payload)
 		}
 	}
+	bufferCache.releaseAll()
+	runtime.GC()
 	meshPayloadMs = time.Since(stageStartedAt).Milliseconds()
 	if t.log != nil {
 		t.log.Info(fmt.Sprintf("Texture encoding completed in %dms (textures=%d)", textureStats.TotalWallMs, textureStats.LogicalTextures), "StaticGlb.loadForViewer")
@@ -459,9 +474,17 @@ func (t *Tools) CleanupModelViewer(_ context.Context, memorySessionID string) (b
 	if exists {
 		delete(t.modelViewerSessions, memorySessionID)
 	}
+	lastSession := exists && len(t.modelViewerSessions) == 0
 	t.modelViewerMu.Unlock()
 	if exists && t.protocol != nil {
 		t.protocol.CleanupMemorySession(memorySessionID)
+	}
+	if lastSession {
+		startedAt := time.Now()
+		modelViewerFreeOSMemory()
+		if t.log != nil {
+			t.log.Info(fmt.Sprintf("Released model viewer memory in %dms (session=%s)", time.Since(startedAt).Milliseconds(), memorySessionID), "StaticGlb.cleanupViewer")
+		}
 	}
 	return exists, nil
 }
@@ -678,7 +701,11 @@ func buildModelViewerDirectMeshesAt(iniPath, modDir, assetPath string, sections 
 			component = task.entry.ib.Name
 		}
 		id := modelViewerNormalizeKey(filepath.Base(iniPath)) + ":" + modelViewerNormalizeKey(component) + ":" + strconv.Itoa(task.drawIndex)
-		return modelViewerDirectMesh{id: id, component: component, sectionName: task.draw.section, ibName: task.entry.ib.Name, positionFile: task.entry.group.VBFilename, geometry: geometry, conditions: conditions}, true
+		positionFile := task.entry.group.VBFilename
+		if len(task.entry.group.SourceFiles) > 0 {
+			positionFile = task.entry.group.SourceFiles[0]
+		}
+		return modelViewerDirectMesh{id: id, component: component, sectionName: task.draw.section, ibName: task.entry.ib.Name, positionFile: positionFile, geometry: geometry, conditions: conditions}, true
 	}
 	if workers := min(len(tasks), runtime.GOMAXPROCS(0)); workers > 1 {
 		work := make(chan int)
@@ -839,19 +866,20 @@ func inferModelViewerFmtLayout(group modelViewerBufferGroup, resources []modelVi
 func buildModelViewerDirectMeshPayload(mesh modelViewerDirectMesh, textures []modelViewerTextureBinding, availableTextures map[string]modelViewerTexturePayload, shapeKeys []modelViewerShapeKey, cache *modelViewerBufferCache) (ModelViewerMeshTransport, modelViewerMeshPayload) {
 	item := ModelViewerMeshTransport{ID: mesh.id, Component: mesh.component, Conditions: mesh.conditions, TextureVariants: []ModelViewerTextureVariant{}, NormalMapVariants: []ModelViewerTextureVariant{}, LightMapVariants: []ModelViewerTextureVariant{}, MaterialMapVariants: []ModelViewerTextureVariant{}, ShapeTargets: []ModelViewerShapeTarget{}, PositionVariants: []ModelViewerPositionVariant{}}
 	payload := modelViewerMeshPayload{
-		Positions: mesh.geometry.Position,
-		Normals:   mesh.geometry.Normal,
-		Tangents:  mesh.geometry.Tangent,
-		UVs:       mesh.geometry.Texcoord0,
-		Indices:   mesh.geometry.Indices,
+		Positions:     mesh.geometry.Position,
+		Normals:       mesh.geometry.Normal,
+		Tangents:      mesh.geometry.Tangent,
+		UVs:           mesh.geometry.Texcoord0,
+		Indices:       mesh.geometry.Indices,
+		SourceIndices: mesh.geometry.SourceIndices,
 	}
-	if len(mesh.positionAssignments) >= 2 {
+	if len(mesh.positionAssignments) > 0 {
 		for _, assignment := range mesh.positionAssignments {
-			if len(assignment.positions) != len(mesh.geometry.Position) || len(assignment.conditions) == 0 {
+			if assignment.sourcePath == "" || assignment.stride <= 0 || assignment.sourceBytes <= 0 || len(assignment.conditions) == 0 {
 				continue
 			}
-			item.PositionVariants = append(item.PositionVariants, ModelViewerPositionVariant{Conditions: assignment.conditions})
-			payload.PositionVariantBytes = append(payload.PositionVariantBytes, assignment.positions)
+			item.PositionVariants = append(item.PositionVariants, ModelViewerPositionVariant{Conditions: assignment.conditions, Stride: assignment.stride, SourceBytes: assignment.sourceBytes})
+			payload.PositionSources = append(payload.PositionSources, assignment)
 		}
 	}
 	authoredRoles := make(map[string]bool)
@@ -1031,6 +1059,12 @@ func writeModelViewerPayload(t *Tools, sessionID string, transport *ModelViewerT
 		if err != nil {
 			return err
 		}
+		if !modelViewerSourceIndicesAreIdentity(payload.SourceIndices) {
+			mesh.SourceIndicesURL, err = write(".source-idx", modelViewerUint32Bytes(payload.SourceIndices))
+			if err != nil {
+				return err
+			}
+		}
 		if payload.Normals != nil {
 			mesh.NormalsURL, err = write(".normal", modelViewerFloat32Bytes(payload.Normals))
 			if err != nil {
@@ -1063,14 +1097,11 @@ func writeModelViewerPayload(t *Tools, sessionID string, transport *ModelViewerT
 				return err
 			}
 		}
-		if len(payload.PositionVariantBytes) != len(mesh.PositionVariants) {
+		if len(payload.PositionSources) != len(mesh.PositionVariants) {
 			return fmt.Errorf("model viewer position variant payload count mismatch for %s", mesh.ID)
 		}
 		for variantIndex := range mesh.PositionVariants {
-			mesh.PositionVariants[variantIndex].PositionsURL, err = write(fmt.Sprintf(".posvar.%d", variantIndex), modelViewerFloat32Bytes(payload.PositionVariantBytes[variantIndex]))
-			if err != nil {
-				return err
-			}
+			mesh.PositionVariants[variantIndex].SourceURL = t.protocol.LocalFileURL(payload.PositionSources[variantIndex].sourcePath, true)
 		}
 		return nil
 	}
@@ -1103,6 +1134,18 @@ func writeModelViewerPayload(t *Tools, sessionID string, transport *ModelViewerT
 		}
 	}
 	return nil
+}
+
+func modelViewerSourceIndicesAreIdentity(indices []uint32) bool {
+	if len(indices) == 0 {
+		return true
+	}
+	for index, source := range indices {
+		if source != uint32(index) {
+			return false
+		}
+	}
+	return true
 }
 
 func readModelViewerShapePositions(cache *modelViewerBufferCache, path string, stride int, sources []uint32, vertexCount int) ([]float32, error) {

--- a/internal/tools/model_viewer_direct_test.go
+++ b/internal/tools/model_viewer_direct_test.go
@@ -3,11 +3,14 @@ package tools
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 
 	"nahida.live/desktop/internal/infra"
@@ -146,10 +149,89 @@ format = DXGI_FORMAT_R32_UINT`
 	if len(result.Animations) != 1 || len(result.Meshes) != 1 || len(result.Meshes[0].PositionVariants) != 2 {
 		t.Fatalf("result = %#v", result)
 	}
-	first := readModelViewerProtocolBytes(t, protocol, result.Meshes[0].PositionVariants[0].PositionsURL)
-	second := readModelViewerProtocolBytes(t, protocol, result.Meshes[0].PositionVariants[1].PositionsURL)
+	firstVariant, secondVariant := result.Meshes[0].PositionVariants[0], result.Meshes[0].PositionVariants[1]
+	if firstVariant.Stride != 40 || secondVariant.Stride != 40 || firstVariant.SourceBytes != 120 || secondVariant.SourceBytes != 120 {
+		t.Fatalf("position descriptors = %#v", result.Meshes[0].PositionVariants)
+	}
+	if !strings.HasPrefix(firstVariant.SourceURL, "/protocol/local?") || !strings.HasPrefix(secondVariant.SourceURL, "/protocol/local?") {
+		t.Fatalf("position sources must use local file protocol: %#v", result.Meshes[0].PositionVariants)
+	}
+	if result.Meshes[0].SourceIndicesURL != "" {
+		t.Fatalf("identity source indices URL = %q", result.Meshes[0].SourceIndicesURL)
+	}
+	first := readModelViewerProtocolBytes(t, protocol, firstVariant.SourceURL)
+	second := readModelViewerProtocolBytes(t, protocol, secondVariant.SourceURL)
 	if len(first) < 4 || len(second) < 4 || math.Float32frombits(binary.LittleEndian.Uint32(first)) != 0 || math.Float32frombits(binary.LittleEndian.Uint32(second)) != 10 {
 		t.Fatalf("position variants do not contain the expected frames")
+	}
+}
+
+func TestModelViewerPositionOverridesPruneMutuallyExclusiveMeshes(t *testing.T) {
+	dir := t.TempDir()
+	var ini strings.Builder
+	ini.WriteString("[TextureOverrideBodyPosition]\n")
+	for index := range 20 {
+		if index == 0 {
+			fmt.Fprintf(&ini, "if $swapvar == %d\n", index)
+		} else {
+			fmt.Fprintf(&ini, "elif $swapvar == %d\n", index)
+		}
+		fmt.Fprintf(&ini, "vb0 = ResourcePos%d\n", index)
+	}
+	ini.WriteString("endif\n")
+	for index := range 20 {
+		fmt.Fprintf(&ini, "[ResourcePos%d]\nfilename = pos%d.buf\nstride = 40\n", index, index)
+		if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("pos%d.buf", index)), make([]byte, 40), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sections := parseModINI(ini.String())
+	variables := map[string]any{"swapvar": float64(0)}
+	meshes := make([]modelViewerDirectMesh, 20)
+	for index := range meshes {
+		meshes[index] = modelViewerDirectMesh{
+			component:    "Body",
+			positionFile: fmt.Sprintf("pos%d.buf", index),
+			conditions:   ModelViewerDNF{{{Var: "swapvar", Value: modelViewerString(index)}}},
+			geometry:     &modelViewerGeometry{Position: make([]float32, 3), VertexCount: 1},
+		}
+	}
+	if err := attachModelViewerDirectPositionOverrides(meshes, sections, collectModelViewerResources(sections), dir, variables, newModelViewerBufferCache()); err != nil {
+		t.Fatal(err)
+	}
+	for index, mesh := range meshes {
+		if len(mesh.positionAssignments) != 0 {
+			t.Fatalf("mesh %d retained incompatible position assignments: %#v", index, mesh.positionAssignments)
+		}
+	}
+}
+
+func TestReadModelViewerShapePositionsMatchesIdentityAndCompactSources(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "positions.buf")
+	raw := make([]byte, 4*40)
+	for index := range 4 {
+		for component := range 3 {
+			binary.LittleEndian.PutUint32(raw[index*40+component*4:], math.Float32bits(float32(index*10+component)))
+		}
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cache := newModelViewerBufferCache()
+	identity, err := readModelViewerShapePositions(cache, path, 40, nil, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compact, err := readModelViewerShapePositions(cache, path, 40, []uint32{3, 1}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(identity, []float32{0, 1, 2, 10, 11, 12, 20, 21, 22, 30, 31, 32}) {
+		t.Fatalf("identity positions = %v", identity)
+	}
+	if !slices.Equal(compact, []float32{30, 31, 32, 10, 11, 12}) {
+		t.Fatalf("compact positions = %v", compact)
 	}
 }
 
@@ -171,19 +253,60 @@ stride = 40`)
 	variables := map[string]any{"frame": float64(0), "__domain:frame": []any{float64(0), float64(1)}}
 	positions := make([]float32, 9)
 	meshes := []modelViewerDirectMesh{{
-		component: "Body",
+		component:    "Body",
+		positionFile: "pos.buf",
+		conditions:   modelViewerDNFTrue(),
 		geometry: &modelViewerGeometry{
 			Position:      positions,
 			VertexCount:   3,
 			SourceIndices: []uint32{0, 1, 2},
 		},
-		positionAssignments: []modelViewerDirectPositionAssignment{{conditions: modelViewerDNFTrue(), file: "pos.buf", positions: positions}},
 	}}
 	if err := attachModelViewerDirectPositionOverrides(meshes, sections, collectModelViewerResources(sections), dir, variables, newModelViewerBufferCache()); err != nil {
 		t.Fatal(err)
 	}
-	if len(meshes[0].positionAssignments) != 1 {
+	if len(meshes[0].positionAssignments) != 0 {
 		t.Fatalf("position assignments = %#v", meshes[0].positionAssignments)
+	}
+}
+
+func TestModelViewerSourceIndicesPayloadOmitsIdentityAndPreservesCompactMapping(t *testing.T) {
+	protocol := infra.NewProtocol()
+	service := NewWithOptions(Options{Protocol: protocol})
+	sessionID := protocol.CreateMemorySession()
+	transport := ModelViewerTransport{Meshes: []ModelViewerMeshTransport{{ID: "identity"}, {ID: "compact"}}, Textures: map[string]ModelViewerTextureTransport{}}
+	payloads := []modelViewerMeshPayload{
+		{Positions: make([]float32, 9), Indices: []uint32{0, 1, 2}, SourceIndices: []uint32{0, 1, 2}},
+		{Positions: make([]float32, 9), Indices: []uint32{0, 1, 2}, SourceIndices: []uint32{7, 3, 11}},
+	}
+	if err := writeModelViewerPayload(service, sessionID, &transport, payloads, nil); err != nil {
+		t.Fatal(err)
+	}
+	if transport.Meshes[0].SourceIndicesURL != "" {
+		t.Fatalf("identity mapping URL = %q", transport.Meshes[0].SourceIndicesURL)
+	}
+	got := readModelViewerProtocolBytes(t, protocol, transport.Meshes[1].SourceIndicesURL)
+	if want := modelViewerUint32Bytes([]uint32{7, 3, 11}); string(got) != string(want) {
+		t.Fatalf("source indices = %v, want %v", got, want)
+	}
+}
+
+func TestCleanupModelViewerReleasesMemoryOnlyAfterLastSession(t *testing.T) {
+	protocol := infra.NewProtocol()
+	service := NewWithOptions(Options{Protocol: protocol})
+	first, second := protocol.CreateMemorySession(), protocol.CreateMemorySession()
+	service.modelViewerSessions[first] = &modelViewerSession{}
+	service.modelViewerSessions[second] = &modelViewerSession{}
+	previous := modelViewerFreeOSMemory
+	called := 0
+	modelViewerFreeOSMemory = func() { called++ }
+	t.Cleanup(func() { modelViewerFreeOSMemory = previous })
+
+	if removed, err := service.CleanupModelViewer(context.Background(), first); err != nil || !removed || called != 0 {
+		t.Fatalf("first cleanup = removed %v, err %v, releases %d", removed, err, called)
+	}
+	if removed, err := service.CleanupModelViewer(context.Background(), second); err != nil || !removed || called != 1 {
+		t.Fatalf("last cleanup = removed %v, err %v, releases %d", removed, err, called)
 	}
 }
 

--- a/internal/tools/model_viewer_direct_test.go
+++ b/internal/tools/model_viewer_direct_test.go
@@ -270,6 +270,58 @@ stride = 40`)
 	}
 }
 
+func TestModelViewerPositionOverridesKeepDistinctPaths(t *testing.T) {
+	dir := t.TempDir()
+	dashedDir := filepath.Join(dir, "a-b")
+	plainDir := filepath.Join(dir, "ab")
+	if err := os.MkdirAll(dashedDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(plainDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	dashedPath := filepath.Join(dashedDir, "pos.buf")
+	plainPath := filepath.Join(plainDir, "pos.buf")
+	if err := os.WriteFile(dashedPath, make([]byte, 40), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(plainPath, make([]byte, 80), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sections := parseModINI(`[TextureOverrideBodyPosition]
+if $frame == 0
+vb0 = ResourceDashed
+elif $frame == 1
+vb0 = ResourcePlain
+endif
+[ResourceDashed]
+filename = a-b/pos.buf
+stride = 40
+[ResourcePlain]
+filename = ab/pos.buf
+stride = 40`)
+	variables := map[string]any{"frame": float64(0), "__domain:frame": []any{float64(0), float64(1)}}
+	meshes := []modelViewerDirectMesh{{
+		component:    "Body",
+		positionFile: "base.buf",
+		conditions:   modelViewerDNFTrue(),
+		geometry:     &modelViewerGeometry{Position: make([]float32, 3), VertexCount: 1},
+	}}
+	if err := attachModelViewerDirectPositionOverrides(meshes, sections, collectModelViewerResources(sections), dir, variables, newModelViewerBufferCache()); err != nil {
+		t.Fatal(err)
+	}
+	if len(meshes[0].positionAssignments) != 2 {
+		t.Fatalf("position assignments = %#v", meshes[0].positionAssignments)
+	}
+	sources := make(map[string]int64, len(meshes[0].positionAssignments))
+	for _, assignment := range meshes[0].positionAssignments {
+		sources[filepath.Clean(assignment.sourcePath)] = assignment.sourceBytes
+	}
+	if sources[filepath.Clean(dashedPath)] != 40 || sources[filepath.Clean(plainPath)] != 80 {
+		t.Fatalf("position sources = %#v", sources)
+	}
+}
+
 func TestModelViewerSourceIndicesPayloadOmitsIdentityAndPreservesCompactMapping(t *testing.T) {
 	protocol := infra.NewProtocol()
 	service := NewWithOptions(Options{Protocol: protocol})

--- a/internal/tools/model_viewer_dnf.go
+++ b/internal/tools/model_viewer_dnf.go
@@ -46,6 +46,24 @@ func modelViewerDNFAnd(left, right ModelViewerDNF) ModelViewerDNF {
 	return output
 }
 
+// modelViewerDNFIntersects reports whether the two expressions select at
+// least one common state. Unlike modelViewerDNFAnd it never materializes the
+// Cartesian product, so it remains exact when either expression has more than
+// maxModelViewerDNFGroups alternatives.
+func modelViewerDNFIntersects(left, right ModelViewerDNF) bool {
+	if len(left) == 0 || len(right) == 0 {
+		return false
+	}
+	for _, leftGroup := range left {
+		for _, rightGroup := range right {
+			if _, possible := simplifyModelViewerDNFGroup(append(append([]ModelViewerDNFClause(nil), leftGroup...), rightGroup...)); possible {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func modelViewerDNFOr(left, right ModelViewerDNF) ModelViewerDNF {
 	if modelViewerDNFIsTrue(left) || modelViewerDNFIsTrue(right) {
 		return modelViewerDNFTrue()

--- a/internal/tools/model_viewer_dnf_test.go
+++ b/internal/tools/model_viewer_dnf_test.go
@@ -85,6 +85,19 @@ func TestModelViewerDNFRemovesContradictoryGroup(t *testing.T) {
 	}
 }
 
+func TestModelViewerDNFIntersectsBeyondMaterializationLimit(t *testing.T) {
+	left := make(ModelViewerDNF, maxModelViewerDNFGroups+1)
+	for index := range left {
+		left[index] = []ModelViewerDNFClause{{Var: "frame", Value: modelViewerString(index)}}
+	}
+	if modelViewerDNFIntersects(left, ModelViewerDNF{{{Var: "frame", Value: "999"}}}) {
+		t.Fatal("disjoint expressions must not intersect")
+	}
+	if !modelViewerDNFIntersects(left, ModelViewerDNF{{{Var: "frame", Value: modelViewerString(maxModelViewerDNFGroups)}}}) {
+		t.Fatal("matching expression should intersect")
+	}
+}
+
 func TestModelViewerDNFCoversAssignmentCondition(t *testing.T) {
 	draw := ModelViewerDNF{{{Var: "color", Value: "1"}, {Var: "hair", Value: "0"}}}
 	if !modelViewerDNFCovers(draw, ModelViewerDNF{{{Var: "color", Value: "1"}}}) {

--- a/internal/tools/model_viewer_resource.go
+++ b/internal/tools/model_viewer_resource.go
@@ -324,6 +324,29 @@ func newModelViewerBufferCache() *modelViewerBufferCache {
 	return &modelViewerBufferCache{files: make(map[string][]byte), indices: make(map[string][]uint32), geometries: make(map[string]*modelViewerGeometry), pairs: make(map[string]modelViewerPairedBuffers), fmts: make(map[string]modelViewerFmtCacheEntry), interleaved: make(map[string]modelViewerInterleavedBuffers)}
 }
 
+func (c *modelViewerBufferCache) releaseGeometryScratch() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	clear(c.indices)
+	clear(c.geometries)
+	clear(c.pairs)
+	clear(c.fmts)
+	clear(c.interleaved)
+	c.mu.Unlock()
+}
+
+func (c *modelViewerBufferCache) releaseAll() {
+	if c == nil {
+		return
+	}
+	c.releaseGeometryScratch()
+	c.mu.Lock()
+	clear(c.files)
+	c.mu.Unlock()
+}
+
 // fmtLayout caches a resolved vertex layout per lookup key so IBs referenced
 // by several ini files parse their .fmt once per viewer load.
 func (c *modelViewerBufferCache) fmtLayout(key string, build func() (modelViewerFmtLayout, error)) (modelViewerFmtLayout, error) {

--- a/internal/tools/model_viewer_scan.go
+++ b/internal/tools/model_viewer_scan.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -397,7 +398,7 @@ func buildModelViewerDirectScannedMeshesAt(iniPath, modDir string, sections []mo
 		if record.auto {
 			indexCount = len(active) * recordDrawCopies(record)
 		}
-		mesh := modelViewerDirectMesh{id: id, component: component, sectionName: record.sectionName, ibName: state.ib, positionFile: position.Filename, geometry: geometry, conditions: conditions, positionAssignments: []modelViewerDirectPositionAssignment{{conditions: cloneModelViewerDNF(conditions), file: position.Filename, positions: geometry.Position}}, textureAuthored: record.authoredDiffuse, nonDiffuseTextureFiles: resourceFilenames(resourceMap, record.nonDiffuse), indexCount: indexCount}
+		mesh := modelViewerDirectMesh{id: id, component: component, sectionName: record.sectionName, ibName: state.ib, positionFile: position.Filename, geometry: geometry, conditions: conditions, textureAuthored: record.authoredDiffuse, nonDiffuseTextureFiles: resourceFilenames(resourceMap, record.nonDiffuse), indexCount: indexCount}
 		appendModelViewerDirectTextureHistory(&mesh, record.textureHistory, resourceMap)
 		geometryIndexes[geometryKey] = len(output)
 		output = append(output, mesh)
@@ -478,7 +479,7 @@ type modelViewerDirectPositionResourceAssignment struct {
 	conditions       ModelViewerDNF
 }
 
-func attachModelViewerDirectPositionOverrides(meshes []modelViewerDirectMesh, sections []modINISection, resources []modelViewerResource, modDir string, variables map[string]any, cache *modelViewerBufferCache) error {
+func attachModelViewerDirectPositionOverrides(meshes []modelViewerDirectMesh, sections []modINISection, resources []modelViewerResource, modDir string, variables map[string]any, _ *modelViewerBufferCache) error {
 	var assignments []modelViewerDirectPositionResourceAssignment
 	for _, section := range sections {
 		if !strings.EqualFold(section.Header, "TextureOverride") || !strings.HasSuffix(strings.ToLower(section.Name), "position") {
@@ -505,27 +506,57 @@ func attachModelViewerDirectPositionOverrides(meshes []modelViewerDirectMesh, se
 	for meshIndex := range meshes {
 		mesh := &meshes[meshIndex]
 		var variants []modelViewerDirectPositionAssignment
-		files := make(map[string]bool)
+		files := make(map[string]int)
 		for _, assignment := range assignments {
-			if !modelViewerKeyMatches(assignment.target, mesh.component, false) {
+			if !modelViewerKeyMatches(assignment.target, mesh.component, false) || !modelViewerDNFIntersects(mesh.conditions, assignment.conditions) {
 				continue
 			}
 			resource, ok := resourceMap[modelViewerNormalizeKey(assignment.resource)]
 			if !ok || resource.Filename == "" {
 				continue
 			}
-			positions, err := readModelViewerShapePositions(cache, filepath.Join(modDir, filepath.FromSlash(resource.Filename)), resource.Stride, mesh.geometry.SourceIndices, mesh.geometry.VertexCount)
-			if err != nil || len(positions) != len(mesh.geometry.Position) {
+			sourcePath, err := resolveModelViewerResourcePath(modDir, modDir, resource.Filename)
+			if err != nil {
 				continue
 			}
-			variants = append(variants, modelViewerDirectPositionAssignment{conditions: assignment.conditions, file: resource.Filename, positions: positions})
-			files[modelViewerNormalizeKey(filepath.ToSlash(resource.Filename))] = true
+			info, err := os.Stat(sourcePath)
+			if err != nil || !info.Mode().IsRegular() {
+				continue
+			}
+			stride := resource.Stride
+			if stride <= 0 {
+				stride = 40
+			}
+			key := modelViewerNormalizeKey(filepath.ToSlash(sourcePath))
+			if existingIndex, exists := files[key]; exists {
+				variants[existingIndex].conditions = modelViewerDNFMergeExact(variants[existingIndex].conditions, assignment.conditions)
+				continue
+			}
+			files[key] = len(variants)
+			variants = append(variants, modelViewerDirectPositionAssignment{conditions: cloneModelViewerDNF(assignment.conditions), sourcePath: sourcePath, stride: stride, sourceBytes: info.Size()})
 		}
-		if len(files) > 1 {
-			mesh.positionAssignments = variants
+		if len(variants) == 1 {
+			basePath, err := resolveModelViewerResourcePath(modDir, modDir, mesh.positionFile)
+			if err == nil && samePathFold(basePath, variants[0].sourcePath) {
+				continue
+			}
 		}
+		mesh.positionAssignments = variants
 	}
 	return nil
+}
+
+func modelViewerDNFMergeExact(left, right ModelViewerDNF) ModelViewerDNF {
+	if modelViewerDNFIsTrue(left) || modelViewerDNFIsTrue(right) {
+		return modelViewerDNFTrue()
+	}
+	output := cloneModelViewerDNF(left)
+	for _, group := range right {
+		if !containsModelViewerDNFGroup(output, group) {
+			output = append(output, append([]ModelViewerDNFClause(nil), group...))
+		}
+	}
+	return output
 }
 
 func appendModelViewerDirectTextureHistory(mesh *modelViewerDirectMesh, assignments []modelViewerDirectTextureAssignment, resourceMap map[string]modelViewerResource) {

--- a/internal/tools/model_viewer_scan.go
+++ b/internal/tools/model_viewer_scan.go
@@ -527,7 +527,7 @@ func attachModelViewerDirectPositionOverrides(meshes []modelViewerDirectMesh, se
 			if stride <= 0 {
 				stride = 40
 			}
-			key := modelViewerNormalizeKey(filepath.ToSlash(sourcePath))
+			key := strings.ToLower(filepath.Clean(sourcePath))
 			if existingIndex, exists := files[key]; exists {
 				variants[existingIndex].conditions = modelViewerDNFMergeExact(variants[existingIndex].conditions, assignment.conditions)
 				continue


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core model-viewer geometry/animation paths and changes the transport contract for position data; regressions could show as wrong poses, failed loads, or memory leaks if worker/cleanup paths misbehave.
> 
> **Overview**
> **Position variants are no longer fully decoded at load time.** The backend now ships **external source descriptors** (`sourceUrl`, stride, `sourceBytes`, optional `sourceIndicesUrl`) instead of baking every variant into the memory session, and it **drops geometry caches earlier** during viewer load plus calls **`FreeOSMemory` when the last viewer session ends**.
> 
> On the frontend, payload evaluation is split into **`preparePayloadEval` (async fetch/decode)** and **`commitPayloadEval` (atomic mesh/visibility updates)**. A **Web Worker** decodes strided buffers with optional index remapping, backed by a **byte-bounded LRU**; the main thread loader supports **abort/dispose** and ignores stale results.
> 
> **`three-model-viewer`** wires this through a dedicated position loader, **cancels in-flight evals** on toggles/animation, **prefetches the next animation frames**, and **`clearPayloadModelData`** on teardown. Position override attachment on the Go side is tightened with **DNF intersection** (no Cartesian blow-up), **path-aware deduping**, and skipping redundant same-file variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30f9cc70768cdaad6959225a2066b7a40a4cd140. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lazy loading for model-viewer position variants, improving initial loading performance.
  * Added background decoding and caching for position data.
  * Added support for compact source-index mappings and external position sources.
  * Added animation prefetching and reusable prepared results.

* **Bug Fixes**
  * Improved cancellation and cleanup during model loading and evaluation.
  * Prevented incomplete model resources from lingering after failures.
  * Improved handling of mutually exclusive and duplicate position assignments.
  * Reduced memory usage during model processing and session cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->