### PR TITLE
feat(mod): show active download progress

### DIFF
--- a/frontend/src/components/mod/merge-mods-dialog.tsx
+++ b/frontend/src/components/mod/merge-mods-dialog.tsx
@@ -123,7 +123,12 @@ export function MergeModsDialog() {
       toast.success(t("page.mod.merge.success"));
       exitMergeMode();
     } catch (error) {
-      toast.error(toErrorMessage(error) || t("page.mod.merge.failed"));
+      const errorMessage = toErrorMessage(error);
+      if (errorMessage.includes("MOD_DOWNLOAD_IN_PROGRESS")) {
+        toast.warning(t("page.mod.download_action_blocked"));
+      } else {
+        toast.error(errorMessage || t("page.mod.merge.failed"));
+      }
     } finally {
       setIsMerging(false);
     }

--- a/frontend/src/components/mod/mod-card.tsx
+++ b/frontend/src/components/mod/mod-card.tsx
@@ -1,6 +1,7 @@
 import { Badge } from "@renderer/components/ui/badge";
 import { Separator } from "@renderer/components/ui/separator";
 import type { ModActionApi } from "@renderer/hooks/use-mod-actions";
+import { useModDownloadTransfer } from "@renderer/hooks/use-mod-download-transfer";
 import { localFileSrc } from "@renderer/lib/local-file";
 import { cn } from "@renderer/lib/utils";
 import { useModStore } from "@renderer/store/mod";
@@ -11,6 +12,7 @@ import { memo, useCallback, useRef } from "react";
 
 import { ModCardHeader } from "./mod-card-header";
 import { ModContextMenu } from "./mod-context-menu";
+import { ModDownloadOverlay } from "./mod-download-overlay";
 import { ModIniList } from "./mod-ini-list";
 import { ModPreviewContainer } from "./mod-preview-container";
 import { getModColorClass } from "./utils";
@@ -37,6 +39,8 @@ export const ModCard = memo(function ModCard({
   onToggleKeyUpdate,
 }: ModCardProps) {
   const isMergeSelected = useModStore((s) => s.isMergeMode && s.selectedModPaths.has(mod.path));
+  const downloadTransfer = useModDownloadTransfer(mod.path);
+  const isDownloading = mod.isDownloading || Boolean(downloadTransfer);
   const setIniListExpanded = useModStore((s) => s.setIniListExpanded);
   const isIniListExpanded = useModStore((s) =>
     selectedGroupPath
@@ -54,17 +58,24 @@ export const ModCard = memo(function ModCard({
 
   return (
     <>
-      <ModContextMenu mod={mod} actions={actions}>
+      <ModContextMenu mod={mod} actions={actions} disabled={isDownloading}>
         <div
+          aria-busy={isDownloading}
+          aria-disabled={isDownloading}
           className={cn(
             "relative h-100 cursor-pointer overflow-hidden rounded-sm border-border/75 p-1 transition-shadow duration-150 hover:shadow-lg",
-            getModColorClass(mod.isEnabled),
-            isMergeSelected && "ring-2 ring-primary ring-offset-2 ring-offset-background",
+            isDownloading ? "cursor-wait bg-muted grayscale" : getModColorClass(mod.isEnabled),
+            !isDownloading &&
+              isMergeSelected &&
+              "ring-2 ring-primary ring-offset-2 ring-offset-background",
           )}
           onMouseDown={(e) => {
             mouseDownTargetRef.current = e.target;
           }}
           onClick={(e) => {
+            if (isDownloading) {
+              return;
+            }
             const target = mouseDownTargetRef.current as HTMLElement;
             if (target && (target.tagName === "INPUT" || target.closest("button"))) {
               return;
@@ -73,69 +84,74 @@ export const ModCard = memo(function ModCard({
           }}
           draggable={false}
         >
-          {mod.preview?.match(/\.(jpeg|jpg|gif|png|webp|bmp)$/i) && (
-            <div
-              className="pointer-events-none absolute inset-0 z-0 scale-110 opacity-25 blur-lg"
-              style={{ transform: "translateZ(0)", willChange: "filter" }}
-            >
-              <img
-                src={localFileSrc(mod.preview, { cacheKey: mod.mtime })}
-                alt="preview"
-                className="h-full w-full object-fill"
-              />
-            </div>
-          )}
-
-          <ModCardHeader mod={mod} actions={actions} />
-
-          <div className="relative z-10 flex h-[calc(100%-2rem)] flex-row space-x-2">
-            <ModPreviewContainer
-              mod={mod}
-              onDeletePreview={() => actions.openDeletePreview(mod)}
-              onPaste={() => actions.openPastePreview(mod)}
-            />
-
-            {!actions.isNteGame && mod.inis.length > 0 && (
-              <>
-                <div className="relative flex items-stretch">
-                  <Separator orientation="vertical" />
-                  <button
-                    type="button"
-                    aria-label={isIniListExpanded ? "Collapse ini list" : "Expand ini list"}
-                    className="pointer-events-auto absolute inset-y-0 left-1/2 z-10 w-6 -translate-x-1/2 bg-transparent"
-                    style={{ cursor: "col-resize" }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleIniListExpandedChange();
-                    }}
-                  />
-                </div>
-
-                <ModIniList
-                  mod={mod}
-                  expanded={isIniListExpanded}
-                  onToggleKeyUpdate={onToggleKeyUpdate}
+          <div className="contents" inert={isDownloading}>
+            {mod.preview?.match(/\.(jpeg|jpg|gif|png|webp|bmp)$/i) && (
+              <div
+                className="pointer-events-none absolute inset-0 z-0 scale-110 opacity-25 blur-lg"
+                style={{ transform: "translateZ(0)", willChange: "filter" }}
+              >
+                <img
+                  src={localFileSrc(mod.preview, { cacheKey: mod.mtime })}
+                  alt="preview"
+                  className="h-full w-full object-fill"
                 />
-              </>
+              </div>
+            )}
+
+            <ModCardHeader mod={mod} actions={actions} />
+
+            <div className="relative z-10 flex h-[calc(100%-2rem)] flex-row space-x-2">
+              <ModPreviewContainer
+                mod={mod}
+                onDeletePreview={() => actions.openDeletePreview(mod)}
+                onPaste={() => actions.openPastePreview(mod)}
+              />
+
+              {!actions.isNteGame && mod.inis.length > 0 && (
+                <>
+                  <div className="relative flex items-stretch">
+                    <Separator orientation="vertical" />
+                    <button
+                      type="button"
+                      aria-label={isIniListExpanded ? "Collapse ini list" : "Expand ini list"}
+                      className="pointer-events-auto absolute inset-y-0 left-1/2 z-10 w-6 -translate-x-1/2 bg-transparent"
+                      style={{ cursor: "col-resize" }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleIniListExpandedChange();
+                      }}
+                    />
+                  </div>
+
+                  <ModIniList
+                    mod={mod}
+                    expanded={isIniListExpanded}
+                    onToggleKeyUpdate={onToggleKeyUpdate}
+                  />
+                </>
+              )}
+            </div>
+
+            {!mod.isDownloadPlaceholder && (
+              <div className="absolute bottom-1 left-1 z-10 flex flex-col space-y-1">
+                <Badge
+                  className="flex h-5 items-center gap-1.5 bg-background/35 text-xs text-foreground backdrop-blur"
+                  style={{ transform: "translateZ(0)", willChange: "backdrop-filter" }}
+                >
+                  <FolderIcon />
+                  {formatSize(mod.size)}
+                </Badge>
+                <Badge
+                  className="flex h-5 items-center gap-1.5 bg-background/35 text-xs text-foreground backdrop-blur"
+                  style={{ transform: "translateZ(0)", willChange: "backdrop-filter" }}
+                >
+                  <CalendarIcon />
+                  {formatDate(new Date(mod.mtime), "ko")}
+                </Badge>
+              </div>
             )}
           </div>
-
-          <div className="absolute bottom-1 left-1 z-10 flex flex-col space-y-1">
-            <Badge
-              className="flex h-5 items-center gap-1.5 bg-background/35 text-xs text-foreground backdrop-blur"
-              style={{ transform: "translateZ(0)", willChange: "backdrop-filter" }}
-            >
-              <FolderIcon />
-              {formatSize(mod.size)}
-            </Badge>
-            <Badge
-              className="flex h-5 items-center gap-1.5 bg-background/35 text-xs text-foreground backdrop-blur"
-              style={{ transform: "translateZ(0)", willChange: "backdrop-filter" }}
-            >
-              <CalendarIcon />
-              {formatDate(new Date(mod.mtime), "ko")}
-            </Badge>
-          </div>
+          {downloadTransfer && <ModDownloadOverlay transfer={downloadTransfer} variant="card" />}
         </div>
       </ModContextMenu>
     </>

--- a/frontend/src/components/mod/mod-card.tsx
+++ b/frontend/src/components/mod/mod-card.tsx
@@ -84,7 +84,12 @@ export const ModCard = memo(function ModCard({
           }}
           draggable={false}
         >
-          <div className="contents" inert={isDownloading}>
+          {/* Remount menu owners so their portaled content closes before this subtree becomes inert. */}
+          <div
+            key={isDownloading ? "downloading" : "interactive"}
+            className="contents"
+            inert={isDownloading}
+          >
             {mod.preview?.match(/\.(jpeg|jpg|gif|png|webp|bmp)$/i) && (
               <div
                 className="pointer-events-none absolute inset-0 z-0 scale-110 opacity-25 blur-lg"

--- a/frontend/src/components/mod/mod-context-menu.tsx
+++ b/frontend/src/components/mod/mod-context-menu.tsx
@@ -40,9 +40,10 @@ interface ModContextMenuProps {
   mod: ModInfo;
   actions: ModActionApi;
   children: ReactNode;
+  disabled?: boolean;
 }
 
-export function ModContextMenu({ mod, actions, children }: ModContextMenuProps) {
+export function ModContextMenu({ mod, actions, children, disabled = false }: ModContextMenuProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [gameBananaSource, setGameBananaSource] = useState<{
@@ -52,6 +53,10 @@ export function ModContextMenu({ mod, actions, children }: ModContextMenuProps) 
   const gameBananaModId =
     gameBananaSource?.modPath === mod.path ? gameBananaSource.modId : undefined;
   const isConvertingModel = actions.convertingModelPath === mod.path;
+
+  if (disabled) {
+    return children;
+  }
 
   const loadGameBananaModId = () => {
     if (gameBananaSource?.modPath === mod.path) return;

--- a/frontend/src/components/mod/mod-download-overlay.test.ts
+++ b/frontend/src/components/mod/mod-download-overlay.test.ts
@@ -47,6 +47,24 @@ describe("getModDownloadDisplay", () => {
         });
     });
 
+    it("clamps known-size progress below zero", () => {
+        expect(getModDownloadDisplay(transfer({ progress: -10, speed: 2048 }))).toEqual({
+            status: "downloading",
+            progress: 0,
+            speed: 2048,
+            pulse: false,
+        });
+    });
+
+    it("clamps known-size progress above 100 and finalizes", () => {
+        expect(getModDownloadDisplay(transfer({ progress: 125, speed: 2048 }))).toEqual({
+            status: "finalizing",
+            progress: 100,
+            speed: null,
+            pulse: false,
+        });
+    });
+
     it("uses an unknown pulsing progress when total size is unavailable", () => {
         expect(
             getModDownloadDisplay(transfer({ totalSize: 0, progress: 100, speed: 512 })),

--- a/frontend/src/components/mod/mod-download-overlay.test.ts
+++ b/frontend/src/components/mod/mod-download-overlay.test.ts
@@ -1,0 +1,80 @@
+import type { TransferWithoutData } from "@shared/types";
+import { describe, expect, it } from "vitest";
+
+import { getModDownloadDisplay } from "./mod-download-overlay";
+
+function transfer(overrides: Partial<TransferWithoutData> = {}): TransferWithoutData {
+    return {
+        pid: "download",
+        type: "download",
+        status: "progress",
+        totalSize: 100,
+        transferedSize: 25,
+        progress: 25,
+        speed: 10,
+        eta: 8,
+        startTime: 1,
+        name: "Mod",
+        totalFiles: 1,
+        transferedFiles: 0,
+        failedFiles: 0,
+        ...overrides,
+    };
+}
+
+describe("getModDownloadDisplay", () => {
+    it("uses pulsing queued and preparing states", () => {
+        expect(getModDownloadDisplay(transfer({ status: "pending", totalSize: 0 }))).toEqual({
+            status: "queued",
+            progress: null,
+            speed: null,
+            pulse: true,
+        });
+        expect(getModDownloadDisplay(transfer({ status: "preparing", totalSize: 0 }))).toEqual({
+            status: "preparing",
+            progress: null,
+            speed: null,
+            pulse: true,
+        });
+    });
+
+    it("shows progress and speed while downloading", () => {
+        expect(getModDownloadDisplay(transfer({ progress: 47.4, speed: 2048 }))).toEqual({
+            status: "downloading",
+            progress: 47.4,
+            speed: 2048,
+            pulse: false,
+        });
+    });
+
+    it("uses an unknown pulsing progress when total size is unavailable", () => {
+        expect(
+            getModDownloadDisplay(transfer({ totalSize: 0, progress: 100, speed: 512 })),
+        ).toEqual({
+            status: "downloading",
+            progress: null,
+            speed: 512,
+            pulse: true,
+        });
+    });
+
+    it("shows finalizing at 100 percent and hides stale speed", () => {
+        expect(getModDownloadDisplay(transfer({ progress: 100, speed: 512 }))).toEqual({
+            status: "finalizing",
+            progress: 100,
+            speed: null,
+            pulse: false,
+        });
+    });
+
+    it("keeps paused progress but hides stale speed", () => {
+        expect(
+            getModDownloadDisplay(transfer({ status: "paused", progress: 63, speed: 512 })),
+        ).toEqual({
+            status: "paused",
+            progress: 63,
+            speed: null,
+            pulse: false,
+        });
+    });
+});

--- a/frontend/src/components/mod/mod-download-overlay.tsx
+++ b/frontend/src/components/mod/mod-download-overlay.tsx
@@ -1,0 +1,82 @@
+import { Progress } from "@renderer/components/ui/progress";
+import { cn } from "@renderer/lib/utils";
+import type { TransferWithoutData } from "@shared/types";
+import { formatSize } from "@shared/utils";
+import { LoaderCircleIcon, PauseIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+export interface ModDownloadDisplay {
+  status: "queued" | "preparing" | "downloading" | "finalizing" | "paused";
+  progress: number | null;
+  speed: number | null;
+  pulse: boolean;
+}
+
+export function getModDownloadDisplay(transfer: TransferWithoutData): ModDownloadDisplay {
+  const progress = transfer.totalSize > 0 ? Math.max(0, Math.min(100, transfer.progress)) : null;
+  if (transfer.status === "pending") {
+    return { status: "queued", progress, speed: null, pulse: true };
+  }
+  if (transfer.status === "preparing") {
+    return { status: "preparing", progress, speed: null, pulse: true };
+  }
+  if (transfer.status === "paused") {
+    return { status: "paused", progress, speed: null, pulse: false };
+  }
+  if (progress !== null && progress >= 100) {
+    return { status: "finalizing", progress, speed: null, pulse: false };
+  }
+  return {
+    status: "downloading",
+    progress,
+    speed: transfer.speed > 0 ? transfer.speed : null,
+    pulse: progress === null,
+  };
+}
+
+export function ModDownloadOverlay({
+  transfer,
+  variant,
+}: {
+  transfer: TransferWithoutData;
+  variant: "card" | "row";
+}) {
+  const { t } = useTranslation();
+  const display = getModDownloadDisplay(transfer);
+  const isPaused = display.status === "paused";
+
+  return (
+    <div
+      className={cn(
+        "absolute inset-0 z-30 flex cursor-wait items-center justify-center bg-muted/88 px-4 backdrop-blur-[2px]",
+        variant === "row" && "cursor-default py-2",
+      )}
+    >
+      <div
+        className={cn(
+          "flex w-full max-w-sm flex-col gap-2",
+          variant === "row" && "max-w-xl gap-1.5",
+        )}
+      >
+        <div className="flex items-center justify-between gap-3 text-sm font-medium">
+          <span className="flex min-w-0 items-center gap-2">
+            {isPaused ? (
+              <PauseIcon className="size-4 shrink-0" />
+            ) : (
+              <LoaderCircleIcon className="size-4 shrink-0 animate-spin" />
+            )}
+            <span className="truncate">{t(`page.mod.download_overlay.${display.status}`)}</span>
+          </span>
+          <span className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground tabular-nums">
+            {display.speed !== null && <span>{formatSize(display.speed)}/s</span>}
+            <span>{display.progress === null ? "--%" : `${Math.round(display.progress)}%`}</span>
+          </span>
+        </div>
+        <Progress
+          value={display.progress ?? 0}
+          className={cn("w-full", display.pulse && "animate-pulse")}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/mod/mod-grid.tsx
+++ b/frontend/src/components/mod/mod-grid.tsx
@@ -4,6 +4,7 @@ import { useDelayedSkeleton } from "@renderer/hooks/use-delayed-skeleton";
 import { useFilteredMods } from "@renderer/hooks/use-filtered-mods";
 import { useModActions } from "@renderer/hooks/use-mod-actions";
 import { useModGroup } from "@renderer/hooks/use-mod-data";
+import { useModsWithDownloadPlaceholders } from "@renderer/hooks/use-mod-download-placeholders";
 import { useModMutations } from "@renderer/hooks/use-mod-mutations";
 import { useModShortcuts } from "@renderer/hooks/use-mod-shortcuts";
 import { useModGridLayoutSettings } from "@renderer/hooks/use-settings";
@@ -35,11 +36,16 @@ export function ModGrid(_props: ModGridProps) {
   const { toggleModMutation, exclusiveToggleModMutation, updateToggleKeyMutation } =
     useModMutations();
 
-  const mods = useFilteredMods(isPlaceholderData ? [] : activeGroup?.mods || [], searchQuery);
+  const displayMods = useModsWithDownloadPlaceholders(
+    selectedGroupPath,
+    isPlaceholderData ? [] : activeGroup?.mods || [],
+  );
+  const mods = useFilteredMods(displayMods, searchQuery);
   useModShortcuts(searchQuery, mods);
   const isLoading = isPending || isPlaceholderData;
   const showDelayedSkeleton = useDelayedSkeleton(isLoading);
-  const showSkeleton = (isPlaceholderData && activeGroup != null) || showDelayedSkeleton;
+  const showSkeleton =
+    displayMods.length === 0 && ((isPlaceholderData && activeGroup != null) || showDelayedSkeleton);
 
   const { data: gridLayoutSettings } = useModGridLayoutSettings();
 

--- a/frontend/src/components/mod/mod-list-row.tsx
+++ b/frontend/src/components/mod/mod-list-row.tsx
@@ -1,5 +1,6 @@
 import { PreviewLightbox } from "@renderer/components/ui/preview-lightbox";
 import type { ModActionApi } from "@renderer/hooks/use-mod-actions";
+import { useModDownloadTransfer } from "@renderer/hooks/use-mod-download-transfer";
 import i18n from "@renderer/lib/i18n";
 import { localFileSrc } from "@renderer/lib/local-file";
 import { cn } from "@renderer/lib/utils";
@@ -11,6 +12,7 @@ import { FolderIcon } from "lucide-react";
 import { memo } from "react";
 
 import { ModContextMenu } from "./mod-context-menu";
+import { ModDownloadOverlay } from "./mod-download-overlay";
 import { MOD_LIST_GRID_TEMPLATE_COLUMNS } from "./mod-list-layout";
 import { getModColorClass } from "./utils";
 
@@ -24,21 +26,29 @@ export const ModListRow = memo(function ModListRow({
   handleToggle: (mod: ModInfo, e?: React.MouseEvent) => void;
 }) {
   const isMergeSelected = useModStore((s) => s.isMergeMode && s.selectedModPaths.has(mod.path));
+  const downloadTransfer = useModDownloadTransfer(mod.path);
+  const isDownloading = mod.isDownloading || Boolean(downloadTransfer);
   const localSrc = mod.preview ? localFileSrc(mod.preview, { cacheKey: mod.mtime }) : "";
   const fullSrc = mod.preview ? localFileSrc(mod.preview, { orig: true, cacheKey: mod.mtime }) : "";
 
   return (
-    <ModContextMenu mod={mod} actions={actions}>
+    <ModContextMenu mod={mod} actions={actions} disabled={isDownloading}>
       <div
         role="row"
+        aria-busy={isDownloading}
+        aria-disabled={isDownloading}
         className={cn(
           "group relative grid h-14 cursor-pointer items-center border-b border-transparent transition-colors",
-          getModColorClass(mod.isEnabled),
-          isMergeSelected && "ring-2 ring-primary ring-inset",
-          "after:pointer-events-none after:absolute after:inset-0 hover:after:bg-black/10 dark:hover:after:bg-white/10",
+          isDownloading ? "cursor-wait bg-muted grayscale" : getModColorClass(mod.isEnabled),
+          !isDownloading && isMergeSelected && "ring-2 ring-primary ring-inset",
+          !isDownloading &&
+            "after:pointer-events-none after:absolute after:inset-0 hover:after:bg-black/10 dark:hover:after:bg-white/10",
         )}
         style={{ gridTemplateColumns: MOD_LIST_GRID_TEMPLATE_COLUMNS }}
         onClick={(e) => {
+          if (isDownloading) {
+            return;
+          }
           const target = e.target as HTMLElement;
           if (target.closest("button") || target.closest(".preview-trigger")) {
             return;
@@ -46,31 +56,34 @@ export const ModListRow = memo(function ModListRow({
           handleToggle(mod, e);
         }}
       >
-        <div role="cell" className="flex items-center justify-center py-2 pl-2 text-center">
-          {mod.preview ? (
-            <PreviewLightbox
-              className="preview-trigger flex size-10 shrink-0 cursor-zoom-in items-center justify-center overflow-hidden rounded-sm bg-secondary"
-              thumbnailSrc={localSrc}
-              fullSrc={fullSrc}
-              isVideo={/\.(mp4|webm|ogg)$/i.test(mod.preview)}
-            />
-          ) : (
-            <div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-sm bg-secondary/20">
-              <FolderIcon className="size-5 text-muted-foreground" />
-            </div>
-          )}
+        <div className="contents" inert={isDownloading}>
+          <div role="cell" className="flex items-center justify-center py-2 pl-2 text-center">
+            {mod.preview ? (
+              <PreviewLightbox
+                className="preview-trigger flex size-10 shrink-0 cursor-zoom-in items-center justify-center overflow-hidden rounded-sm bg-secondary"
+                thumbnailSrc={localSrc}
+                fullSrc={fullSrc}
+                isVideo={/\.(mp4|webm|ogg)$/i.test(mod.preview)}
+              />
+            ) : (
+              <div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-sm bg-secondary/20">
+                <FolderIcon className="size-5 text-muted-foreground" />
+              </div>
+            )}
+          </div>
+          <div role="cell" className="min-w-0 p-2 text-left">
+            <span className="block w-full truncate text-left font-medium">
+              {stripDisabledPrefix(mod.name)}
+            </span>
+          </div>
+          <div role="cell" className="p-2 text-right whitespace-nowrap text-muted-foreground">
+            {mod.isDownloadPlaceholder ? "—" : formatSize(mod.size || 0)}
+          </div>
+          <div role="cell" className="p-2 pr-3 text-right whitespace-nowrap text-muted-foreground">
+            {mod.isDownloadPlaceholder ? "—" : formatDate(new Date(mod.mtime), i18n.language)}
+          </div>
         </div>
-        <div role="cell" className="min-w-0 p-2 text-left">
-          <span className="block w-full truncate text-left font-medium">
-            {stripDisabledPrefix(mod.name)}
-          </span>
-        </div>
-        <div role="cell" className="p-2 text-right whitespace-nowrap text-muted-foreground">
-          {formatSize(mod.size || 0)}
-        </div>
-        <div role="cell" className="p-2 pr-3 text-right whitespace-nowrap text-muted-foreground">
-          {formatDate(new Date(mod.mtime), i18n.language)}
-        </div>
+        {downloadTransfer && <ModDownloadOverlay transfer={downloadTransfer} variant="row" />}
       </div>
     </ModContextMenu>
   );

--- a/frontend/src/components/mod/mod-list.tsx
+++ b/frontend/src/components/mod/mod-list.tsx
@@ -4,6 +4,7 @@ import { useDelayedSkeleton } from "@renderer/hooks/use-delayed-skeleton";
 import { useFilteredMods } from "@renderer/hooks/use-filtered-mods";
 import { useModActions } from "@renderer/hooks/use-mod-actions";
 import { useModGroup } from "@renderer/hooks/use-mod-data";
+import { useModsWithDownloadPlaceholders } from "@renderer/hooks/use-mod-download-placeholders";
 import { useModMutations } from "@renderer/hooks/use-mod-mutations";
 import { useModShortcuts } from "@renderer/hooks/use-mod-shortcuts";
 import { useModStore } from "@renderer/store/mod";
@@ -33,11 +34,16 @@ export function ModList(_props: ModListProps) {
   const toggleMergeSelection = useModStore((s) => s.toggleMergeSelection);
   const { toggleModMutation, exclusiveToggleModMutation } = useModMutations();
 
-  const mods = useFilteredMods(isPlaceholderData ? [] : activeGroup?.mods || [], searchQuery);
+  const displayMods = useModsWithDownloadPlaceholders(
+    selectedGroupPath,
+    isPlaceholderData ? [] : activeGroup?.mods || [],
+  );
+  const mods = useFilteredMods(displayMods, searchQuery);
   useModShortcuts(searchQuery, mods);
   const isLoading = isPending || isPlaceholderData;
   const showDelayedSkeleton = useDelayedSkeleton(isLoading);
-  const showSkeleton = (isPlaceholderData && activeGroup != null) || showDelayedSkeleton;
+  const showSkeleton =
+    displayMods.length === 0 && ((isPlaceholderData && activeGroup != null) || showDelayedSkeleton);
   const getRowKey = useCallback(
     (index: number) => {
       const modPath = mods[index]?.path;

--- a/frontend/src/hooks/use-filtered-mods.ts
+++ b/frontend/src/hooks/use-filtered-mods.ts
@@ -34,6 +34,10 @@ export function useFilteredMods(mods: ModInfo[], searchQuery: string) {
 
         return filtered
             .sort((a, b) => {
+                if (Boolean(a.mod.isDownloading) !== Boolean(b.mod.isDownloading)) {
+                    return a.mod.isDownloading ? -1 : 1;
+                }
+
                 if (a.mod.isEnabled !== b.mod.isEnabled) {
                     return a.mod.isEnabled ? -1 : 1;
                 }

--- a/frontend/src/hooks/use-mod-download-placeholders.test.ts
+++ b/frontend/src/hooks/use-mod-download-placeholders.test.ts
@@ -1,0 +1,143 @@
+import type { ModInfo, TransferWithoutData } from "@shared/types";
+import { describe, expect, it } from "vitest";
+
+import {
+    getDownloadDirectoryTargetIdentity,
+    getDownloadDirectoryTargets,
+    getSelectedDownloadPaths,
+    mergeDownloadPlaceholders,
+} from "./use-mod-download-placeholders";
+import { normalizeModDownloadPath } from "./use-mod-download-transfer";
+
+function transfer(overrides: Partial<TransferWithoutData> = {}): TransferWithoutData {
+    return {
+        pid: "download",
+        type: "download",
+        status: "progress",
+        totalSize: 100,
+        transferedSize: 25,
+        progress: 25,
+        speed: 10,
+        eta: 8,
+        startTime: 123,
+        name: "Mod",
+        totalFiles: 1,
+        transferedFiles: 0,
+        failedFiles: 0,
+        path: "C:/Mods/Character",
+        destinationPaths: ["C:/Mods/Character/Mod"],
+        destinationTargets: [{ path: "C:/Mods/Character/Mod", kind: "directory" }],
+        ...overrides,
+    };
+}
+
+function mod(overrides: Partial<ModInfo> = {}): ModInfo {
+    return {
+        id: "installed",
+        name: "Installed",
+        path: "C:/Mods/Character/Installed",
+        isEnabled: true,
+        mtime: 1,
+        size: 10,
+        inis: [],
+        ...overrides,
+    };
+}
+
+describe("download mod placeholders", () => {
+    const groupPath = normalizeModDownloadPath("C:\\Mods\\Character\\");
+
+    it.each(["pending", "preparing", "progress", "paused"] as const)(
+        "collects direct directory targets from %s downloads",
+        (status) => {
+            expect(getDownloadDirectoryTargets([transfer({ status })], groupPath)).toEqual([
+                {
+                    normalizedPath: "c:/mods/character/mod",
+                    path: "C:/Mods/Character/Mod",
+                    pid: "download",
+                    startTime: 123,
+                },
+            ]);
+        },
+    );
+
+    it("excludes files, nested directories, other groups, uploads, and terminal transfers", () => {
+        const targets = [
+            transfer({
+                destinationTargets: [
+                    { path: "C:/Mods/Character/file.zip", kind: "file" },
+                    { path: "C:/Mods/Character/Mod/Nested", kind: "directory" },
+                    { path: "C:/Mods/Other/Mod", kind: "directory" },
+                ],
+            }),
+            transfer({ pid: "upload", type: "upload" }),
+            transfer({ pid: "completed", status: "completed" }),
+            transfer({ pid: "error", status: "error" }),
+            transfer({ pid: "canceled", status: "canceled" }),
+        ];
+
+        expect(getDownloadDirectoryTargets(targets, groupPath)).toEqual([]);
+    });
+
+    it("deduplicates equivalent Windows paths", () => {
+        const duplicate = transfer({
+            pid: "duplicate",
+            destinationTargets: [{ path: "c:\\mods\\character\\MOD\\", kind: "directory" }],
+        });
+
+        expect(getDownloadDirectoryTargets([transfer(), duplicate], groupPath)).toHaveLength(1);
+    });
+
+    it("finds existing merge selections that become download targets", () => {
+        const selected = new Set(["C:\\Mods\\Character\\Mod\\", "C:\\Mods\\Character\\Other"]);
+        const targets = new Set(["c:/mods/character/mod"]);
+
+        expect(getSelectedDownloadPaths(selected, targets)).toEqual(["C:\\Mods\\Character\\Mod\\"]);
+    });
+
+    it("keeps list identity stable across progress-only updates", () => {
+        const before = getDownloadDirectoryTargetIdentity([transfer()], groupPath);
+        const after = getDownloadDirectoryTargetIdentity(
+            [transfer({ progress: 70, transferedSize: 70, speed: 2048, eta: 2 })],
+            groupPath,
+        );
+
+        expect(after).toBe(before);
+        expect(
+            getDownloadDirectoryTargetIdentity(
+                [
+                    transfer({
+                        destinationTargets: [
+                            { path: "C:/Mods/Character/Renamed", kind: "directory" },
+                        ],
+                    }),
+                ],
+                groupPath,
+            ),
+        ).not.toBe(before);
+    });
+
+    it("adds a minimal placeholder and prefers a scanned mod at the same path", () => {
+        const targets = getDownloadDirectoryTargets([transfer()], groupPath);
+        const placeholder = mergeDownloadPlaceholders([], targets);
+
+        expect(placeholder).toEqual([
+            {
+                id: "download:download:c:/mods/character/mod",
+                name: "Mod",
+                path: "C:/Mods/Character/Mod",
+                isEnabled: false,
+                mtime: 123,
+                size: 0,
+                inis: [],
+                isDownloading: true,
+                isDownloadPlaceholder: true,
+            },
+        ]);
+
+        const installed = mod({ path: "c:\\MODS\\Character\\Mod\\" });
+        expect(mergeDownloadPlaceholders([installed], targets)).toEqual([
+            { ...installed, isDownloading: true },
+        ]);
+    });
+});

--- a/frontend/src/hooks/use-mod-download-placeholders.ts
+++ b/frontend/src/hooks/use-mod-download-placeholders.ts
@@ -1,0 +1,148 @@
+import { globalStore, useGlobalStore } from "@renderer/store/global";
+import { modStore } from "@renderer/store/mod";
+import type { ModInfo, TransferWithoutData } from "@shared/types";
+import { useCallback, useEffect, useMemo } from "react";
+
+import { isActiveModDownloadTransfer, normalizeModDownloadPath } from "./use-mod-download-transfer";
+
+export interface DownloadDirectoryTarget {
+    normalizedPath: string;
+    path: string;
+    pid: string;
+    startTime: number;
+}
+
+export function useModsWithDownloadPlaceholders(
+    groupPath: string | undefined,
+    installedMods: ModInfo[],
+): ModInfo[] {
+    const normalizedGroupPath = useMemo(
+        () => (groupPath ? normalizeModDownloadPath(groupPath) : ""),
+        [groupPath],
+    );
+    const targetIdentity = useGlobalStore(
+        useCallback(
+            (state) => getDownloadDirectoryTargetIdentity(state.transfers, normalizedGroupPath),
+            [normalizedGroupPath],
+        ),
+    );
+    const targets = useMemo(
+        () => getDownloadDirectoryTargets(globalStore.getState().transfers, normalizedGroupPath),
+        [normalizedGroupPath, targetIdentity],
+    );
+
+    useEffect(() => {
+        const targetPaths = new Set(targets.map((target) => target.normalizedPath));
+        if (targetPaths.size === 0) {
+            return;
+        }
+        const state = modStore.getState();
+        const selectedDownloads = getSelectedDownloadPaths(state.selectedModPaths, targetPaths);
+        state.removeMergeSelections(selectedDownloads);
+    }, [targets]);
+
+    return useMemo(
+        () => mergeDownloadPlaceholders(installedMods, targets),
+        [installedMods, targets],
+    );
+}
+
+export function getSelectedDownloadPaths(
+    selectedModPaths: Iterable<string>,
+    normalizedTargetPaths: ReadonlySet<string>,
+): string[] {
+    return Array.from(selectedModPaths).filter((path) =>
+        normalizedTargetPaths.has(normalizeModDownloadPath(path)),
+    );
+}
+
+export function getDownloadDirectoryTargetIdentity(
+    transfers: TransferWithoutData[],
+    normalizedGroupPath: string,
+): string {
+    return JSON.stringify(
+        getDownloadDirectoryTargets(transfers, normalizedGroupPath).map((target) => [
+            target.pid,
+            target.normalizedPath,
+            target.startTime,
+        ]),
+    );
+}
+
+export function getDownloadDirectoryTargets(
+    transfers: TransferWithoutData[],
+    normalizedGroupPath: string,
+): DownloadDirectoryTarget[] {
+    if (!normalizedGroupPath) {
+        return [];
+    }
+
+    const seenPaths = new Set<string>();
+    return transfers.flatMap((transfer) => {
+        if (!isActiveModDownloadTransfer(transfer)) {
+            return [];
+        }
+
+        return (transfer.destinationTargets ?? []).flatMap((target) => {
+            if (target.kind !== "directory") {
+                return [];
+            }
+            const normalizedPath = normalizeModDownloadPath(target.path);
+            if (
+                getNormalizedParentPath(normalizedPath) !== normalizedGroupPath ||
+                seenPaths.has(normalizedPath)
+            ) {
+                return [];
+            }
+            seenPaths.add(normalizedPath);
+            return [
+                {
+                    normalizedPath,
+                    path: target.path,
+                    pid: transfer.pid,
+                    startTime: transfer.startTime,
+                },
+            ];
+        });
+    });
+}
+
+export function mergeDownloadPlaceholders(
+    installedMods: ModInfo[],
+    targets: DownloadDirectoryTarget[],
+): ModInfo[] {
+    const targetPaths = new Set(targets.map((target) => target.normalizedPath));
+    const mergedInstalledMods = installedMods.map((mod) =>
+        targetPaths.has(normalizeModDownloadPath(mod.path)) ? { ...mod, isDownloading: true } : mod,
+    );
+    const installedPaths = new Set(installedMods.map((mod) => normalizeModDownloadPath(mod.path)));
+    const placeholders = targets.flatMap((target): ModInfo[] => {
+        if (installedPaths.has(target.normalizedPath)) {
+            return [];
+        }
+        return [
+            {
+                id: `download:${target.pid}:${target.normalizedPath}`,
+                name: getWindowsBaseName(target.path),
+                path: target.path,
+                isEnabled: false,
+                mtime: target.startTime,
+                size: 0,
+                inis: [],
+                isDownloading: true,
+                isDownloadPlaceholder: true,
+            },
+        ];
+    });
+    return [...mergedInstalledMods, ...placeholders];
+}
+
+function getNormalizedParentPath(path: string): string {
+    const separatorIndex = path.lastIndexOf("/");
+    return separatorIndex < 0 ? "" : path.slice(0, separatorIndex);
+}
+
+function getWindowsBaseName(path: string): string {
+    const normalized = path.replaceAll("\\", "/").replace(/\/+$/, "");
+    return normalized.slice(normalized.lastIndexOf("/") + 1);
+}

--- a/frontend/src/hooks/use-mod-download-transfer.test.ts
+++ b/frontend/src/hooks/use-mod-download-transfer.test.ts
@@ -1,0 +1,74 @@
+import type { TransferWithoutData } from "@shared/types";
+import { describe, expect, it } from "vitest";
+
+import { findModDownloadTransfer, normalizeModDownloadPath } from "./use-mod-download-transfer";
+
+function transfer(overrides: Partial<TransferWithoutData> = {}): TransferWithoutData {
+    return {
+        pid: "download",
+        type: "download",
+        status: "progress",
+        totalSize: 100,
+        transferedSize: 25,
+        progress: 25,
+        speed: 10,
+        eta: 8,
+        startTime: 1,
+        name: "Mod",
+        totalFiles: 1,
+        transferedFiles: 0,
+        failedFiles: 0,
+        path: "C:/Mods/Character",
+        destinationPaths: ["C:/Mods/Character/Mod"],
+        ...overrides,
+    };
+}
+
+describe("findModDownloadTransfer", () => {
+    it("normalizes Windows separators, casing, and trailing separators", () => {
+        expect(normalizeModDownloadPath("C:\\Mods\\Character\\Mod\\")).toBe(
+            "c:/mods/character/mod",
+        );
+        expect(
+            findModDownloadTransfer(
+                [transfer({ destinationPaths: ["C:\\MODS\\Character\\Mod\\"] })],
+                "c:/mods/character/mod",
+            )?.pid,
+        ).toBe("download");
+    });
+
+    it.each(["pending", "preparing", "progress", "paused"] as const)(
+        "matches %s downloads",
+        (status) => {
+            expect(
+                findModDownloadTransfer([transfer({ status })], "C:/Mods/Character/Mod")?.pid,
+            ).toBe("download");
+        },
+    );
+
+    it.each(["completed", "error", "canceled"] as const)(
+        "does not match %s downloads",
+        (status) => {
+            expect(findModDownloadTransfer([transfer({ status })], "C:/Mods/Character/Mod")).toBe(
+                undefined,
+            );
+        },
+    );
+
+    it("does not match uploads or an unrelated child of the same parent", () => {
+        expect(
+            findModDownloadTransfer([transfer({ type: "upload" })], "C:/Mods/Character/Mod"),
+        ).toBeUndefined();
+        expect(findModDownloadTransfer([transfer()], "C:/Mods/Character/Other")).toBeUndefined();
+    });
+
+    it("matches every destination in a batch to the same transfer", () => {
+        const batch = transfer({
+            pid: "batch",
+            destinationPaths: ["C:/Mods/Character/One", "C:/Mods/Character/Two"],
+        });
+
+        expect(findModDownloadTransfer([batch], "C:/Mods/Character/One")?.pid).toBe("batch");
+        expect(findModDownloadTransfer([batch], "C:/Mods/Character/Two")?.pid).toBe("batch");
+    });
+});

--- a/frontend/src/hooks/use-mod-download-transfer.ts
+++ b/frontend/src/hooks/use-mod-download-transfer.ts
@@ -1,0 +1,50 @@
+import { useGlobalStore } from "@renderer/store/global";
+import type { TransferWithoutData } from "@shared/types";
+import { useCallback, useMemo } from "react";
+
+const MOD_DOWNLOAD_STATUSES = new Set<TransferWithoutData["status"]>([
+    "pending",
+    "preparing",
+    "progress",
+    "paused",
+]);
+
+export function isActiveModDownloadTransfer(transfer: TransferWithoutData): boolean {
+    return transfer.type === "download" && MOD_DOWNLOAD_STATUSES.has(transfer.status);
+}
+
+export function normalizeModDownloadPath(path: string): string {
+    return path.replaceAll("\\", "/").replace(/\/+$/, "").toLowerCase();
+}
+
+export function findModDownloadTransfer(
+    transfers: TransferWithoutData[],
+    modPath: string,
+): TransferWithoutData | undefined {
+    const normalizedModPath = normalizeModDownloadPath(modPath);
+    return findModDownloadTransferByNormalizedPath(transfers, normalizedModPath);
+}
+
+export function useModDownloadTransfer(modPath: string): TransferWithoutData | undefined {
+    const normalizedModPath = useMemo(() => normalizeModDownloadPath(modPath), [modPath]);
+    return useGlobalStore(
+        useCallback(
+            (state) => findModDownloadTransferByNormalizedPath(state.transfers, normalizedModPath),
+            [normalizedModPath],
+        ),
+    );
+}
+
+function findModDownloadTransferByNormalizedPath(
+    transfers: TransferWithoutData[],
+    normalizedModPath: string,
+): TransferWithoutData | undefined {
+    return transfers.find(
+        (transfer) =>
+            isActiveModDownloadTransfer(transfer) &&
+            transfer.destinationPaths?.some(
+                (destinationPath) =>
+                    normalizeModDownloadPath(destinationPath) === normalizedModPath,
+            ),
+    );
+}

--- a/frontend/src/hooks/use-mod-mutations.ts
+++ b/frontend/src/hooks/use-mod-mutations.ts
@@ -304,6 +304,11 @@ export function useModMutations() {
             return;
         }
 
+        if (errorMessage.includes("MOD_DOWNLOAD_IN_PROGRESS")) {
+            toast.warning(t("page.mod.download_action_blocked"));
+            return;
+        }
+
         toast.error(t("page.mod.hooks.use-mod-mutations.toggle-mutation.2"));
     };
 
@@ -338,6 +343,11 @@ export function useModMutations() {
             errorMessage.includes("INVALID_MOD_NAME")
         ) {
             toast.error(t("page.mod.hooks.use-mod-mutations.rename-mutation.2"));
+            return;
+        }
+
+        if (errorMessage.includes("MOD_DOWNLOAD_IN_PROGRESS")) {
+            toast.warning(t("page.mod.download_action_blocked"));
             return;
         }
 

--- a/frontend/src/hooks/use-mod-shortcuts.ts
+++ b/frontend/src/hooks/use-mod-shortcuts.ts
@@ -1,7 +1,10 @@
 import { useModMutations } from "@renderer/hooks/use-mod-mutations";
+import { globalStore } from "@renderer/store/global";
 import { modStore } from "@renderer/store/mod";
 import type { ModInfo } from "@renderer/types/mod";
 import { useEffect, useLayoutEffect, useRef } from "react";
+
+import { findModDownloadTransfer } from "./use-mod-download-transfer";
 
 export function useModShortcuts(searchQuery: string, filteredMods: ModInfo[]) {
     const latestSearchQueryRef = useRef(searchQuery);
@@ -69,8 +72,16 @@ export function useModShortcuts(searchQuery: string, filteredMods: ModInfo[]) {
                 return;
             }
 
+            const mod = latestFilteredModsRef.current[0];
             e.preventDefault();
-            exclusiveToggleRef.current(latestFilteredModsRef.current[0]);
+            if (
+                mod.isDownloading ||
+                findModDownloadTransfer(globalStore.getState().transfers, mod.path)
+            ) {
+                return;
+            }
+
+            exclusiveToggleRef.current(mod);
             modStore.getState().setSearchQuery("");
         };
 

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -278,6 +278,14 @@
         "description": "Compressed files will be automatically extracted"
       },
       "download_completed": "Downloaded \"{{name}}\".",
+      "download_action_blocked": "A mod cannot be changed while it is downloading.",
+      "download_overlay": {
+        "queued": "Queued",
+        "preparing": "Preparing",
+        "downloading": "Downloading",
+        "finalizing": "Finalizing",
+        "paused": "Paused"
+      },
       "all_enabled": "Enable all",
       "all_disabled": "Disable all",
       "merge": {

--- a/frontend/src/lib/i18n/locales/ja.json
+++ b/frontend/src/lib/i18n/locales/ja.json
@@ -262,6 +262,14 @@
         "description": "圧縮ファイルは自動的に解凍されます"
       },
       "download_completed": "\"{{name}}\" のダウンロードが完了しました。",
+      "download_action_blocked": "ダウンロード中のMODは変更できません。",
+      "download_overlay": {
+        "queued": "待機中",
+        "preparing": "準備中",
+        "downloading": "ダウンロード中",
+        "finalizing": "完了処理中",
+        "paused": "一時停止"
+      },
       "all_enabled": "すべて有効化",
       "all_disabled": "すべて無効化",
       "merge": {

--- a/frontend/src/lib/i18n/locales/ko.json
+++ b/frontend/src/lib/i18n/locales/ko.json
@@ -261,6 +261,14 @@
         "description": "압축 파일은 자동으로 압축 해제됩니다"
       },
       "download_completed": "\"{{name}}\" 다운로드가 완료되었습니다.",
+      "download_action_blocked": "다운로드 중인 모드는 변경할 수 없습니다.",
+      "download_overlay": {
+        "queued": "대기 중",
+        "preparing": "준비 중",
+        "downloading": "다운로드 중",
+        "finalizing": "마무리 중",
+        "paused": "일시정지"
+      },
       "all_enabled": "모두 활성화",
       "all_disabled": "모두 비활성화",
       "merge": {

--- a/frontend/src/lib/i18n/locales/zh.json
+++ b/frontend/src/lib/i18n/locales/zh.json
@@ -261,6 +261,14 @@
         "description": "压缩文件将自动解压"
       },
       "download_completed": "已下载 \"{{name}}\"。",
+      "download_action_blocked": "模组下载期间无法修改。",
+      "download_overlay": {
+        "queued": "等待中",
+        "preparing": "准备中",
+        "downloading": "下载中",
+        "finalizing": "正在完成",
+        "paused": "已暂停"
+      },
       "all_enabled": "全部启用",
       "all_disabled": "全部禁用",
       "merge": {

--- a/frontend/src/shared/types.ts
+++ b/frontend/src/shared/types.ts
@@ -263,6 +263,8 @@ export interface ModInfo {
     preview?: string;
     mtime: number;
     size: number;
+    isDownloading?: boolean;
+    isDownloadPlaceholder?: boolean;
     inis: {
         name: string;
         path: string;
@@ -562,6 +564,11 @@ export interface Transfer {
     transferedFiles: number;
     failedFiles: number;
     path?: string;
+    destinationPaths?: string[];
+    destinationTargets?: {
+        path: string;
+        kind: "file" | "directory";
+    }[];
     error?: string;
     errorCode?: string;
     planPhase?: PlanPhase;

--- a/frontend/src/store/mod.test.ts
+++ b/frontend/src/store/mod.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { modStore } from "./mod";
+
+afterEach(() => {
+    modStore.setState({
+        isMergeMode: false,
+        selectedModPaths: new Set(),
+        isMergeDialogOpen: false,
+    });
+});
+
+describe("mod merge selections", () => {
+    it("removes downloading mods and closes an invalid merge dialog", () => {
+        modStore.setState({
+            isMergeMode: true,
+            selectedModPaths: new Set(["A", "B"]),
+            isMergeDialogOpen: true,
+        });
+
+        modStore.getState().removeMergeSelections(["A"]);
+
+        expect(modStore.getState().selectedModPaths).toEqual(new Set(["B"]));
+        expect(modStore.getState().isMergeDialogOpen).toBe(false);
+        expect(modStore.getState().isMergeMode).toBe(true);
+    });
+
+    it("leaves the dialog open while at least two selections remain", () => {
+        modStore.setState({
+            isMergeMode: true,
+            selectedModPaths: new Set(["A", "B", "C"]),
+            isMergeDialogOpen: true,
+        });
+
+        modStore.getState().removeMergeSelections(["A"]);
+
+        expect(modStore.getState().selectedModPaths).toEqual(new Set(["B", "C"]));
+        expect(modStore.getState().isMergeDialogOpen).toBe(true);
+    });
+});

--- a/frontend/src/store/mod.ts
+++ b/frontend/src/store/mod.ts
@@ -82,6 +82,7 @@ interface ModState {
     enterMergeMode: () => void;
     exitMergeMode: () => void;
     toggleMergeSelection: (modPath: string) => void;
+    removeMergeSelections: (modPaths: string[]) => void;
     setMergeDialogOpen: (open: boolean) => void;
 }
 
@@ -228,6 +229,21 @@ export const modStore = createStore<ModState>((set) => ({
             if (next.has(modPath)) next.delete(modPath);
             else next.add(modPath);
             return { selectedModPaths: next };
+        }),
+    removeMergeSelections: (modPaths) =>
+        set((state) => {
+            const next = new Set(state.selectedModPaths);
+            const changed = modPaths.reduce(
+                (removed, modPath) => next.delete(modPath) || removed,
+                false,
+            );
+            if (!changed) {
+                return state;
+            }
+            return {
+                selectedModPaths: next,
+                isMergeDialogOpen: next.size >= 2 && state.isMergeDialogOpen,
+            };
         }),
     setMergeDialogOpen: (isMergeDialogOpen) => set({ isMergeDialogOpen }),
 

--- a/frontend/src/types/mod.ts
+++ b/frontend/src/types/mod.ts
@@ -23,6 +23,8 @@ export interface ModInfo {
     preview?: string;
     mtime: number;
     size: number;
+    isDownloading?: boolean;
+    isDownloadPlaceholder?: boolean;
     inis: {
         name: string;
         path: string;

--- a/internal/drive/download_service.go
+++ b/internal/drive/download_service.go
@@ -32,11 +32,6 @@ type StartDownloadResult struct {
 	Status string `json:"status"`
 }
 
-type downloadRunnerState struct {
-	mu       sync.Mutex
-	metadata *DownloadMetadata
-}
-
 func (d *Drive) StartDownload(ctx context.Context, params StartDownloadParams) (result StartDownloadResult, err error) {
 	defer normalizeDriveBoundaryError(&err, "fn:startDownload")
 	if d == nil || d.transfer == nil || d.download == nil {
@@ -74,26 +69,51 @@ func (d *Drive) StartDownload(ctx context.Context, params StartDownloadParams) (
 		return StartDownloadResult{}, fmt.Errorf("path is not writable: %s", targetPath)
 	}
 	params.TargetPath = filepath.Clean(targetPath)
+	var metadata DownloadMetadata
+	if params.Data == nil {
+		metadata, err = d.fetchDownloadMetadata(ctx, params.Items, params.Link)
+		if err != nil {
+			return StartDownloadResult{}, err
+		}
+	} else {
+		metadata = cloneDownloadMetadata(*params.Data)
+	}
+	prepared, err := d.prepareDownloadMetadata(ctx, nil, "", metadata, params)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			if ctx.Err() != nil {
+				return StartDownloadResult{}, ctx.Err()
+			}
+			return StartDownloadResult{Status: "canceled"}, nil
+		}
+		return StartDownloadResult{}, err
+	}
+	destinationTargets, err := resolveDownloadDestinationTargets(prepared, params.TargetPath)
+	if err != nil {
+		return StartDownloadResult{}, err
+	}
+	data := transfer.Data{Root: &prepared.Root, Files: slices.Clone(prepared.Files), Dirs: slices.Clone(prepared.Dirs)}
+	name := prepared.Root.Name
+	if len(params.Items) != 1 {
+		name = fmt.Sprintf("%d items", len(params.Items))
+	}
 	pid := uuid.NewString()
-	rootName := "Loading"
-	initial := transfer.Data{Root: &transfer.Root{Name: rootName}, Files: []transfer.DownloadFile{}, Dirs: []transfer.Directory{}}
-	name := "Preparing Download..."
 	if _, err := d.transfer.Create(transfer.CreateParams{
-		PID:           pid,
-		Type:          "download",
-		Name:          name,
-		Path:          filepath.ToSlash(params.TargetPath),
-		CurrentID:     downloadCurrentID(params),
-		InitialStatus: transfer.StatusPreparing,
-		Data:          initial,
-		RestartData:   params,
+		PID:                pid,
+		Type:               "download",
+		Name:               name,
+		Path:               filepath.ToSlash(params.TargetPath),
+		DestinationTargets: destinationTargets,
+		CurrentID:          downloadCurrentID(params),
+		InitialStatus:      transfer.StatusPreparing,
+		Data:               data,
+		RestartData:        params,
 	}); err != nil {
 		return StartDownloadResult{}, err
 	}
-	state := &downloadRunnerState{}
-	if params.Data != nil {
-		cloned := cloneDownloadMetadata(*params.Data)
-		state.metadata = &cloned
+	if err := d.transfer.SetData(pid, data, prepared.TotalBytes, name, destinationTargets); err != nil {
+		_ = d.transfer.Cancel(pid)
+		return StartDownloadResult{}, err
 	}
 	pending := transfer.StatusPending
 	if err := d.transfer.Update(pid, transfer.Updates{Status: &pending}); err != nil {
@@ -101,7 +121,7 @@ func (d *Drive) StartDownload(ctx context.Context, params StartDownloadParams) (
 		return StartDownloadResult{}, err
 	}
 	if err := d.transfer.RegisterRunner(pid, func(runCtx context.Context, transfers *transfer.Transfer, runnerPID string) error {
-		return d.runDownload(runCtx, transfers, runnerPID, params, state)
+		return d.runDownload(runCtx, transfers, runnerPID, params, prepared)
 	}); err != nil {
 		_ = d.transfer.Cancel(pid)
 		return StartDownloadResult{}, err
@@ -161,30 +181,16 @@ func (d *Drive) resolveDownloadTarget(ctx context.Context, params StartDownloadP
 	return resolvedDownloadTarget{path: *path, suggestedName: suggestedName}, nil
 }
 
-func (d *Drive) runDownload(ctx context.Context, transfers *transfer.Transfer, pid string, params StartDownloadParams, state *downloadRunnerState) error {
+func (d *Drive) runDownload(
+	ctx context.Context,
+	transfers *transfer.Transfer,
+	pid string,
+	params StartDownloadParams,
+	prepared DownloadMetadata,
+) error {
 	preparing := transfer.StatusPreparing
 	if err := transfers.Update(pid, transfer.Updates{Status: &preparing, ClearError: true, ClearErrorCode: true}); err != nil {
 		return err
-	}
-	state.mu.Lock()
-	metadata := state.metadata
-	state.mu.Unlock()
-	if metadata == nil {
-		fetched, err := d.fetchDownloadMetadata(ctx, params.Items, params.Link)
-		if err != nil {
-			return d.failDownloadTransfer(transfers, pid, err)
-		}
-		metadata = &fetched
-		state.mu.Lock()
-		state.metadata = metadata
-		state.mu.Unlock()
-	}
-	prepared, err := d.prepareDownloadMetadata(ctx, transfers, pid, *metadata, params)
-	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			return err
-		}
-		return d.failDownloadTransfer(transfers, pid, err)
 	}
 	name := prepared.Root.Name
 	if len(params.Items) != 1 {

--- a/internal/drive/download_service.go
+++ b/internal/drive/download_service.go
@@ -190,8 +190,12 @@ func (d *Drive) runDownload(ctx context.Context, transfers *transfer.Transfer, p
 	if len(params.Items) != 1 {
 		name = fmt.Sprintf("%d items", len(params.Items))
 	}
+	destinationTargets, err := resolveDownloadDestinationTargets(prepared, params.TargetPath)
+	if err != nil {
+		return d.failDownloadTransfer(transfers, pid, err)
+	}
 	data := transfer.Data{Root: &prepared.Root, Files: slices.Clone(prepared.Files), Dirs: slices.Clone(prepared.Dirs)}
-	if err := transfers.SetData(pid, data, prepared.TotalBytes, name); err != nil {
+	if err := transfers.SetData(pid, data, prepared.TotalBytes, name, destinationTargets); err != nil {
 		return err
 	}
 	if err := d.executeDownload(ctx, transfers, pid, params, prepared); err != nil {
@@ -517,6 +521,48 @@ func resolveDownloadPaths(metadata DownloadMetadata, targetPath string) (map[str
 		}
 	}
 	return paths, false, nil
+}
+
+func resolveDownloadDestinationTargets(metadata DownloadMetadata, targetPath string) ([]transfer.DestinationTarget, error) {
+	paths, singleFile, err := resolveDownloadPaths(metadata, targetPath)
+	if err != nil {
+		return nil, err
+	}
+	if singleFile {
+		return []transfer.DestinationTarget{{
+			Path: filepath.Join(targetPath, metadata.Files[0].Name),
+			Kind: transfer.DestinationFile,
+		}}, nil
+	}
+	if metadata.Root.Name != "" {
+		return []transfer.DestinationTarget{{
+			Path: paths[metadata.Root.ID],
+			Kind: transfer.DestinationDirectory,
+		}}, nil
+	}
+
+	destinationTargets := make([]transfer.DestinationTarget, 0)
+	for _, directory := range metadata.Dirs {
+		if directory.ParentID == nil || *directory.ParentID != metadata.Root.ID {
+			continue
+		}
+		if path := paths[directory.ID]; path != "" {
+			destinationTargets = append(destinationTargets, transfer.DestinationTarget{
+				Path: path,
+				Kind: transfer.DestinationDirectory,
+			})
+		}
+	}
+	rootPath := paths[metadata.Root.ID]
+	for _, file := range metadata.Files {
+		if file.ParentID != nil && *file.ParentID == metadata.Root.ID {
+			destinationTargets = append(destinationTargets, transfer.DestinationTarget{
+				Path: filepath.Join(rootPath, file.Name),
+				Kind: transfer.DestinationFile,
+			})
+		}
+	}
+	return destinationTargets, nil
 }
 
 func parentDownloadKey(file transfer.DownloadFile, rootID string, singleFile bool) string {

--- a/internal/drive/download_service_test.go
+++ b/internal/drive/download_service_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -122,6 +123,19 @@ func TestCanceledDownloadDoesNotCreateQueuedEmptyDirectories(t *testing.T) {
 	case <-requestStarted:
 	case <-time.After(time.Second):
 		t.Fatal("download did not start")
+	}
+	record, ok := transfers.Get(result.PID)
+	if !ok || record.Status != transfer.StatusProgress {
+		t.Fatalf("active transfer = %+v, ok=%v", record, ok)
+	}
+	wantDestination := filepath.Join(target, "package")
+	if len(record.DestinationPaths) != 1 || record.DestinationPaths[0] != wantDestination {
+		t.Fatalf("active destination paths = %#v, want %q", record.DestinationPaths, wantDestination)
+	}
+	if len(record.DestinationTargets) != 1 ||
+		record.DestinationTargets[0].Path != wantDestination ||
+		record.DestinationTargets[0].Kind != transfer.DestinationDirectory {
+		t.Fatalf("active destination targets = %#v", record.DestinationTargets)
 	}
 	if err := transfers.Cancel(result.PID); err != nil {
 		t.Fatal(err)
@@ -432,6 +446,70 @@ func TestResolveDownloadPathsRejectsDuplicateDirectoryID(t *testing.T) {
 	}
 	if _, _, err := resolveDownloadPaths(metadata, t.TempDir()); err == nil {
 		t.Fatal("expected duplicate directory error")
+	}
+}
+
+func TestResolveDownloadDestinationTargets(t *testing.T) {
+	target := filepath.Join(`C:\Mods`, "Character")
+	rootID := "root"
+	batchID := "batch-root"
+
+	tests := []struct {
+		name     string
+		metadata DownloadMetadata
+		want     []transfer.DestinationTarget
+	}{
+		{
+			name: "single file",
+			metadata: DownloadMetadata{
+				Root:  transfer.Root{ID: "file", Name: "mod.zip"},
+				Files: []transfer.DownloadFile{{ID: "file", Name: "mod.zip"}},
+			},
+			want: []transfer.DestinationTarget{{
+				Path: filepath.Join(target, "mod.zip"),
+				Kind: transfer.DestinationFile,
+			}},
+		},
+		{
+			name: "single renamed folder",
+			metadata: DownloadMetadata{
+				Root: transfer.Root{ID: rootID, Name: "Mod (2)"},
+				Dirs: []transfer.Directory{{ID: rootID, Name: "Mod (2)"}},
+			},
+			want: []transfer.DestinationTarget{{
+				Path: filepath.Join(target, "Mod (2)"),
+				Kind: transfer.DestinationDirectory,
+			}},
+		},
+		{
+			name: "batch folders and file",
+			metadata: DownloadMetadata{
+				Root: transfer.Root{ID: batchID},
+				Dirs: []transfer.Directory{
+					{ID: "one", ParentID: &batchID, Name: "One"},
+					{ID: "nested", ParentID: &rootID, Name: "Nested"},
+					{ID: rootID, ParentID: &batchID, Name: "Two"},
+				},
+				Files: []transfer.DownloadFile{{ID: "file", ParentID: &batchID, Name: "readme.txt"}},
+			},
+			want: []transfer.DestinationTarget{
+				{Path: filepath.Join(target, "One"), Kind: transfer.DestinationDirectory},
+				{Path: filepath.Join(target, "Two"), Kind: transfer.DestinationDirectory},
+				{Path: filepath.Join(target, "readme.txt"), Kind: transfer.DestinationFile},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := resolveDownloadDestinationTargets(test.metadata, target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Equal(got, test.want) {
+				t.Fatalf("destination targets = %#v, want %#v", got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/drive/download_service_test.go
+++ b/internal/drive/download_service_test.go
@@ -269,6 +269,74 @@ func TestStartDownloadRunsProvidedMetadataThroughTransferQueue(t *testing.T) {
 	}
 }
 
+func TestQueuedDownloadReservesDestinationBeforeRunnerStarts(t *testing.T) {
+	content := []byte("queued content")
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			close(requestStarted)
+			<-releaseRequest
+		}
+		_, _ = w.Write(content)
+	}))
+	defer server.Close()
+
+	transfers := transfer.New()
+	drive := downloadServiceTestDrive(server, transfers)
+	metadata := DownloadMetadata{
+		Root:       transfer.Root{ID: "file", Name: "mod.bin"},
+		TotalBytes: int64(len(content)),
+		Files: []transfer.DownloadFile{{
+			ID: "file", FileID: "file", Name: "mod.bin", Size: int64(len(content)), URL: server.URL,
+		}},
+	}
+	target := t.TempDir()
+	params := StartDownloadParams{
+		Items: []DownloadItem{{ID: "file", Name: "mod.bin"}}, TargetPath: target, Data: &metadata,
+	}
+	first, err := drive.StartDownload(context.Background(), params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- transfers.ProcessQueue(context.Background()) }()
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first download did not block")
+	}
+	second, err := drive.StartDownload(context.Background(), params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(target, "mod.bin")
+	queued, ok := transfers.Get(second.PID)
+	if !ok || queued.Status != transfer.StatusPending {
+		t.Fatalf("queued transfer = %+v, ok=%v", queued, ok)
+	}
+	if len(queued.DestinationTargets) != 1 || queued.DestinationTargets[0].Path != want ||
+		queued.DestinationTargets[0].Kind != transfer.DestinationFile {
+		t.Fatalf("queued destination targets = %#v, want %q", queued.DestinationTargets, want)
+	}
+	if !transfers.IsActiveDownloadDestination(want) {
+		t.Fatalf("queued destination %q is not reserved", want)
+	}
+	close(releaseRequest)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("download queue did not finish")
+	}
+	if record, ok := transfers.Get(first.PID); !ok || record.Status != transfer.StatusCompleted {
+		t.Fatalf("first transfer = %+v, ok=%v", record, ok)
+	}
+}
+
 func TestDownloadFallsBackToFreshPresignedURLAfterForbidden(t *testing.T) {
 	content := []byte("fresh")
 	var server *httptest.Server

--- a/internal/mod/actions.go
+++ b/internal/mod/actions.go
@@ -15,9 +15,11 @@ func (m *Mod) Toggle(ctx context.Context, modPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := m.rejectActiveDownloadAction(modPath); err != nil {
+	release, err := m.rejectActiveDownloadAction(modPath)
+	if err != nil {
 		return "", err
 	}
+	defer release()
 	if isNTEImporter(game.Importer) {
 		return m.setNteModEnabled(ctx, modPath, !isNteModEnabled(modPath))
 	}
@@ -36,9 +38,11 @@ func (m *Mod) Disable(ctx context.Context, modPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := m.rejectActiveDownloadAction(modPath); err != nil {
+	release, err := m.rejectActiveDownloadAction(modPath)
+	if err != nil {
 		return "", err
 	}
+	defer release()
 	if isNTEImporter(game.Importer) {
 		return m.setNteModEnabled(ctx, modPath, false)
 	}
@@ -61,9 +65,11 @@ func (m *Mod) Enable(ctx context.Context, modPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := m.rejectActiveDownloadAction(modPath); err != nil {
+	release, err := m.rejectActiveDownloadAction(modPath)
+	if err != nil {
 		return "", err
 	}
+	defer release()
 	if isNTEImporter(game.Importer) {
 		return m.setNteModEnabled(ctx, modPath, true)
 	}
@@ -75,24 +81,45 @@ func (m *Mod) ExclusiveToggle(ctx context.Context, modPath string) (string, erro
 	if err != nil {
 		return "", err
 	}
-	if err := m.rejectActiveDownloadAction(modPath); err != nil {
-		return "", err
-	}
 	if isNTEImporter(game.Importer) {
 		roots := nteRootsFor(*game)
 		groupPath := filepath.Dir(modPath)
 		if isNtePakWrapper(roots, groupPath) {
 			groupPath = filepath.Dir(groupPath)
 		}
+		entries := collectNteModEntries(roots, groupPath)
+		paths := make([]string, len(entries)+1)
+		paths[0] = modPath
+		for index, entry := range entries {
+			paths[index+1] = entry.path
+		}
+		blocked, release := m.guardActiveDownloadActions(paths)
+		if blocked[0] {
+			release()
+			return "", errors.New("MOD_DOWNLOAD_IN_PROGRESS")
+		}
+		defer release()
 		return m.retryExclusiveToggleOperation(ctx, modPath, func() (string, error) {
 			if isNteModEnabled(modPath) {
 				return m.setNteModEnabled(ctx, modPath, false)
 			}
-			m.setAllNteBestEffort(ctx, collectNteModEntries(roots, groupPath), false)
+			for index, entry := range entries {
+				if blocked[index+1] || !isNteModEnabled(entry.path) {
+					continue
+				}
+				if _, err := m.setNteModEnabled(ctx, entry.path, false); err != nil {
+					m.logActionError(err, "Mod:setAllNte:"+entry.path)
+				}
+			}
 			return m.setNteModEnabled(ctx, modPath, true)
 		})
 	}
 	if !isDisabled(filepath.Base(modPath)) {
+		release, err := m.rejectActiveDownloadAction(modPath)
+		if err != nil {
+			return "", err
+		}
+		defer release()
 		return m.retryExclusiveToggleOperation(ctx, modPath, func() (string, error) {
 			return m.disableWithShaders(ctx, modPath)
 		})
@@ -101,13 +128,21 @@ func (m *Mod) ExclusiveToggle(ctx context.Context, modPath string) (string, erro
 	if err != nil {
 		return "", err
 	}
+	paths := []string{modPath}
 	for _, entry := range entries {
-		if strings.HasPrefix(entry.Name(), ".") {
-			continue
+		if !strings.HasPrefix(entry.Name(), ".") && entry.IsDir() &&
+			!samePath(filepath.Join(filepath.Dir(modPath), entry.Name()), modPath) && !isDisabled(entry.Name()) {
+			paths = append(paths, filepath.Join(filepath.Dir(modPath), entry.Name()))
 		}
-		path := filepath.Join(filepath.Dir(modPath), entry.Name())
-		if entry.IsDir() && !samePath(path, modPath) && !isDisabled(entry.Name()) &&
-			!m.isActiveDownloadDestination(path) {
+	}
+	blocked, release := m.guardActiveDownloadActions(paths)
+	if blocked[0] {
+		release()
+		return "", errors.New("MOD_DOWNLOAD_IN_PROGRESS")
+	}
+	defer release()
+	for index, path := range paths[1:] {
+		if !blocked[index+1] {
 			if _, err := m.retryExclusiveToggleOperation(ctx, path, func() (string, error) {
 				return m.disableWithShaders(ctx, path)
 			}); err != nil {
@@ -124,9 +159,11 @@ func (m *Mod) Rename(ctx context.Context, modPath, newName string) (string, erro
 	if _, err := m.ownedPath(ctx, modPath); err != nil {
 		return "", err
 	}
-	if err := m.rejectActiveDownloadAction(modPath); err != nil {
+	release, err := m.rejectActiveDownloadAction(modPath)
+	if err != nil {
 		return "", err
 	}
+	defer release()
 	newName = stripDisabled(newName)
 	if newName == "" {
 		return "", errors.New("INVALID_MOD_NAME")
@@ -167,12 +204,16 @@ func (m *Mod) EnableAll(ctx context.Context, groupPath string) error {
 	if err != nil {
 		return err
 	}
+	paths := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		if strings.HasPrefix(entry.Name(), ".") {
-			continue
+		if !strings.HasPrefix(entry.Name(), ".") && entry.IsDir() && isDisabled(entry.Name()) {
+			paths = append(paths, filepath.Join(groupPath, entry.Name()))
 		}
-		path := filepath.Join(groupPath, entry.Name())
-		if entry.IsDir() && isDisabled(entry.Name()) && !m.isActiveDownloadDestination(path) {
+	}
+	blocked, release := m.guardActiveDownloadActions(paths)
+	defer release()
+	for index, path := range paths {
+		if !blocked[index] {
 			if _, err := m.enableWithShaders(ctx, path); err != nil {
 				m.logActionError(err, "Mod:enableAll:"+path)
 			}
@@ -194,12 +235,16 @@ func (m *Mod) DisableAll(ctx context.Context, groupPath string) error {
 	if err != nil {
 		return err
 	}
+	paths := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		if strings.HasPrefix(entry.Name(), ".") {
-			continue
+		if !strings.HasPrefix(entry.Name(), ".") && entry.IsDir() && !isDisabled(entry.Name()) {
+			paths = append(paths, filepath.Join(groupPath, entry.Name()))
 		}
-		path := filepath.Join(groupPath, entry.Name())
-		if entry.IsDir() && !isDisabled(entry.Name()) && !m.isActiveDownloadDestination(path) {
+	}
+	blocked, release := m.guardActiveDownloadActions(paths)
+	defer release()
+	for index, path := range paths {
+		if !blocked[index] {
 			if _, err := m.disableWithShaders(ctx, path); err != nil {
 				m.logActionError(err, "Mod:disableAll:"+path)
 			}
@@ -242,8 +287,14 @@ func isRetryableExclusiveToggleError(err error) bool {
 }
 
 func (m *Mod) setAllNteBestEffort(ctx context.Context, entries []nteModEntry, enabled bool) {
-	for _, entry := range entries {
-		if isNteModEnabled(entry.path) == enabled || m.isActiveDownloadDestination(entry.path) {
+	paths := make([]string, len(entries))
+	for index, entry := range entries {
+		paths[index] = entry.path
+	}
+	blocked, release := m.guardActiveDownloadActions(paths)
+	defer release()
+	for index, entry := range entries {
+		if isNteModEnabled(entry.path) == enabled || blocked[index] {
 			continue
 		}
 		if _, err := m.setNteModEnabled(ctx, entry.path, enabled); err != nil {
@@ -252,15 +303,24 @@ func (m *Mod) setAllNteBestEffort(ctx context.Context, entries []nteModEntry, en
 	}
 }
 
-func (m *Mod) rejectActiveDownloadAction(path string) error {
-	if m.isActiveDownloadDestination(path) {
-		return errors.New("MOD_DOWNLOAD_IN_PROGRESS")
+func (m *Mod) rejectActiveDownloadAction(path string) (func(), error) {
+	blocked, release := m.guardActiveDownloadActions([]string{path})
+	if blocked[0] {
+		release()
+		return nil, errors.New("MOD_DOWNLOAD_IN_PROGRESS")
 	}
-	return nil
+	return release, nil
 }
 
 func (m *Mod) isActiveDownloadDestination(path string) bool {
 	return m != nil && m.transfer != nil && m.transfer.IsActiveDownloadDestination(path)
+}
+
+func (m *Mod) guardActiveDownloadActions(paths []string) ([]bool, func()) {
+	if m == nil || m.transfer == nil {
+		return make([]bool, len(paths)), func() {}
+	}
+	return m.transfer.GuardDownloadDestinations(paths)
 }
 
 func (m *Mod) logActionError(err error, where string) {

--- a/internal/mod/actions.go
+++ b/internal/mod/actions.go
@@ -15,6 +15,9 @@ func (m *Mod) Toggle(ctx context.Context, modPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if err := m.rejectActiveDownloadAction(modPath); err != nil {
+		return "", err
+	}
 	if isNTEImporter(game.Importer) {
 		return m.setNteModEnabled(ctx, modPath, !isNteModEnabled(modPath))
 	}
@@ -31,6 +34,9 @@ func (m *Mod) Toggle(ctx context.Context, modPath string) (string, error) {
 func (m *Mod) Disable(ctx context.Context, modPath string) (string, error) {
 	game, err := m.ownedPath(ctx, modPath)
 	if err != nil {
+		return "", err
+	}
+	if err := m.rejectActiveDownloadAction(modPath); err != nil {
 		return "", err
 	}
 	if isNTEImporter(game.Importer) {
@@ -55,6 +61,9 @@ func (m *Mod) Enable(ctx context.Context, modPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if err := m.rejectActiveDownloadAction(modPath); err != nil {
+		return "", err
+	}
 	if isNTEImporter(game.Importer) {
 		return m.setNteModEnabled(ctx, modPath, true)
 	}
@@ -64,6 +73,9 @@ func (m *Mod) Enable(ctx context.Context, modPath string) (string, error) {
 func (m *Mod) ExclusiveToggle(ctx context.Context, modPath string) (string, error) {
 	game, err := m.ownedPath(ctx, modPath)
 	if err != nil {
+		return "", err
+	}
+	if err := m.rejectActiveDownloadAction(modPath); err != nil {
 		return "", err
 	}
 	if isNTEImporter(game.Importer) {
@@ -94,7 +106,8 @@ func (m *Mod) ExclusiveToggle(ctx context.Context, modPath string) (string, erro
 			continue
 		}
 		path := filepath.Join(filepath.Dir(modPath), entry.Name())
-		if entry.IsDir() && !samePath(path, modPath) && !isDisabled(entry.Name()) {
+		if entry.IsDir() && !samePath(path, modPath) && !isDisabled(entry.Name()) &&
+			!m.isActiveDownloadDestination(path) {
 			if _, err := m.retryExclusiveToggleOperation(ctx, path, func() (string, error) {
 				return m.disableWithShaders(ctx, path)
 			}); err != nil {
@@ -109,6 +122,9 @@ func (m *Mod) ExclusiveToggle(ctx context.Context, modPath string) (string, erro
 
 func (m *Mod) Rename(ctx context.Context, modPath, newName string) (string, error) {
 	if _, err := m.ownedPath(ctx, modPath); err != nil {
+		return "", err
+	}
+	if err := m.rejectActiveDownloadAction(modPath); err != nil {
 		return "", err
 	}
 	newName = stripDisabled(newName)
@@ -155,9 +171,10 @@ func (m *Mod) EnableAll(ctx context.Context, groupPath string) error {
 		if strings.HasPrefix(entry.Name(), ".") {
 			continue
 		}
-		if entry.IsDir() && isDisabled(entry.Name()) {
-			if _, err := m.enableWithShaders(ctx, filepath.Join(groupPath, entry.Name())); err != nil {
-				m.logActionError(err, "Mod:enableAll:"+filepath.Join(groupPath, entry.Name()))
+		path := filepath.Join(groupPath, entry.Name())
+		if entry.IsDir() && isDisabled(entry.Name()) && !m.isActiveDownloadDestination(path) {
+			if _, err := m.enableWithShaders(ctx, path); err != nil {
+				m.logActionError(err, "Mod:enableAll:"+path)
 			}
 		}
 	}
@@ -181,9 +198,10 @@ func (m *Mod) DisableAll(ctx context.Context, groupPath string) error {
 		if strings.HasPrefix(entry.Name(), ".") {
 			continue
 		}
-		if entry.IsDir() && !isDisabled(entry.Name()) {
-			if _, err := m.disableWithShaders(ctx, filepath.Join(groupPath, entry.Name())); err != nil {
-				m.logActionError(err, "Mod:disableAll:"+filepath.Join(groupPath, entry.Name()))
+		path := filepath.Join(groupPath, entry.Name())
+		if entry.IsDir() && !isDisabled(entry.Name()) && !m.isActiveDownloadDestination(path) {
+			if _, err := m.disableWithShaders(ctx, path); err != nil {
+				m.logActionError(err, "Mod:disableAll:"+path)
 			}
 		}
 	}
@@ -225,13 +243,24 @@ func isRetryableExclusiveToggleError(err error) bool {
 
 func (m *Mod) setAllNteBestEffort(ctx context.Context, entries []nteModEntry, enabled bool) {
 	for _, entry := range entries {
-		if isNteModEnabled(entry.path) == enabled {
+		if isNteModEnabled(entry.path) == enabled || m.isActiveDownloadDestination(entry.path) {
 			continue
 		}
 		if _, err := m.setNteModEnabled(ctx, entry.path, enabled); err != nil {
 			m.logActionError(err, "Mod:setAllNte:"+entry.path)
 		}
 	}
+}
+
+func (m *Mod) rejectActiveDownloadAction(path string) error {
+	if m.isActiveDownloadDestination(path) {
+		return errors.New("MOD_DOWNLOAD_IN_PROGRESS")
+	}
+	return nil
+}
+
+func (m *Mod) isActiveDownloadDestination(path string) bool {
+	return m != nil && m.transfer != nil && m.transfer.IsActiveDownloadDestination(path)
 }
 
 func (m *Mod) logActionError(err error, where string) {

--- a/internal/mod/actions_resilience_test.go
+++ b/internal/mod/actions_resilience_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"nahida.live/desktop/internal/infra"
+	"nahida.live/desktop/internal/transfer"
 )
 
 type flakyActionSettings struct {
@@ -178,5 +179,114 @@ func TestEnableAllContinuesAfterFailure(t *testing.T) {
 	}
 	if !strings.Contains(logs.String(), "Mod:enableAll:") || !strings.Contains(logs.String(), "simulated enable failure") {
 		t.Fatalf("enableAll logs = %s", logs.String())
+	}
+}
+
+func TestActiveDownloadDestinationRejectsDirectModActions(t *testing.T) {
+	ctx := context.Background()
+	service, root := newTestMod(t, testSettings{})
+	modsRoot := filepath.Join(root, "mods")
+	group := filepath.Join(modsRoot, "Group")
+	active := filepath.Join(group, "Active")
+	if err := os.MkdirAll(active, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.AddGame(ctx, "Game", modsRoot, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	registerActiveModDownload(t, service, "active", active)
+
+	for name, action := range map[string]func() error{
+		"disable": func() error {
+			_, err := service.Disable(ctx, active)
+			return err
+		},
+		"enable": func() error {
+			_, err := service.Enable(ctx, active)
+			return err
+		},
+		"toggle": func() error {
+			_, err := service.Toggle(ctx, active)
+			return err
+		},
+		"exclusive toggle": func() error {
+			_, err := service.ExclusiveToggle(ctx, active)
+			return err
+		},
+		"rename": func() error {
+			_, err := service.Rename(ctx, active, "Renamed")
+			return err
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := action()
+			if err == nil || err.Error() != "MOD_DOWNLOAD_IN_PROGRESS" {
+				t.Fatalf("action error = %v", err)
+			}
+			if _, statErr := os.Stat(active); statErr != nil {
+				t.Fatalf("active download folder changed: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestBulkAndExclusiveActionsSkipActiveDownloadDestinations(t *testing.T) {
+	ctx := context.Background()
+	service, root := newTestMod(t, testSettings{})
+	modsRoot := filepath.Join(root, "mods")
+	group := filepath.Join(modsRoot, "Group")
+	for _, name := range []string{"Active", "Other", "DISABLED Active Disabled", "DISABLED Other Disabled", "DISABLED Target"} {
+		if err := os.MkdirAll(filepath.Join(group, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := service.AddGame(ctx, "Game", modsRoot, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	registerActiveModDownload(t, service, "active-enabled", filepath.Join(group, "Active"))
+	registerActiveModDownload(t, service, "active-disabled", filepath.Join(group, "DISABLED Active Disabled"))
+
+	if err := service.DisableAll(ctx, group); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(group, "Active")); err != nil {
+		t.Fatalf("active download was disabled: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(group, "DISABLED Other")); err != nil {
+		t.Fatalf("ordinary mod was not disabled: %v", err)
+	}
+
+	target := filepath.Join(group, "DISABLED Target")
+	if _, err := service.ExclusiveToggle(ctx, target); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(group, "Active")); err != nil {
+		t.Fatalf("exclusive toggle disabled active download: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(group, "Target")); err != nil {
+		t.Fatalf("exclusive target was not enabled: %v", err)
+	}
+
+	if err := service.EnableAll(ctx, group); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(group, "DISABLED Active Disabled")); err != nil {
+		t.Fatalf("active disabled download was enabled: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(group, "Other Disabled")); err != nil {
+		t.Fatalf("ordinary disabled mod was not enabled: %v", err)
+	}
+}
+
+func registerActiveModDownload(t *testing.T, service *Mod, pid, destinationPath string) {
+	t.Helper()
+	if service.transfer == nil {
+		service.transfer = transfer.New()
+	}
+	if _, err := service.transfer.Create(transfer.CreateParams{
+		PID: pid, Type: "download", Name: pid, InitialStatus: transfer.StatusProgress,
+		DestinationPaths: []string{destinationPath}, ManualStart: true,
+	}); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/mod/actions_resilience_test.go
+++ b/internal/mod/actions_resilience_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"nahida.live/desktop/internal/infra"
 	"nahida.live/desktop/internal/transfer"
@@ -227,6 +228,61 @@ func TestActiveDownloadDestinationRejectsDirectModActions(t *testing.T) {
 				t.Fatalf("active download folder changed: %v", statErr)
 			}
 		})
+	}
+}
+
+func TestModActionStaysBlockedUntilDownloadRunnerFinalizes(t *testing.T) {
+	ctx := context.Background()
+	service, root := newTestMod(t, testSettings{})
+	modsRoot := filepath.Join(root, "mods")
+	active := filepath.Join(modsRoot, "Group", "Active")
+	if err := os.MkdirAll(active, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.AddGame(ctx, "Game", modsRoot, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	service.transfer = transfer.New()
+	if _, err := service.transfer.Create(transfer.CreateParams{
+		PID: "finalizing", Type: "download", Name: "finalizing",
+		InitialStatus: transfer.StatusPending, DestinationPaths: []string{active}, ManualStart: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	finalizing := make(chan struct{})
+	releaseRunner := make(chan struct{})
+	if err := service.transfer.RegisterRunner("finalizing", func(_ context.Context, transfers *transfer.Transfer, pid string) error {
+		completed := transfer.StatusCompleted
+		if err := transfers.Update(pid, transfer.Updates{Status: &completed}); err != nil {
+			return err
+		}
+		close(finalizing)
+		<-releaseRunner
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- service.transfer.ProcessQueue(ctx) }()
+	select {
+	case <-finalizing:
+	case <-time.After(time.Second):
+		t.Fatal("download runner did not reach finalization barrier")
+	}
+	if _, err := service.Rename(ctx, active, "Renamed"); err == nil || err.Error() != "MOD_DOWNLOAD_IN_PROGRESS" {
+		t.Fatalf("rename during finalization error = %v", err)
+	}
+	close(releaseRunner)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("download runner did not finish")
+	}
+	if renamed, err := service.Rename(ctx, active, "Renamed"); err != nil || filepath.Base(renamed) != "Renamed" {
+		t.Fatalf("rename after finalization = %q, %v", renamed, err)
 	}
 }
 

--- a/internal/mod/merge_execute.go
+++ b/internal/mod/merge_execute.go
@@ -141,6 +141,9 @@ func (m *Mod) validateMergeRequest(ctx context.Context, request MergeModsRequest
 		if _, err := m.ownedPath(ctx, leaf); err != nil {
 			return mergeOwnedPathError(err)
 		}
+		if err := m.rejectActiveDownloadAction(leaf); err != nil {
+			return err
+		}
 		resolved, err := resolveForCompare(leaf)
 		if err != nil {
 			return err

--- a/internal/mod/merge_execute.go
+++ b/internal/mod/merge_execute.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 )
@@ -98,6 +99,14 @@ func (m *Mod) MergeMods(ctx context.Context, request MergeModsRequest) (result M
 	if err := m.validateMergeRequest(ctx, request); err != nil {
 		return result, err
 	}
+	leaves := []string{}
+	collectMergeLeafPaths(request.Root, &leaves)
+	blocked, release := m.guardActiveDownloadActions(leaves)
+	if slices.Contains(blocked, true) {
+		release()
+		return result, errors.New("MOD_DOWNLOAD_IN_PROGRESS")
+	}
+	defer release()
 	created := []mergeRollback{}
 	defer func() {
 		if err != nil {
@@ -141,9 +150,11 @@ func (m *Mod) validateMergeRequest(ctx context.Context, request MergeModsRequest
 		if _, err := m.ownedPath(ctx, leaf); err != nil {
 			return mergeOwnedPathError(err)
 		}
-		if err := m.rejectActiveDownloadAction(leaf); err != nil {
+		release, err := m.rejectActiveDownloadAction(leaf)
+		if err != nil {
 			return err
 		}
+		release()
 		resolved, err := resolveForCompare(leaf)
 		if err != nil {
 			return err
@@ -153,6 +164,16 @@ func (m *Mod) validateMergeRequest(ctx context.Context, request MergeModsRequest
 		}
 	}
 	return validateMergeOutputs(request.Root, group, request.PackName)
+}
+
+func collectMergeLeafPaths(node MergePlanNode, leaves *[]string) {
+	if node.Kind == "leaf" {
+		*leaves = append(*leaves, node.Path)
+		return
+	}
+	for _, child := range node.Children {
+		collectMergeLeafPaths(child, leaves)
+	}
 }
 
 func uniqueLexicalMergeLeaves(leaves []string) bool {

--- a/internal/mod/merge_validate_test.go
+++ b/internal/mod/merge_validate_test.go
@@ -127,6 +127,35 @@ func TestValidateMergeRequestRejectsPathsOutsideManagedRootOrGroup(t *testing.T)
 	}
 }
 
+func TestValidateMergeRequestRejectsActiveDownloadLeaf(t *testing.T) {
+	ctx := context.Background()
+	service, root := newTestMod(t, testSettings{})
+	modsRoot := filepath.Join(root, "mods")
+	group := filepath.Join(modsRoot, "CharA")
+	first := filepath.Join(group, "A")
+	second := filepath.Join(group, "B")
+	for _, path := range []string{first, second} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := service.AddGame(ctx, "Game", modsRoot, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	registerActiveModDownload(t, service, "merge-active", first)
+	request := MergeModsRequest{
+		GroupPath: group, Placement: "new_folder", PackName: "Merged",
+		Root: MergePlanNode{
+			Kind: "group", ID: "root", Engine: "classic", Name: "Merged", ForwardKey: "vk_right",
+			Children: []MergePlanNode{{Kind: "leaf", Path: first}, {Kind: "leaf", Path: second}},
+		},
+	}
+
+	if err := service.validateMergeRequest(ctx, request); err == nil || err.Error() != "MOD_DOWNLOAD_IN_PROGRESS" {
+		t.Fatalf("merge validation error = %v", err)
+	}
+}
+
 func TestValidateMergeRequestFollowsGroupSymlinks(t *testing.T) {
 	ctx := context.Background()
 	service, root := newTestMod(t, testSettings{})

--- a/internal/mod/mod_test.go
+++ b/internal/mod/mod_test.go
@@ -439,6 +439,48 @@ func TestPresetCreateAndApplyRestoresEnabledState(t *testing.T) {
 	}
 }
 
+func TestApplyPresetSkipsActiveDownloadDestination(t *testing.T) {
+	ctx := context.Background()
+	service, root := newTestMod(t, testSettings{style: "space"})
+	modsRoot := filepath.Join(root, "mods")
+	group := filepath.Join(modsRoot, "Character")
+	modPath := filepath.Join(group, "Costume")
+	if err := os.MkdirAll(modPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(modPath, "mod.ini"), []byte("[Constants]"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.AddGame(ctx, "Game", modsRoot, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	disabledPath, err := service.Toggle(ctx, modPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preset, err := service.CreatePreset(ctx, "Game", "Disabled", nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enabledPath, err := service.Toggle(ctx, disabledPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registerActiveModDownload(t, service, "preset-active", enabledPath)
+
+	result, err := service.ApplyPreset(ctx, preset.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Applied) != 0 || len(result.Skipped) != 1 ||
+		!strings.EqualFold(result.Skipped[0], filepath.ToSlash(filepath.Join("Character", "Costume"))) {
+		t.Fatalf("apply result = %#v", result)
+	}
+	if _, err := os.Stat(enabledPath); err != nil {
+		t.Fatalf("active download folder changed: %v", err)
+	}
+}
+
 func TestApplyPresetRoutesNteModsThroughPakToggle(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/mod/presets.go
+++ b/internal/mod/presets.go
@@ -202,15 +202,23 @@ func (m *Mod) ApplyPreset(ctx context.Context, presetID string) (ApplyPresetResu
 			result.Skipped = append(result.Skipped, item.RelativePath)
 			continue
 		}
+		if m.isActiveDownloadDestination(item.ActualPath) {
+			result.Skipped = append(result.Skipped, item.RelativePath)
+			continue
+		}
 		var actionErr error
 		if wanted.IsEnabled {
 			_, actionErr = m.Enable(ctx, item.ActualPath)
 		} else {
 			_, actionErr = m.Disable(ctx, item.ActualPath)
 		}
-		if actionErr == nil {
-			result.Applied = append(result.Applied, item.RelativePath)
+		if actionErr != nil {
+			if actionErr.Error() == "MOD_DOWNLOAD_IN_PROGRESS" {
+				result.Skipped = append(result.Skipped, item.RelativePath)
+			}
+			continue
 		}
+		result.Applied = append(result.Applied, item.RelativePath)
 	}
 	return result, nil
 }

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -225,6 +225,7 @@ type entry struct {
 
 type Transfer struct {
 	mu                 sync.RWMutex
+	destinationMu      sync.RWMutex
 	emitMu             sync.Mutex
 	powerMu            sync.Mutex
 	entries            map[string]*entry
@@ -381,16 +382,19 @@ func orderSnapshots(items []orderedSnapshot) []Snapshot {
 }
 
 func (t *Transfer) Cancel(pid string) error {
+	t.destinationMu.Lock()
 	t.mu.Lock()
 	item, ok := t.entries[pid]
 	if !ok {
 		t.mu.Unlock()
+		t.destinationMu.Unlock()
 		return fmt.Errorf("transfer %q not found", pid)
 	}
-	if isTerminal(item.record.Status) {
+	if isTerminal(item.record.Status) && item.cancel == nil {
 		delete(t.entries, pid)
 		shouldEmit := t.scheduleEmitLocked(true, t.now())
 		t.mu.Unlock()
+		t.destinationMu.Unlock()
 		if shouldEmit {
 			t.emit()
 		}
@@ -402,6 +406,7 @@ func (t *Transfer) Cancel(pid string) error {
 	item.record.Status = StatusCanceled
 	shouldEmit := t.scheduleEmitLocked(true, t.now())
 	t.mu.Unlock()
+	t.destinationMu.Unlock()
 	if shouldEmit {
 		t.emit()
 	}
@@ -410,14 +415,17 @@ func (t *Transfer) Cancel(pid string) error {
 }
 
 func (t *Transfer) Pause(pid string) error {
+	t.destinationMu.Lock()
 	t.mu.Lock()
 	item, ok := t.entries[pid]
 	if !ok {
 		t.mu.Unlock()
+		t.destinationMu.Unlock()
 		return fmt.Errorf("transfer %q not found", pid)
 	}
 	if item.record.Status != StatusPending && item.record.Status != StatusPreparing && item.record.Status != StatusProgress {
 		t.mu.Unlock()
+		t.destinationMu.Unlock()
 		return nil
 	}
 	item.record.Status = StatusPaused
@@ -426,6 +434,7 @@ func (t *Transfer) Pause(pid string) error {
 	}
 	shouldEmit := t.scheduleEmitLocked(true, t.now())
 	t.mu.Unlock()
+	t.destinationMu.Unlock()
 	if shouldEmit {
 		t.emit()
 	}
@@ -486,16 +495,18 @@ func (t *Transfer) ResumeAll() error {
 }
 
 func (t *Transfer) Clear() error {
+	t.destinationMu.Lock()
 	t.mu.Lock()
 	changed := false
 	for pid, item := range t.entries {
-		if isTerminal(item.record.Status) {
+		if isTerminal(item.record.Status) && item.cancel == nil {
 			delete(t.entries, pid)
 			changed = true
 		}
 	}
 	shouldEmit := changed && t.scheduleEmitLocked(true, t.now())
 	t.mu.Unlock()
+	t.destinationMu.Unlock()
 	if shouldEmit {
 		t.emit()
 	}
@@ -538,9 +549,11 @@ func (t *Transfer) Create(params CreateParams) (Record, error) {
 		}
 	}
 
+	t.destinationMu.Lock()
 	t.mu.Lock()
 	if _, exists := t.entries[params.PID]; exists {
 		t.mu.Unlock()
+		t.destinationMu.Unlock()
 		return Record{}, fmt.Errorf("transfer %q already exists", params.PID)
 	}
 	queueGroupID := params.QueueGroupID
@@ -590,6 +603,7 @@ func (t *Transfer) Create(params CreateParams) (Record, error) {
 	}
 	shouldEmit := t.scheduleEmitLocked(true, t.now())
 	t.mu.Unlock()
+	t.destinationMu.Unlock()
 	if shouldEmit {
 		t.emit()
 	}
@@ -610,12 +624,14 @@ func (t *Transfer) AttachCancel(pid string, cancel context.CancelFunc) error {
 	if cancel == nil {
 		return errors.New("transfer cancel function is required")
 	}
+	t.destinationMu.Lock()
 	t.mu.Lock()
 	item, ok := t.entries[pid]
 	if ok {
 		item.cancel = cancel
 	}
 	t.mu.Unlock()
+	t.destinationMu.Unlock()
 	if !ok {
 		return fmt.Errorf("transfer %q not found", pid)
 	}
@@ -626,11 +642,13 @@ func (t *Transfer) AttachCancel(pid string, cancel context.CancelFunc) error {
 //
 //wails:ignore
 func (t *Transfer) ClearCancel(pid string) {
+	t.destinationMu.Lock()
 	t.mu.Lock()
 	if item, ok := t.entries[pid]; ok {
 		item.cancel = nil
 	}
 	t.mu.Unlock()
+	t.destinationMu.Unlock()
 }
 
 func (t *Transfer) notifyStarted(ctx context.Context, name string) {
@@ -712,16 +730,19 @@ func (t *Transfer) next(parent context.Context) (string, Runner, context.Context
 }
 
 func (t *Transfer) finishRun(pid string, runErr error) {
+	t.destinationMu.Lock()
 	t.mu.Lock()
 	item, ok := t.entries[pid]
 	if !ok {
 		t.mu.Unlock()
+		t.destinationMu.Unlock()
 		return
 	}
 	item.cancel = nil
 	if item.record.Status == StatusPaused || item.record.Status == StatusCanceled {
 		shouldEmit := t.scheduleEmitLocked(true, t.now())
 		t.mu.Unlock()
+		t.destinationMu.Unlock()
 		if shouldEmit {
 			t.emit()
 		}
@@ -734,6 +755,7 @@ func (t *Transfer) finishRun(pid string, runErr error) {
 	}
 	shouldEmit := t.scheduleEmitLocked(true, t.now())
 	t.mu.Unlock()
+	t.destinationMu.Unlock()
 	if shouldEmit {
 		t.emit()
 	}
@@ -743,10 +765,17 @@ func (t *Transfer) finishRun(pid string, runErr error) {
 //wails:ignore
 func (t *Transfer) Update(pid string, updates Updates) error {
 	now := t.now()
+	reservationChange := updates.Status != nil || updates.DestinationPaths != nil || updates.DestinationTargets != nil
+	if reservationChange {
+		t.destinationMu.Lock()
+	}
 	t.mu.Lock()
 	item, ok := t.entries[pid]
 	if !ok {
 		t.mu.Unlock()
+		if reservationChange {
+			t.destinationMu.Unlock()
+		}
 		return fmt.Errorf("transfer %q not found", pid)
 	}
 	applyUpdates(&item.record.Snapshot, updates)
@@ -783,6 +812,9 @@ func (t *Transfer) Update(pid string, updates Updates) error {
 	}
 	shouldEmit := t.scheduleEmitLocked(updates.Status != nil, now)
 	t.mu.Unlock()
+	if reservationChange {
+		t.destinationMu.Unlock()
+	}
 	if shouldEmit {
 		t.emit()
 	}
@@ -807,11 +839,36 @@ func (t *Transfer) Get(pid string) (Record, bool) {
 
 //wails:ignore
 func (t *Transfer) IsActiveDownloadDestination(path string) bool {
+	t.destinationMu.RLock()
+	defer t.destinationMu.RUnlock()
 	t.mu.RLock()
 	defer t.mu.RUnlock()
+	return t.isActiveDownloadDestinationLocked(path)
+}
+
+// GuardDownloadDestinations takes a stable snapshot of active destination
+// conflicts and prevents transfer registration or state changes until release.
+// Callers must invoke release after the protected filesystem operations finish.
+//
+//wails:ignore
+func (t *Transfer) GuardDownloadDestinations(paths []string) (blocked []bool, release func()) {
+	if t == nil {
+		return make([]bool, len(paths)), func() {}
+	}
+	t.destinationMu.RLock()
+	t.mu.RLock()
+	blocked = make([]bool, len(paths))
+	for index, path := range paths {
+		blocked[index] = t.isActiveDownloadDestinationLocked(path)
+	}
+	t.mu.RUnlock()
+	return blocked, t.destinationMu.RUnlock
+}
+
+func (t *Transfer) isActiveDownloadDestinationLocked(path string) bool {
 	for _, item := range t.entries {
 		if item.record.Type != "download" ||
-			(!isOpen(item.record.Status) && item.record.Status != StatusPaused) {
+			(!isOpen(item.record.Status) && item.record.Status != StatusPaused && item.cancel == nil) {
 			continue
 		}
 		if slices.ContainsFunc(item.record.DestinationPaths, func(destinationPath string) bool {
@@ -825,10 +882,12 @@ func (t *Transfer) IsActiveDownloadDestination(path string) bool {
 
 //wails:ignore
 func (t *Transfer) SetData(pid string, data Data, totalSize int64, name string, destinationTargets []DestinationTarget) error {
+	t.destinationMu.Lock()
 	t.mu.Lock()
 	item, ok := t.entries[pid]
 	if !ok {
 		t.mu.Unlock()
+		t.destinationMu.Unlock()
 		return fmt.Errorf("transfer %q not found", pid)
 	}
 	item.record.Data = cloneData(data)
@@ -841,6 +900,7 @@ func (t *Transfer) SetData(pid string, data Data, totalSize int64, name string, 
 	}
 	shouldEmit := t.scheduleEmitLocked(true, t.now())
 	t.mu.Unlock()
+	t.destinationMu.Unlock()
 	if shouldEmit {
 		t.emit()
 	}
@@ -1042,14 +1102,17 @@ func (t *Transfer) ManualStart(pid string) error {
 		}
 	}
 
+	t.destinationMu.Lock()
 	t.mu.Lock()
 	item, ok = t.entries[pid]
 	if !ok {
 		t.mu.Unlock()
+		t.destinationMu.Unlock()
 		return fmt.Errorf("transfer %q not found", pid)
 	}
 	if item.runner == nil {
 		t.mu.Unlock()
+		t.destinationMu.Unlock()
 		return fmt.Errorf("transfer %q has no registered runner", pid)
 	}
 	if !isOpen(item.record.Status) || item.record.QueueGroupID == nil {
@@ -1080,6 +1143,7 @@ func (t *Transfer) ManualStart(pid string) error {
 	item.record.ErrorCode = ""
 	shouldEmit := t.scheduleEmitLocked(true, t.now())
 	t.mu.Unlock()
+	t.destinationMu.Unlock()
 	if shouldEmit {
 		t.emit()
 	}

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -86,6 +88,18 @@ type Directory struct {
 	Name     string  `json:"name" cbor:"name"`
 }
 
+type DestinationKind string
+
+const (
+	DestinationFile      DestinationKind = "file"
+	DestinationDirectory DestinationKind = "directory"
+)
+
+type DestinationTarget struct {
+	Path string          `json:"path"`
+	Kind DestinationKind `json:"kind"`
+}
+
 type Data struct {
 	Root  *Root          `json:"root,omitempty"`
 	Files []DownloadFile `json:"files"`
@@ -95,26 +109,28 @@ type Data struct {
 // Snapshot is the renderer-safe transfer shape. The payload Data and runner
 // state are deliberately absent, matching Electron's getDisplayTransfers.
 type Snapshot struct {
-	PID              string     `json:"pid"`
-	Type             string     `json:"type"`
-	QueueGroupID     *uint64    `json:"queueGroupId,omitempty"`
-	CurrentID        string     `json:"currentId,omitempty"`
-	Status           Status     `json:"status"`
-	TotalSize        int64      `json:"totalSize"`
-	TransferredSize  int64      `json:"transferedSize"`
-	Progress         float64    `json:"progress"`
-	Speed            float64    `json:"speed"`
-	ETA              float64    `json:"eta"`
-	StartTime        int64      `json:"startTime"`
-	Name             string     `json:"name"`
-	TotalFiles       int        `json:"totalFiles"`
-	TransferredFiles int        `json:"transferedFiles"`
-	FailedFiles      int        `json:"failedFiles"`
-	Path             string     `json:"path,omitempty"`
-	Error            string     `json:"error,omitempty"`
-	ErrorCode        string     `json:"errorCode,omitempty"`
-	PlanPhase        *PlanPhase `json:"planPhase,omitempty"`
-	PlanProgress     *float64   `json:"planProgress,omitempty"`
+	PID                string              `json:"pid"`
+	Type               string              `json:"type"`
+	QueueGroupID       *uint64             `json:"queueGroupId,omitempty"`
+	CurrentID          string              `json:"currentId,omitempty"`
+	Status             Status              `json:"status"`
+	TotalSize          int64               `json:"totalSize"`
+	TransferredSize    int64               `json:"transferedSize"`
+	Progress           float64             `json:"progress"`
+	Speed              float64             `json:"speed"`
+	ETA                float64             `json:"eta"`
+	StartTime          int64               `json:"startTime"`
+	Name               string              `json:"name"`
+	TotalFiles         int                 `json:"totalFiles"`
+	TransferredFiles   int                 `json:"transferedFiles"`
+	FailedFiles        int                 `json:"failedFiles"`
+	Path               string              `json:"path,omitempty"`
+	DestinationPaths   []string            `json:"destinationPaths,omitempty"`
+	DestinationTargets []DestinationTarget `json:"destinationTargets,omitempty"`
+	Error              string              `json:"error,omitempty"`
+	ErrorCode          string              `json:"errorCode,omitempty"`
+	PlanPhase          *PlanPhase          `json:"planPhase,omitempty"`
+	PlanProgress       *float64            `json:"planProgress,omitempty"`
 }
 
 type Record struct {
@@ -123,16 +139,18 @@ type Record struct {
 }
 
 type CreateParams struct {
-	PID           string
-	Type          string
-	Name          string
-	Path          string
-	CurrentID     string
-	InitialStatus Status
-	Data          Data
-	QueueGroupID  *uint64
-	ManualStart   bool
-	RestartData   any
+	PID                string
+	Type               string
+	Name               string
+	Path               string
+	DestinationPaths   []string
+	DestinationTargets []DestinationTarget
+	CurrentID          string
+	InitialStatus      Status
+	Data               Data
+	QueueGroupID       *uint64
+	ManualStart        bool
+	RestartData        any
 }
 
 // Runner performs one transfer attempt. Implementations must stop promptly
@@ -162,24 +180,26 @@ type Options struct {
 }
 
 type Updates struct {
-	Status            *Status
-	CurrentID         *string
-	TotalSize         *int64
-	TotalFiles        *int
-	TransferredSize   *int64
-	Progress          *float64
-	TransferredFiles  *int
-	FailedFiles       *int
-	Path              *string
-	Error             *string
-	ErrorCode         *string
-	PlanPhase         *PlanPhase
-	PlanProgress      *float64
-	ClearCurrentID    bool
-	ClearError        bool
-	ClearErrorCode    bool
-	ClearPlanPhase    bool
-	ClearPlanProgress bool
+	Status             *Status
+	CurrentID          *string
+	TotalSize          *int64
+	TotalFiles         *int
+	TransferredSize    *int64
+	Progress           *float64
+	TransferredFiles   *int
+	FailedFiles        *int
+	Path               *string
+	DestinationPaths   []string
+	DestinationTargets []DestinationTarget
+	Error              *string
+	ErrorCode          *string
+	PlanPhase          *PlanPhase
+	PlanProgress       *float64
+	ClearCurrentID     bool
+	ClearError         bool
+	ClearErrorCode     bool
+	ClearPlanPhase     bool
+	ClearPlanProgress  bool
 }
 
 type speedSample struct {
@@ -337,7 +357,7 @@ func (t *Transfer) List() []Snapshot {
 func (t *Transfer) snapshotEntriesLocked() []orderedSnapshot {
 	items := make([]orderedSnapshot, 0, len(t.entries))
 	for _, item := range t.entries {
-		items = append(items, orderedSnapshot{snapshot: item.record.Snapshot, order: item.createdOrder})
+		items = append(items, orderedSnapshot{snapshot: cloneSnapshot(item.record.Snapshot), order: item.createdOrder})
 	}
 	return items
 }
@@ -540,18 +560,24 @@ func (t *Transfer) Create(params CreateParams) (Record, error) {
 	}
 	t.creationSequence++
 	t.queueSequence++
+	destinationPaths := slices.Clone(params.DestinationPaths)
+	if params.DestinationTargets != nil {
+		destinationPaths = destinationTargetPaths(params.DestinationTargets)
+	}
 	record := Record{
 		Snapshot: Snapshot{
-			PID:          params.PID,
-			Type:         params.Type,
-			QueueGroupID: queueGroupID,
-			CurrentID:    params.CurrentID,
-			Status:       initialStatus,
-			TotalSize:    totalSize,
-			StartTime:    t.now().UnixMilli(),
-			Name:         params.Name,
-			TotalFiles:   len(params.Data.Files),
-			Path:         params.Path,
+			PID:                params.PID,
+			Type:               params.Type,
+			QueueGroupID:       queueGroupID,
+			CurrentID:          params.CurrentID,
+			Status:             initialStatus,
+			TotalSize:          totalSize,
+			StartTime:          t.now().UnixMilli(),
+			Name:               params.Name,
+			TotalFiles:         len(params.Data.Files),
+			Path:               params.Path,
+			DestinationPaths:   destinationPaths,
+			DestinationTargets: slices.Clone(params.DestinationTargets),
 		},
 		Data: cloneData(params.Data),
 	}
@@ -780,7 +806,25 @@ func (t *Transfer) Get(pid string) (Record, bool) {
 }
 
 //wails:ignore
-func (t *Transfer) SetData(pid string, data Data, totalSize int64, name string) error {
+func (t *Transfer) IsActiveDownloadDestination(path string) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	for _, item := range t.entries {
+		if item.record.Type != "download" ||
+			(!isOpen(item.record.Status) && item.record.Status != StatusPaused) {
+			continue
+		}
+		if slices.ContainsFunc(item.record.DestinationPaths, func(destinationPath string) bool {
+			return transferPathsOverlap(path, destinationPath)
+		}) {
+			return true
+		}
+	}
+	return false
+}
+
+//wails:ignore
+func (t *Transfer) SetData(pid string, data Data, totalSize int64, name string, destinationTargets []DestinationTarget) error {
 	t.mu.Lock()
 	item, ok := t.entries[pid]
 	if !ok {
@@ -790,6 +834,8 @@ func (t *Transfer) SetData(pid string, data Data, totalSize int64, name string) 
 	item.record.Data = cloneData(data)
 	item.record.TotalSize = max(0, totalSize)
 	item.record.TotalFiles = len(data.Files)
+	item.record.DestinationPaths = destinationTargetPaths(destinationTargets)
+	item.record.DestinationTargets = slices.Clone(destinationTargets)
 	if name != "" {
 		item.record.Name = name
 	}
@@ -1219,6 +1265,14 @@ func applyUpdates(record *Snapshot, updates Updates) {
 	if updates.Path != nil {
 		record.Path = *updates.Path
 	}
+	if updates.DestinationPaths != nil {
+		record.DestinationPaths = slices.Clone(updates.DestinationPaths)
+		record.DestinationTargets = nil
+	}
+	if updates.DestinationTargets != nil {
+		record.DestinationTargets = slices.Clone(updates.DestinationTargets)
+		record.DestinationPaths = destinationTargetPaths(updates.DestinationTargets)
+	}
 	if updates.Error != nil {
 		record.Error = *updates.Error
 	}
@@ -1404,17 +1458,55 @@ func cloneData(data Data) Data {
 
 func cloneRecord(record Record) Record {
 	record.Data = cloneData(record.Data)
-	if record.QueueGroupID != nil {
-		id := *record.QueueGroupID
-		record.QueueGroupID = &id
-	}
-	if record.PlanPhase != nil {
-		phase := *record.PlanPhase
-		record.PlanPhase = &phase
-	}
-	if record.PlanProgress != nil {
-		progress := *record.PlanProgress
-		record.PlanProgress = &progress
-	}
+	record.Snapshot = cloneSnapshot(record.Snapshot)
 	return record
+}
+
+func cloneSnapshot(snapshot Snapshot) Snapshot {
+	snapshot.DestinationPaths = slices.Clone(snapshot.DestinationPaths)
+	snapshot.DestinationTargets = slices.Clone(snapshot.DestinationTargets)
+	if snapshot.QueueGroupID != nil {
+		id := *snapshot.QueueGroupID
+		snapshot.QueueGroupID = &id
+	}
+	if snapshot.PlanPhase != nil {
+		phase := *snapshot.PlanPhase
+		snapshot.PlanPhase = &phase
+	}
+	if snapshot.PlanProgress != nil {
+		progress := *snapshot.PlanProgress
+		snapshot.PlanProgress = &progress
+	}
+	return snapshot
+}
+
+func destinationTargetPaths(targets []DestinationTarget) []string {
+	paths := make([]string, len(targets))
+	for index, target := range targets {
+		paths[index] = target.Path
+	}
+	return paths
+}
+
+func transferPathsOverlap(first, second string) bool {
+	first = cleanTransferPath(first)
+	second = cleanTransferPath(second)
+	return pathContains(first, second) || pathContains(second, first)
+}
+
+func cleanTransferPath(path string) string {
+	if absolute, err := filepath.Abs(path); err == nil {
+		path = absolute
+	}
+	return filepath.Clean(path)
+}
+
+func pathContains(parent, child string) bool {
+	if strings.EqualFold(parent, child) {
+		return true
+	}
+	if !strings.HasSuffix(parent, string(filepath.Separator)) {
+		parent += string(filepath.Separator)
+	}
+	return strings.HasPrefix(strings.ToLower(child), strings.ToLower(parent))
 }

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -169,6 +169,85 @@ func TestIsActiveDownloadDestinationMatchesOverlappingOpenDownloadPaths(t *testi
 	}
 }
 
+func TestCanceledDownloadKeepsDestinationReservedUntilRunnerStops(t *testing.T) {
+	service := New()
+	path := `C:\Mods\Character\Active`
+	if _, err := service.Create(CreateParams{
+		PID: "canceling", Type: "download", Name: "canceling", InitialStatus: StatusPending,
+		DestinationPaths: []string{path}, ManualStart: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	releaseRunner := make(chan struct{})
+	if err := service.RegisterRunner("canceling", func(ctx context.Context, _ *Transfer, _ string) error {
+		close(started)
+		<-ctx.Done()
+		close(canceled)
+		<-releaseRunner
+		return ctx.Err()
+	}); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- service.ProcessQueue(context.Background()) }()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("download runner did not start")
+	}
+	if err := service.Cancel("canceling"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("download runner did not observe cancellation")
+	}
+	if !service.IsActiveDownloadDestination(path) {
+		t.Fatal("destination reservation released before canceled runner stopped")
+	}
+	close(releaseRunner)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled runner did not stop")
+	}
+	if service.IsActiveDownloadDestination(path) {
+		t.Fatal("destination reservation remains after canceled runner stopped")
+	}
+}
+
+func TestFailedDownloadReleasesDestinationAfterRunnerStops(t *testing.T) {
+	service := New()
+	path := `C:\Mods\Character\Failed`
+	if _, err := service.Create(CreateParams{
+		PID: "failing", Type: "download", Name: "failing", InitialStatus: StatusPending,
+		DestinationPaths: []string{path}, ManualStart: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.RegisterRunner("failing", func(context.Context, *Transfer, string) error {
+		return errors.New("download failed")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.ProcessQueue(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	record, ok := service.Get("failing")
+	if !ok || record.Status != StatusError {
+		t.Fatalf("failed transfer = %+v, ok=%v", record, ok)
+	}
+	if service.IsActiveDownloadDestination(path) {
+		t.Fatal("destination reservation remains after failed runner stopped")
+	}
+}
+
 func TestCreateEmitsStartToastAndOptionalNavigation(t *testing.T) {
 	var events []struct {
 		name string

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -61,6 +61,114 @@ func TestCreateBuildsRecordAndListOmitsData(t *testing.T) {
 	}
 }
 
+func TestDestinationPathsAreClonedAcrossTransferBoundaries(t *testing.T) {
+	service := New()
+	createdPaths := []string{`C:\Mods\Legacy`}
+	createdTargets := []DestinationTarget{{Path: `C:\Mods\First`, Kind: DestinationDirectory}}
+	record, err := service.Create(CreateParams{
+		PID: "paths", Type: "download", Name: "paths", InitialStatus: StatusPreparing,
+		DestinationPaths: createdPaths, DestinationTargets: createdTargets, ManualStart: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	createdPaths[0] = `C:\Mods\Mutated`
+	createdTargets[0].Path = `C:\Mods\MutatedTarget`
+	record.DestinationPaths[0] = `C:\Mods\Returned`
+	record.DestinationTargets[0].Path = `C:\Mods\ReturnedTarget`
+	if got := service.List()[0].DestinationPaths[0]; got != `C:\Mods\First` {
+		t.Fatalf("created destination path = %q", got)
+	}
+	if got := service.List()[0].DestinationTargets[0]; got.Path != `C:\Mods\First` || got.Kind != DestinationDirectory {
+		t.Fatalf("created destination target = %#v", got)
+	}
+
+	updatedTargets := []DestinationTarget{
+		{Path: `C:\Mods\Second`, Kind: DestinationDirectory},
+		{Path: `C:\Mods\Third.zip`, Kind: DestinationFile},
+	}
+	if err := service.Update("paths", Updates{DestinationTargets: updatedTargets}); err != nil {
+		t.Fatal(err)
+	}
+	updatedTargets[0].Path = `C:\Mods\MutatedAgain`
+	listed := service.List()
+	listed[0].DestinationPaths[1] = `C:\Mods\ReturnedAgain`
+	listed[0].DestinationTargets[1].Path = `C:\Mods\ReturnedTargetAgain`
+	got := service.List()[0].DestinationPaths
+	if len(got) != 2 || got[0] != `C:\Mods\Second` || got[1] != `C:\Mods\Third.zip` {
+		t.Fatalf("updated destination paths = %#v", got)
+	}
+	gotTargets := service.List()[0].DestinationTargets
+	if len(gotTargets) != 2 || gotTargets[0].Path != `C:\Mods\Second` || gotTargets[1].Kind != DestinationFile {
+		t.Fatalf("updated destination targets = %#v", gotTargets)
+	}
+
+	setDataTargets := []DestinationTarget{{Path: `C:\Mods\SetData`, Kind: DestinationDirectory}}
+	if err := service.SetData("paths", Data{}, 0, "paths", setDataTargets); err != nil {
+		t.Fatal(err)
+	}
+	setDataTargets[0].Path = `C:\Mods\MutatedSetData`
+	gotRecord, ok := service.Get("paths")
+	if !ok {
+		t.Fatal("SetData transfer not found")
+	}
+	gotRecord.DestinationTargets[0].Path = `C:\Mods\ReturnedSetData`
+	if got := service.List()[0]; len(got.DestinationPaths) != 1 || got.DestinationPaths[0] != `C:\Mods\SetData` ||
+		got.DestinationTargets[0].Path != `C:\Mods\SetData` {
+		t.Fatalf("SetData destinations = %#v, %#v", got.DestinationPaths, got.DestinationTargets)
+	}
+
+	legacyPaths := []string{`C:\Mods\LegacySecond`}
+	if err := service.Update("paths", Updates{DestinationPaths: legacyPaths}); err != nil {
+		t.Fatal(err)
+	}
+	legacyPaths[0] = `C:\Mods\MutatedLegacy`
+	if got := service.List()[0]; len(got.DestinationPaths) != 1 || got.DestinationPaths[0] != `C:\Mods\LegacySecond` ||
+		got.DestinationTargets != nil {
+		t.Fatalf("legacy destination update = %#v, %#v", got.DestinationPaths, got.DestinationTargets)
+	}
+}
+
+func TestIsActiveDownloadDestinationMatchesOverlappingOpenDownloadPaths(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		type_  string
+		status Status
+		want   bool
+	}{
+		{name: "pending", type_: "download", status: StatusPending, want: true},
+		{name: "preparing", type_: "download", status: StatusPreparing, want: true},
+		{name: "progress", type_: "download", status: StatusProgress, want: true},
+		{name: "paused", type_: "download", status: StatusPaused, want: true},
+		{name: "completed", type_: "download", status: StatusCompleted},
+		{name: "canceled", type_: "download", status: StatusCanceled},
+		{name: "error", type_: "download", status: StatusError},
+		{name: "upload", type_: "upload", status: StatusProgress},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			service := New()
+			if _, err := service.Create(CreateParams{
+				PID: "active", Type: test.type_, Name: "active", InitialStatus: test.status,
+				DestinationPaths: []string{`C:\Mods\Character\Active`}, ManualStart: true,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			for _, path := range []string{
+				`c:\mods\character\active`,
+				`C:\Mods\Character\Active\Nested`,
+				`C:\Mods\Character`,
+			} {
+				if got := service.IsActiveDownloadDestination(path); got != test.want {
+					t.Fatalf("IsActiveDownloadDestination(%q) = %v, want %v", path, got, test.want)
+				}
+			}
+			if service.IsActiveDownloadDestination(`C:\Mods\Character\Other`) {
+				t.Fatal("unrelated sibling matched active destination")
+			}
+		})
+	}
+}
+
 func TestCreateEmitsStartToastAndOptionalNavigation(t *testing.T) {
 	var events []struct {
 		name string


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes span transfer reservation timing, filesystem mod actions, and list/merge UI; incorrect destination overlap logic could block legitimate edits or allow races during downloads.
> 
> **Overview**
> Adds **in-mod-list download UX** tied to global transfer state: active folder downloads show as placeholders (or mark existing rows), sort to the top, and display a **progress overlay** (status, speed, %) on grid cards and list rows while input and context menus are disabled.
> 
> On the **backend**, downloads now compute and attach **`destinationTargets`** when a transfer is created (including while queued), and the transfer layer **reserves paths** until the runner finishes. Mod operations that touch those paths return **`MOD_DOWNLOAD_IN_PROGRESS`** (or skip in bulk/preset flows) for toggle, rename, merge, and enable/disable-all; the UI surfaces a localized warning instead of a generic error.
> 
> **Merge mode** drops selections for mods that become download targets and closes the merge dialog when fewer than two mods remain selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c832df8ac7208fc4ea189cf3cb04395dc0d4343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added download progress overlays showing status, speed, and completion percentage.
  - Downloading mods now appear immediately as placeholders and are prioritized in lists.
  - Mod cards and rows are visibly disabled while downloads are active.

- **Bug Fixes**
  - Prevented editing, merging, renaming, and toggling mods during active downloads.
  - Added clear warning messages when an action is blocked by a download.
  - Improved handling of canceled and incomplete downloads.

- **Localization**
  - Added download status and action-blocked messages in English, Japanese, Korean, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->