### PR TITLE
Use shared Three.js renderers for body shape and model viewers

### DIFF
--- a/frontend/src/components/tools/body-shape/body-shape-viewport.tsx
+++ b/frontend/src/components/tools/body-shape/body-shape-viewport.tsx
@@ -2,6 +2,7 @@ import { OrbitControls } from "@react-three/drei";
 import { Canvas, useThree } from "@react-three/fiber";
 import { parseOrientation } from "@renderer/components/tools/model-viewer/model-viewer-contract";
 import type { BrushMode } from "@renderer/components/tools/model-viewer/model-viewer-menu-bar";
+import { createThreeRenderer } from "@renderer/components/tools/three-renderer";
 import {
   applyMultiRegionDeform,
   composeDisplayWeightsInto,
@@ -76,6 +77,8 @@ export type BodyShapeViewportProps = {
 
 type OrbitControlsImpl = ElementRef<typeof OrbitControls>;
 
+const bodyShapeRenderer = createThreeRenderer({ alpha: true, antialias: true });
+
 export const BodyShapeViewport = forwardRef<BodyShapeViewportHandle, BodyShapeViewportProps>(
   function BodyShapeViewport(props, ref) {
     const controlsRef = useRef<OrbitControlsImpl | null>(null);
@@ -107,7 +110,7 @@ export const BodyShapeViewport = forwardRef<BodyShapeViewportHandle, BodyShapeVi
           frameloop="demand"
           camera={{ position: [0, 1.2, 2.4], fov: 45, near: 0.01, far: 500 }}
           dpr={Math.min(window.devicePixelRatio, 2)}
-          gl={{ antialias: true, alpha: true }}
+          gl={bodyShapeRenderer}
         >
           <color attach="background" args={["#12141a"]} />
           <ambientLight intensity={0.55} />

--- a/frontend/src/components/tools/model-viewer/three-model-viewer.tsx
+++ b/frontend/src/components/tools/model-viewer/three-model-viewer.tsx
@@ -1,5 +1,6 @@
 import { OrbitControls } from "@react-three/drei";
 import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import { createThreeRenderer } from "@renderer/components/tools/three-renderer";
 import { cn } from "@renderer/lib/utils";
 import { fetchFloat32, fetchUint32 } from "@renderer/wails/binary-memory";
 import { evaluateViewerState } from "@shared/mod-viewer/eval";
@@ -75,6 +76,12 @@ const DEFAULT_CAMERA_POSITION = new Vector3(0, 0, 4);
 const ORBIT_CONTROLS_ZOOM_SPEED = 1.5;
 const SMOOTH_ZOOM_DAMPING = 0.16;
 const SMOOTH_ZOOM_DELTA_SCALE = 0.0015;
+const modelViewerRenderer = createThreeRenderer({
+  mode: "webgl",
+  alpha: true,
+  antialias: true,
+  preserveDrawingBuffer: true,
+});
 
 type LoadedShapeKey = {
   metadata: ModelViewerRealtimeShapeKey;
@@ -174,7 +181,7 @@ export const ThreeModelViewer = memo(
             position: DEFAULT_CAMERA_POSITION.toArray(),
           }}
           dpr={window.devicePixelRatio}
-          gl={{ alpha: true, antialias: true, preserveDrawingBuffer: true }}
+          gl={modelViewerRenderer}
         >
           <ambientLight intensity={lighting.ambient} />
           {lighting.hemisphere > 0 ? (

--- a/frontend/src/components/tools/three-renderer.ts
+++ b/frontend/src/components/tools/three-renderer.ts
@@ -2,6 +2,9 @@ import type { GLProps } from "@react-three/fiber";
 import { WebGLRenderer, type WebGLRendererParameters } from "three";
 import type { WebGPURendererParameters } from "three/webgpu";
 
+type RendererFactory = Extract<GLProps, (...args: never[]) => unknown>;
+type RendererProperties = Parameters<RendererFactory>[0];
+
 export type ThreeRendererMode = "auto" | "webgl";
 
 export type ThreeRendererOptions =
@@ -25,12 +28,37 @@ export function createThreeRenderer(options: ThreeRendererOptions = {}): GLProps
     }
 
     const { mode: _mode, ...rendererOptions } = options;
-    return async (properties) => {
+    const initializations = new WeakMap<object, ReturnType<typeof initialize>>();
+    return (properties) => {
+        const canvas = properties.canvas as HTMLCanvasElement | OffscreenCanvas;
+        const pending = initializations.get(canvas);
+        if (pending) {
+            return pending;
+        }
+
+        const initialization = initialize(canvas, properties);
+        initializations.set(canvas, initialization);
+        const clearInitialization = () => {
+            // Retain the settled promise until R3F's await continuation assigns state.gl.
+            queueMicrotask(() => {
+                if (initializations.get(canvas) === initialization) {
+                    initializations.delete(canvas);
+                }
+            });
+        };
+        void initialization.then(clearInitialization, clearInitialization);
+        return initialization;
+    };
+
+    async function initialize(
+        canvas: HTMLCanvasElement | OffscreenCanvas,
+        properties: RendererProperties,
+    ) {
         const { WebGPURenderer } = await import("three/webgpu");
         const renderer = new WebGPURenderer({
             alpha: properties.alpha,
             antialias: properties.antialias,
-            canvas: properties.canvas as HTMLCanvasElement | OffscreenCanvas,
+            canvas,
             depth: properties.depth,
             logarithmicDepthBuffer: properties.logarithmicDepthBuffer,
             powerPreference:
@@ -40,5 +68,5 @@ export function createThreeRenderer(options: ThreeRendererOptions = {}): GLProps
         });
         await renderer.init();
         return renderer;
-    };
+    }
 }

--- a/frontend/src/components/tools/three-renderer.ts
+++ b/frontend/src/components/tools/three-renderer.ts
@@ -1,0 +1,44 @@
+import type { GLProps } from "@react-three/fiber";
+import { WebGLRenderer, type WebGLRendererParameters } from "three";
+import type { WebGPURendererParameters } from "three/webgpu";
+
+export type ThreeRendererMode = "auto" | "webgl";
+
+export type ThreeRendererOptions =
+    | (Omit<WebGPURendererParameters, "canvas" | "forceWebGL" | "getFallback"> & {
+          mode?: "auto";
+      })
+    | (Omit<WebGLRendererParameters, "canvas"> & {
+          mode: "webgl";
+      });
+
+export function createThreeRenderer(options: ThreeRendererOptions = {}): GLProps {
+    if (options.mode === "webgl") {
+        const { mode: _mode, ...rendererOptions } = options;
+        return (properties) =>
+            new WebGLRenderer({
+                ...properties,
+                ...rendererOptions,
+                // R3F declares a minimal OffscreenCanvas type, while three.js uses the DOM type.
+                canvas: properties.canvas as HTMLCanvasElement | OffscreenCanvas,
+            });
+    }
+
+    const { mode: _mode, ...rendererOptions } = options;
+    return async (properties) => {
+        const { WebGPURenderer } = await import("three/webgpu");
+        const renderer = new WebGPURenderer({
+            alpha: properties.alpha,
+            antialias: properties.antialias,
+            canvas: properties.canvas as HTMLCanvasElement | OffscreenCanvas,
+            depth: properties.depth,
+            logarithmicDepthBuffer: properties.logarithmicDepthBuffer,
+            powerPreference:
+                properties.powerPreference === "default" ? undefined : properties.powerPreference,
+            stencil: properties.stencil,
+            ...rendererOptions,
+        });
+        await renderer.init();
+        return renderer;
+    };
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Body shape may switch from WebGL-only to WebGPU when available, and async renderer init touches core viewport behavior; model viewer mitigates capture risk by staying on WebGL.
> 
> **Overview**
> Introduces **`createThreeRenderer`** so React Three Fiber `Canvas` components stop inlining `gl` option objects and share one setup path.
> 
> **Body shape** now uses the factory with transparency and antialiasing only (default **auto** mode), which **async-initializes WebGPU** when supported instead of always constructing `WebGLRenderer`.
> 
> **Model viewer** wires the same helper but forces **`mode: "webgl"`** and keeps **`preserveDrawingBuffer`** so square PNG capture via `toDataURL` continues to work reliably.
> 
> The factory handles R3F’s async renderer contract (deduped init per canvas, microtask cleanup) and maps fiber canvas types to three.js.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 696210862179bf43d6fc2b8f33ba25f1b551172e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved 3D rendering setup for body-shape and model-viewer experiences.
  * Standardized renderer configuration to support smoother, more consistent canvas rendering.
  * Added flexible rendering support to enable WebGL and WebGPU capabilities where available.
  * Preserved visual features such as transparency, anti-aliasing, and drawing-buffer support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->