### PR TITLE
feat(akasha): apply server upload rules before upload

### DIFF
--- a/internal/drive/drive.go
+++ b/internal/drive/drive.go
@@ -64,8 +64,10 @@ type Drive struct {
 	now              func() time.Time
 	dirRetries       int
 
-	mu  sync.Mutex
-	ops map[string]*copyOperation
+	mu            sync.Mutex
+	ops           map[string]*copyOperation
+	uploadRulesMu sync.Mutex
+	uploadRules   *UploadRules
 }
 
 func New() *Drive {

--- a/internal/drive/upload_execute.go
+++ b/internal/drive/upload_execute.go
@@ -315,7 +315,12 @@ func (d *Drive) executeUploadPlanV2(
 			continue
 		}
 		source := targets[0]
-		if source.Size >= rules.DirectThreshold() {
+		data, compression, useParts, err := prepareUploadRoute(source, upload, rules.MaxUploadBodyBytes)
+		if err != nil {
+			failTargets(err, targets)
+			continue
+		}
+		if useParts {
 			taskCtx := targetContext(targets)
 			if err := queueTask(func() {
 				select {
@@ -335,11 +340,6 @@ func (d *Drive) executeUploadPlanV2(
 			}); err != nil {
 				return err
 			}
-			continue
-		}
-		data, compression, err := prepareDirectUpload(source)
-		if err != nil {
-			failTargets(err, targets)
 			continue
 		}
 		member := preparedUpload{

--- a/internal/drive/upload_execute.go
+++ b/internal/drive/upload_execute.go
@@ -54,6 +54,13 @@ func (d *Drive) executeUploadPlanV2(
 	concurrency int,
 	onProgress func(UploadExecutionProgress),
 ) error {
+	if d == nil || d.http == nil {
+		return errDriveHTTPUnconfigured
+	}
+	rules, err := d.UploadRules(ctx)
+	if err != nil {
+		return err
+	}
 	filesByID := make(map[string]FinalUploadFile, len(files))
 	for _, file := range files {
 		filesByID[file.FID] = file
@@ -228,7 +235,7 @@ func (d *Drive) executeUploadPlanV2(
 		failTargets(&UploadV2Error{Code: reason, Message: file.Name + ": " + reason}, []FinalUploadFile{file})
 	}
 
-	packed := make([]preparedUpload, 0, uploadPackMaxFiles)
+	packed := make([]preparedUpload, 0, max(1, rules.Pack.MaxFiles))
 	var packedBytes int64
 	taskPool := newUploadTaskPool(ctx, concurrency)
 	defer func() { _ = taskPool.Close() }()
@@ -241,8 +248,8 @@ func (d *Drive) executeUploadPlanV2(
 		return nil
 	}
 	flushPacked := func() error {
-		groups := partitionPackedUploads(packed)
-		packed = make([]preparedUpload, 0, uploadPackMaxFiles)
+		groups := partitionPackedUploads(packed, rules.Pack)
+		packed = make([]preparedUpload, 0, max(1, rules.Pack.MaxFiles))
 		packedBytes = 0
 		for _, group := range groups {
 			if len(group.members) == 1 {
@@ -308,7 +315,7 @@ func (d *Drive) executeUploadPlanV2(
 			continue
 		}
 		source := targets[0]
-		if source.Size >= directUploadThreshold {
+		if source.Size >= rules.DirectThreshold() {
 			taskCtx := targetContext(targets)
 			if err := queueTask(func() {
 				select {
@@ -317,7 +324,7 @@ func (d *Drive) executeUploadPlanV2(
 					return
 				}
 				defer func() { <-multipartSlots }()
-				err := d.uploadParts(taskCtx, upload, source, func(bytes int64) { report(source, bytes, false) })
+				err := d.uploadParts(taskCtx, upload, source, rules, func(bytes int64) { report(source, bytes, false) })
 				if err != nil {
 					if taskCtx.Err() == nil || ctx.Err() != nil {
 						failTargets(err, targets)
@@ -362,7 +369,7 @@ func (d *Drive) executeUploadPlanV2(
 		}
 		packed = append(packed, member)
 		packedBytes += member.payloadBytes
-		if shouldFlushUploadPack(len(packed), packedBytes) {
+		if shouldFlushUploadPack(len(packed), packedBytes, rules.Pack) {
 			if err := flushPacked(); err != nil {
 				return err
 			}
@@ -433,8 +440,8 @@ func (d *Drive) executeUploadPlanV2(
 	return nil
 }
 
-func shouldFlushUploadPack(files int, payloadBytes int64) bool {
-	return files >= uploadPackMaxFiles || payloadBytes >= uploadPackPayloadBudget
+func shouldFlushUploadPack(files int, payloadBytes int64, pack UploadPackRules) bool {
+	return files >= pack.MaxFiles || payloadBytes >= pack.PayloadBudget
 }
 
 func runUploadTasks(ctx context.Context, concurrency int, tasks []func()) error {

--- a/internal/drive/upload_execute_test.go
+++ b/internal/drive/upload_execute_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -133,6 +134,44 @@ func TestExecuteUploadPlanPacksSmallNonBundleIntents(t *testing.T) {
 	slices.Sort(completed)
 	if bytes != 5 || !slices.Equal(completed, []string{"file-1", "file-2"}) {
 		t.Fatalf("bytes = %d, completed = %v", bytes, completed)
+	}
+}
+
+func TestExecuteUploadPlanUsesPartsWhenDirectBodyExceedsLimit(t *testing.T) {
+	var partRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		switch {
+		case strings.HasSuffix(request.URL.Path, "/parts/0"):
+			partRequests.Add(1)
+			if err := request.ParseMultipartForm(1024); err != nil {
+				t.Fatal(err)
+			}
+			_, _ = io.WriteString(w, `{}`)
+		case strings.HasSuffix(request.URL.Path, "/complete"):
+			_, _ = io.WriteString(w, `{}`)
+		default:
+			t.Fatalf("unexpected path %s", request.URL.Path)
+		}
+	}))
+	defer server.Close()
+	directory := t.TempDir()
+	files := []FinalUploadFile{uploadExecutionFile(t, directory, "file-1", "one.ini", "ab")}
+	plan := UploadPlan{
+		Items: []UploadPlanItem{{ClientID: "file-1", Status: "pending", IntentID: "one"}},
+		Uploads: map[string]UploadPlanEntry{
+			"one": uploadPlanEntry("one", server.URL+"/v2/uploads/one", "token-1", "hash-1"),
+		},
+		Bundles: map[string]NTEBundle{},
+	}
+	drive := uploadTestDrive(server)
+	rules := testUploadRules()
+	rules.MaxUploadBodyBytes = 32
+	drive.setUploadRules(rules)
+	if err := drive.executeUploadPlanV2(context.Background(), files, plan, 8, nil); err != nil {
+		t.Fatal(err)
+	}
+	if partRequests.Load() != 1 {
+		t.Fatalf("part requests = %d, want 1", partRequests.Load())
 	}
 }
 

--- a/internal/drive/upload_execute_test.go
+++ b/internal/drive/upload_execute_test.go
@@ -62,10 +62,11 @@ func TestUploadPackAndMultipartLimitsMatchElectron(t *testing.T) {
 	if maxMultipartUploadConcurrency != 4 {
 		t.Fatalf("multipart concurrency = %d, want 4", maxMultipartUploadConcurrency)
 	}
-	if shouldFlushUploadPack(uploadPackMaxFiles-1, uploadPackPayloadBudget-1) {
+	pack := testUploadRules().Pack
+	if shouldFlushUploadPack(pack.MaxFiles-1, pack.PayloadBudget-1, pack) {
 		t.Fatal("pack flushed below both limits")
 	}
-	if !shouldFlushUploadPack(uploadPackMaxFiles, 1) || !shouldFlushUploadPack(1, uploadPackPayloadBudget) {
+	if !shouldFlushUploadPack(pack.MaxFiles, 1, pack) || !shouldFlushUploadPack(1, pack.PayloadBudget, pack) {
 		t.Fatal("pack did not flush at an Electron limit")
 	}
 }

--- a/internal/drive/upload_pack.go
+++ b/internal/drive/upload_pack.go
@@ -6,12 +6,6 @@ import (
 	"regexp"
 )
 
-const (
-	uploadPackPayloadBudget = 90 * 1024 * 1024
-	uploadPackMemberMax     = 4 * 1024 * 1024
-	uploadPackMaxFiles      = 100
-)
-
 var uploadIntentURLPattern = regexp.MustCompile(`/uploads/[^/]+$`)
 
 type preparedUpload struct {
@@ -28,25 +22,25 @@ type packedUploadGroup struct {
 	members []preparedUpload
 }
 
-func partitionPackedUploads(members []preparedUpload) []packedUploadGroup {
+func partitionPackedUploads(members []preparedUpload, pack UploadPackRules) []packedUploadGroup {
 	groups := make([]packedUploadGroup, 0)
-	current := make([]preparedUpload, 0, uploadPackMaxFiles)
+	current := make([]preparedUpload, 0, max(1, pack.MaxFiles))
 	var bytes int64
 	flush := func() {
 		if len(current) == 0 {
 			return
 		}
 		groups = append(groups, packedUploadGroup{members: current})
-		current = make([]preparedUpload, 0, uploadPackMaxFiles)
+		current = make([]preparedUpload, 0, max(1, pack.MaxFiles))
 		bytes = 0
 	}
 	for _, member := range members {
-		if member.payloadBytes > uploadPackMemberMax {
+		if member.payloadBytes > pack.MemberMax {
 			flush()
 			groups = append(groups, packedUploadGroup{members: []preparedUpload{member}})
 			continue
 		}
-		if len(current) > 0 && (len(current) >= uploadPackMaxFiles || bytes+member.payloadBytes > uploadPackPayloadBudget) {
+		if len(current) > 0 && (len(current) >= pack.MaxFiles || bytes+member.payloadBytes > pack.PayloadBudget) {
 			flush()
 		}
 		current = append(current, member)

--- a/internal/drive/upload_pack_test.go
+++ b/internal/drive/upload_pack_test.go
@@ -7,26 +7,28 @@ func packMember(payload, logical int64) preparedUpload {
 }
 
 func TestPartitionPackedUploadsHonorsMemberAndGroupLimits(t *testing.T) {
+	pack := testUploadRules().Pack
 	members := []preparedUpload{
 		packMember(2*1024*1024, 3),
 		packMember(2*1024*1024, 4),
-		packMember(uploadPackMemberMax+1, 5),
-		packMember(uploadPackPayloadBudget-1, 6),
+		packMember(pack.MemberMax+1, 5),
+		packMember(pack.PayloadBudget-1, 6),
 		packMember(2, 7),
 	}
-	groups := partitionPackedUploads(members)
+	groups := partitionPackedUploads(members, pack)
 	if len(groups) != 4 || len(groups[0].members) != 2 || len(groups[1].members) != 1 || len(groups[2].members) != 1 || len(groups[3].members) != 1 {
 		t.Fatalf("groups = %#v", groups)
 	}
 }
 
 func TestPartitionPackedUploadsHonorsFileLimit(t *testing.T) {
-	members := make([]preparedUpload, uploadPackMaxFiles+1)
+	pack := testUploadRules().Pack
+	members := make([]preparedUpload, pack.MaxFiles+1)
 	for index := range members {
 		members[index] = packMember(1, 1)
 	}
-	groups := partitionPackedUploads(members)
-	if len(groups) != 2 || len(groups[0].members) != uploadPackMaxFiles || len(groups[1].members) != 1 {
+	groups := partitionPackedUploads(members, pack)
+	if len(groups) != 2 || len(groups[0].members) != pack.MaxFiles || len(groups[1].members) != 1 {
 		t.Fatalf("group sizes = %d, %d", len(groups[0].members), len(groups[1].members))
 	}
 }

--- a/internal/drive/upload_prepare.go
+++ b/internal/drive/upload_prepare.go
@@ -17,12 +17,6 @@ import (
 	"sync"
 )
 
-var defaultUploadExtensions = []string{
-	".buf", ".ib", ".vb", ".dds", ".ini", ".jpeg", ".jpg", ".png", ".webp", ".gif",
-	".avif", ".avifs", ".bmp", ".hlsl", ".py", ".json", ".txt", ".pmx", ".tga", ".spa",
-	".assets", ".wem", ".mp4", ".webm", ".blend", ".pck", ".bin", ".pak", ".utoc", ".ucas",
-}
-
 type UploadFile struct {
 	FID        string `json:"FID"`
 	Path       string `json:"path"`
@@ -82,7 +76,11 @@ func (d *Drive) GetUploadConflicts(ctx context.Context, params GetUploadConflict
 		return UploadConflictsResult{}, err
 	}
 	existingNames := childNames(item)
-	files, directories, err := collectUploadPaths(params.Paths, nil, false)
+	rules, err := d.UploadRules(ctx)
+	if err != nil {
+		return UploadConflictsResult{}, err
+	}
+	files, directories, err := collectUploadPaths(params.Paths, rules, nil, false)
 	if err != nil {
 		return UploadConflictsResult{}, err
 	}
@@ -125,14 +123,14 @@ func ensureUploadSourceReadable(path string) error {
 }
 
 //wails:ignore
-func PrepareUpload(paths []string, existingNames []string, strategy UploadConflictStrategy, additionalExtensions []string, allowAllFiles bool) (UploadPreparation, error) {
+func PrepareUpload(paths []string, existingNames []string, strategy UploadConflictStrategy, rules UploadRules, additionalExtensions []string, allowAllFiles bool) (UploadPreparation, error) {
 	if strategy == "" {
 		strategy = UploadConflictSuffix
 	}
 	if strategy != UploadConflictSuffix && strategy != UploadConflictSkip {
 		return UploadPreparation{}, fmt.Errorf("unsupported upload conflict strategy %q", strategy)
 	}
-	files, directories, err := collectUploadPaths(paths, additionalExtensions, allowAllFiles)
+	files, directories, err := collectUploadPaths(paths, rules, additionalExtensions, allowAllFiles)
 	if err != nil {
 		return UploadPreparation{}, err
 	}
@@ -216,18 +214,8 @@ func PrepareUpload(paths []string, existingNames []string, strategy UploadConfli
 	}, nil
 }
 
-func collectUploadPaths(paths, additionalExtensions []string, allowAllFiles bool) ([]UploadFile, []UploadDirectory, error) {
-	allowed := make(map[string]struct{}, len(defaultUploadExtensions)+len(additionalExtensions))
-	for _, extension := range append(slices.Clone(defaultUploadExtensions), additionalExtensions...) {
-		extension = strings.ToLower(strings.TrimSpace(extension))
-		if extension == "" {
-			continue
-		}
-		if !strings.HasPrefix(extension, ".") {
-			extension = "." + extension
-		}
-		allowed[extension] = struct{}{}
-	}
+func collectUploadPaths(paths []string, rules UploadRules, additionalExtensions []string, allowAllFiles bool) ([]UploadFile, []UploadDirectory, error) {
+	allowed := extensionMaxSizes(rules, additionalExtensions)
 	files := make([]UploadFile, 0)
 	directories := make([]UploadDirectory, 0)
 	for _, rawPath := range paths {
@@ -244,7 +232,7 @@ func collectUploadPaths(paths, additionalExtensions []string, allowAllFiles bool
 			continue
 		}
 		if info.Mode().IsRegular() {
-			if allowAllFiles || uploadExtensionAllowed(info.Name(), allowed) {
+			if uploadFilePermitted(info.Name(), info.Size(), allowed, allowAllFiles, rules.MaxFileSize) {
 				files = append(files, UploadFile{
 					Path:       info.Name(),
 					Name:       info.Name(),
@@ -286,7 +274,7 @@ func collectUploadPaths(paths, additionalExtensions []string, allowAllFiles bool
 			if infoErr != nil {
 				return infoErr
 			}
-			if !entryInfo.Mode().IsRegular() || (!allowAllFiles && !uploadExtensionAllowed(entry.Name(), allowed)) {
+			if !entryInfo.Mode().IsRegular() || !uploadFilePermitted(entry.Name(), entryInfo.Size(), allowed, allowAllFiles, rules.MaxFileSize) {
 				return nil
 			}
 			files = append(files, UploadFile{
@@ -441,11 +429,6 @@ func isSystemFile(name string) bool {
 		name == ".TemporaryItems" || name == ".apdisk" || name == "__MACOSX" ||
 		lower == "thumbs.db" || (strings.HasPrefix(lower, "ehthumbs") && strings.HasSuffix(lower, ".db")) ||
 		lower == "desktop.ini" || name == "~"
-}
-
-func uploadExtensionAllowed(name string, allowed map[string]struct{}) bool {
-	_, ok := allowed[strings.ToLower(filepath.Ext(name))]
-	return ok
 }
 
 func uniqueUploadName(base string, existing map[string]struct{}) string {

--- a/internal/drive/upload_prepare_test.go
+++ b/internal/drive/upload_prepare_test.go
@@ -64,7 +64,7 @@ func TestPrepareUploadCollectsAllowedFilesAndSkipsSystemEntries(t *testing.T) {
 	writeUploadFile(t, filepath.Join(root, "__MACOSX", "metadata.ini"), "metadata")
 	writeUploadFile(t, filepath.Join(root, "desktop.ini"), "metadata")
 
-	prepared, err := PrepareUpload([]string{root}, nil, UploadConflictSuffix, nil, false)
+	prepared, err := PrepareUpload([]string{root}, nil, UploadConflictSuffix, testUploadRules(), nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,11 +90,11 @@ func TestPrepareUploadCollectsAllowedFilesAndSkipsSystemEntries(t *testing.T) {
 func TestPrepareUploadStableIDsAreDeterministic(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "Mod")
 	writeUploadFile(t, filepath.Join(root, "file.ini"), "value")
-	first, err := PrepareUpload([]string{root}, nil, UploadConflictSuffix, nil, false)
+	first, err := PrepareUpload([]string{root}, nil, UploadConflictSuffix, testUploadRules(), nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := PrepareUpload([]string{root}, nil, UploadConflictSuffix, nil, false)
+	second, err := PrepareUpload([]string{root}, nil, UploadConflictSuffix, testUploadRules(), nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,6 +113,7 @@ func TestPrepareUploadSuffixesRootConflicts(t *testing.T) {
 		[]string{root, rootFile},
 		[]string{"Mod", "preview.png", "Mod (2)"},
 		UploadConflictSuffix,
+		testUploadRules(),
 		nil,
 		false,
 	)
@@ -143,6 +144,7 @@ func TestPrepareUploadSkipDropsConflictingRootTree(t *testing.T) {
 		[]string{root, other},
 		[]string{"Mod"},
 		UploadConflictSkip,
+		testUploadRules(),
 		nil,
 		false,
 	)
@@ -163,18 +165,35 @@ func TestPrepareUploadAllowsAdditionalExtensionAndAllFiles(t *testing.T) {
 	executable := filepath.Join(base, "tool.exe")
 	writeUploadFile(t, custom, "custom")
 	writeUploadFile(t, executable, "tool")
-	withExtension, err := PrepareUpload([]string{custom}, nil, UploadConflictSuffix, []string{"xyz"}, false)
+	withExtension, err := PrepareUpload([]string{custom}, nil, UploadConflictSuffix, testUploadRules(), []string{"xyz"}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(withExtension.Files) != 1 {
 		t.Fatalf("additional extension files = %#v", withExtension.Files)
 	}
-	all, err := PrepareUpload([]string{executable}, nil, UploadConflictSuffix, nil, true)
+	all, err := PrepareUpload([]string{executable}, nil, UploadConflictSuffix, testUploadRules(), nil, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(all.Files) != 1 {
 		t.Fatalf("allow-all files = %#v", all.Files)
+	}
+}
+
+func TestPrepareUploadSkipsOversizedFiles(t *testing.T) {
+	root := t.TempDir()
+	allowed := filepath.Join(root, "ok.ini")
+	oversized := filepath.Join(root, "huge.png")
+	writeUploadFile(t, allowed, "ini")
+	if err := os.WriteFile(oversized, make([]byte, 100*1024*1024), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := PrepareUpload([]string{root}, nil, UploadConflictSuffix, testUploadRules(), nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prepared.Files) != 1 || prepared.Files[0].Name != "ok.ini" {
+		t.Fatalf("files = %#v", prepared.Files)
 	}
 }

--- a/internal/drive/upload_rules.go
+++ b/internal/drive/upload_rules.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	preferredDirectUploadThreshold = 80 * 1024 * 1024
-	preferredUploadPartSize        = 25 * 1024 * 1024
+	preferredUploadPartSize = 25 * 1024 * 1024
 )
 
 type UploadExtensionRule struct {
@@ -39,18 +38,38 @@ type UploadRules struct {
 	Parts              UploadPartRules       `json:"parts"`
 }
 
-func (r UploadRules) DirectThreshold() int64 {
-	if r.MaxUploadBodyBytes > 0 && r.MaxUploadBodyBytes < preferredDirectUploadThreshold {
-		return r.MaxUploadBodyBytes
-	}
-	return preferredDirectUploadThreshold
-}
-
 func (r UploadRules) PartSize() int64 {
 	if r.Parts.MaxBytes > 0 && r.Parts.MaxBytes < preferredUploadPartSize {
 		return r.Parts.MaxBytes
 	}
 	return preferredUploadPartSize
+}
+
+func (r UploadRules) partSizeForFile(fileSize int64) (int64, bool) {
+	if r.Parts.MaxBytes <= 0 || r.Parts.MaxParts <= 0 {
+		return 0, false
+	}
+	partSize := r.PartSize()
+	required := requiredUploadPartSize(fileSize, r.Parts.MaxParts)
+	if required > partSize {
+		partSize = required
+	}
+	if partSize > r.Parts.MaxBytes {
+		return 0, false
+	}
+	return partSize, true
+}
+
+func requiredUploadPartSize(fileSize int64, maxParts int) int64 {
+	if fileSize <= 0 || maxParts <= 0 {
+		return 0
+	}
+	n := int64(maxParts)
+	size := fileSize / n
+	if fileSize%n != 0 {
+		size++
+	}
+	return size
 }
 
 func (r UploadRules) MaxSizeFor(name string) (int64, bool) {
@@ -167,6 +186,9 @@ func uploadFilePermitted(name string, size int64, allowed map[string]int64, allo
 	}
 	if maxSize <= 0 {
 		maxSize = maxFileSize
+	}
+	if maxFileSize > 0 {
+		maxSize = min(maxSize, maxFileSize)
 	}
 	return size <= maxSize
 }

--- a/internal/drive/upload_rules.go
+++ b/internal/drive/upload_rules.go
@@ -1,0 +1,172 @@
+package drive
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	preferredDirectUploadThreshold = 80 * 1024 * 1024
+	preferredUploadPartSize        = 25 * 1024 * 1024
+)
+
+type UploadExtensionRule struct {
+	Ext     string `json:"ext"`
+	MaxSize int64  `json:"maxSize"`
+}
+
+type UploadPackRules struct {
+	PayloadBudget int64 `json:"payloadBudget"`
+	MemberMax     int64 `json:"memberMax"`
+	MaxFiles      int   `json:"maxFiles"`
+}
+
+type UploadPartRules struct {
+	MaxBytes int64 `json:"maxBytes"`
+	MaxParts int   `json:"maxParts"`
+}
+
+type UploadRules struct {
+	MaxFileSize        int64                 `json:"maxFileSize"`
+	MaxPlanFiles       int                   `json:"maxPlanFiles"`
+	MaxUploadBodyBytes int64                 `json:"maxUploadBodyBytes"`
+	Extensions         []UploadExtensionRule `json:"extensions"`
+	Pack               UploadPackRules       `json:"pack"`
+	Parts              UploadPartRules       `json:"parts"`
+}
+
+func (r UploadRules) DirectThreshold() int64 {
+	if r.MaxUploadBodyBytes > 0 && r.MaxUploadBodyBytes < preferredDirectUploadThreshold {
+		return r.MaxUploadBodyBytes
+	}
+	return preferredDirectUploadThreshold
+}
+
+func (r UploadRules) PartSize() int64 {
+	if r.Parts.MaxBytes > 0 && r.Parts.MaxBytes < preferredUploadPartSize {
+		return r.Parts.MaxBytes
+	}
+	return preferredUploadPartSize
+}
+
+func (r UploadRules) MaxSizeFor(name string) (int64, bool) {
+	ext := strings.ToLower(filepath.Ext(name))
+	for _, item := range r.Extensions {
+		if strings.ToLower(item.Ext) == ext {
+			return item.MaxSize, true
+		}
+	}
+	return 0, false
+}
+
+//wails:ignore
+func (d *Drive) UploadRules(ctx context.Context) (UploadRules, error) {
+	if d == nil || d.http == nil {
+		return UploadRules{}, errDriveHTTPUnconfigured
+	}
+	d.uploadRulesMu.Lock()
+	if d.uploadRules != nil {
+		rules := *d.uploadRules
+		d.uploadRulesMu.Unlock()
+		return rules, nil
+	}
+	d.uploadRulesMu.Unlock()
+
+	decoded, edenErr, err := d.doJSON(ctx, http.MethodGet, "/akasha/v2/upload-rules", nil, nil)
+	if err != nil {
+		return UploadRules{}, err
+	}
+	if edenErr != nil {
+		return UploadRules{}, CreateDriveAPIError(edenErr.asAny(), "get:upload-rules", edenErr.Status)
+	}
+	rules, err := parseUploadRules(decoded)
+	if err != nil {
+		return UploadRules{}, err
+	}
+	d.uploadRulesMu.Lock()
+	d.uploadRules = &rules
+	d.uploadRulesMu.Unlock()
+	return rules, nil
+}
+
+func (d *Drive) setUploadRules(rules UploadRules) {
+	if d == nil {
+		return
+	}
+	cloned := rules
+	d.uploadRulesMu.Lock()
+	d.uploadRules = &cloned
+	d.uploadRulesMu.Unlock()
+}
+
+func parseUploadRules(decoded any) (UploadRules, error) {
+	raw, err := json.Marshal(decoded)
+	if err != nil {
+		return UploadRules{}, err
+	}
+	var rules UploadRules
+	if err := json.Unmarshal(raw, &rules); err != nil {
+		return UploadRules{}, err
+	}
+	if rules.MaxFileSize <= 0 || rules.MaxPlanFiles <= 0 || rules.MaxUploadBodyBytes <= 0 || len(rules.Extensions) == 0 {
+		return UploadRules{}, errors.New("upload_rules_unavailable")
+	}
+	if rules.Pack.PayloadBudget <= 0 || rules.Pack.MemberMax <= 0 || rules.Pack.MaxFiles <= 0 {
+		return UploadRules{}, errors.New("upload_rules_unavailable")
+	}
+	if rules.Parts.MaxBytes <= 0 || rules.Parts.MaxParts <= 0 {
+		return UploadRules{}, errors.New("upload_rules_unavailable")
+	}
+	return rules, nil
+}
+
+func normalizeUploadExt(extension string) string {
+	extension = strings.ToLower(strings.TrimSpace(extension))
+	if extension == "" {
+		return ""
+	}
+	if !strings.HasPrefix(extension, ".") {
+		extension = "." + extension
+	}
+	return extension
+}
+
+func extensionMaxSizes(rules UploadRules, additional []string) map[string]int64 {
+	allowed := make(map[string]int64, len(rules.Extensions)+len(additional))
+	for _, item := range rules.Extensions {
+		ext := normalizeUploadExt(item.Ext)
+		if ext == "" {
+			continue
+		}
+		allowed[ext] = item.MaxSize
+	}
+	for _, extension := range additional {
+		ext := normalizeUploadExt(extension)
+		if ext == "" {
+			continue
+		}
+		if _, exists := allowed[ext]; !exists {
+			allowed[ext] = rules.MaxFileSize
+		}
+	}
+	return allowed
+}
+
+func uploadFilePermitted(name string, size int64, allowed map[string]int64, allowAll bool, maxFileSize int64) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	maxSize, ok := allowed[ext]
+	if !ok {
+		if !allowAll {
+			return false
+		}
+		maxSize = maxFileSize
+	}
+	if maxSize <= 0 {
+		maxSize = maxFileSize
+	}
+	return size <= maxSize
+}

--- a/internal/drive/upload_rules_test.go
+++ b/internal/drive/upload_rules_test.go
@@ -3,6 +3,7 @@ package drive
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -70,5 +71,47 @@ func TestUploadRulesFetchesAndCaches(t *testing.T) {
 func TestParseUploadRulesRejectsIncompletePayload(t *testing.T) {
 	if _, err := parseUploadRules(map[string]any{"maxFileSize": 1}); err == nil {
 		t.Fatal("expected unavailable rules")
+	}
+}
+
+func TestUploadFilePermittedCapsExtensionLimitAtMaxFileSize(t *testing.T) {
+	allowed := map[string]int64{".bin": 200}
+	if uploadFilePermitted("mod.bin", 150, allowed, false, 100) {
+		t.Fatal("matching extension should not exceed maxFileSize")
+	}
+	if !uploadFilePermitted("mod.bin", 100, allowed, false, 100) {
+		t.Fatal("size equal to maxFileSize should remain permitted")
+	}
+	if !uploadFilePermitted("mod.bin", 50, allowed, false, 100) {
+		t.Fatal("size under the capped limit should remain permitted")
+	}
+}
+
+func TestPartSizeForFileRaisesOnlyWhenFixedSizeExceedsMaxParts(t *testing.T) {
+	rules := testUploadRules()
+	fixed, ok := rules.partSizeForFile(preferredUploadPartSize)
+	if !ok || fixed != preferredUploadPartSize {
+		t.Fatalf("fixed part size = %d ok=%v, want %d", fixed, ok, preferredUploadPartSize)
+	}
+	fileSize := preferredUploadPartSize*int64(rules.Parts.MaxParts) + 1
+	got, ok := rules.partSizeForFile(fileSize)
+	want := requiredUploadPartSize(fileSize, rules.Parts.MaxParts)
+	if !ok || got != want || got <= preferredUploadPartSize {
+		t.Fatalf("raised part size = %d ok=%v, want %d", got, ok, want)
+	}
+	tooLarge := rules.Parts.MaxBytes*int64(rules.Parts.MaxParts) + 1
+	if _, ok := rules.partSizeForFile(tooLarge); ok {
+		t.Fatal("required part size over MaxBytes should be rejected")
+	}
+	if _, ok := (UploadRules{}).partSizeForFile(1); ok {
+		t.Fatal("invalid part limits should be rejected")
+	}
+}
+
+func TestRequiredUploadPartSizeIsOverflowSafe(t *testing.T) {
+	got := requiredUploadPartSize(math.MaxInt64, 2)
+	want := int64(math.MaxInt64/2 + 1)
+	if got != want {
+		t.Fatalf("required part size = %d, want %d", got, want)
 	}
 }

--- a/internal/drive/upload_rules_test.go
+++ b/internal/drive/upload_rules_test.go
@@ -1,0 +1,74 @@
+package drive
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"nahida.live/desktop/internal/infra"
+)
+
+func testUploadRules() UploadRules {
+	return UploadRules{
+		MaxFileSize:        1024 * 1024 * 1024,
+		MaxPlanFiles:       500,
+		MaxUploadBodyBytes: 100 * 1024 * 1024,
+		Extensions: []UploadExtensionRule{
+			{Ext: ".ini", MaxSize: 10*1024*1024 - 1},
+			{Ext: ".dds", MaxSize: 1024 * 1024 * 1024},
+			{Ext: ".png", MaxSize: 100*1024*1024 - 1},
+			{Ext: ".bin", MaxSize: 1024 * 1024 * 1024},
+			{Ext: ".pak", MaxSize: 1024 * 1024 * 1024},
+			{Ext: ".utoc", MaxSize: 1024 * 1024 * 1024},
+			{Ext: ".ucas", MaxSize: 1024 * 1024 * 1024},
+		},
+		Pack: UploadPackRules{
+			PayloadBudget: 90 * 1024 * 1024,
+			MemberMax:     4 * 1024 * 1024,
+			MaxFiles:      100,
+		},
+		Parts: UploadPartRules{MaxBytes: 32 * 1024 * 1024, MaxParts: 64},
+	}
+}
+
+func TestUploadRulesFetchesAndCaches(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/akasha/v2/upload-rules" || request.Method != http.MethodGet {
+			t.Fatalf("request = %s %s", request.Method, request.URL.Path)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(testUploadRules()); err != nil {
+			t.Fatal(err)
+		}
+	}))
+	defer server.Close()
+	drive := NewWithOptions(Options{HTTP: infra.NewClientWithOptions(infra.ClientOptions{
+		BackendURL: server.URL,
+		HTTPClient: server.Client(),
+		Status:     infra.BackendOnline,
+	})})
+	first, err := drive.UploadRules(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := drive.UploadRules(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("fetches = %d, want 1", calls)
+	}
+	if first.MaxPlanFiles != 500 || second.MaxFileSize != first.MaxFileSize || len(first.Extensions) == 0 {
+		t.Fatalf("rules = %#v", first)
+	}
+}
+
+func TestParseUploadRulesRejectsIncompletePayload(t *testing.T) {
+	if _, err := parseUploadRules(map[string]any{"maxFileSize": 1}); err == nil {
+		t.Fatal("expected unavailable rules")
+	}
+}

--- a/internal/drive/upload_service.go
+++ b/internal/drive/upload_service.go
@@ -129,7 +129,11 @@ func (d *Drive) StartUpload(ctx context.Context, params StartUploadParams) (resu
 	if err != nil {
 		return StartUploadResult{}, err
 	}
-	preparation, err := PrepareUpload(params.Paths, slices.Collect(stringsMapKeys(childNames(item))), params.ConflictStrategy, params.AdditionalExtensions, params.AllowAllFiles)
+	rules, err := d.UploadRules(ctx)
+	if err != nil {
+		return StartUploadResult{}, err
+	}
+	preparation, err := PrepareUpload(params.Paths, slices.Collect(stringsMapKeys(childNames(item))), params.ConflictStrategy, rules, params.AdditionalExtensions, params.AllowAllFiles)
 	if err != nil {
 		return StartUploadResult{}, err
 	}

--- a/internal/drive/upload_service_test.go
+++ b/internal/drive/upload_service_test.go
@@ -46,6 +46,11 @@ func TestStartUploadRunsThroughTransferQueue(t *testing.T) {
 		switch request.URL.Path {
 		case "/akasha/content/dest":
 			_, _ = io.WriteString(w, `{"children":[]}`)
+		case "/akasha/v2/upload-rules":
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(testUploadRules()); err != nil {
+				t.Fatal(err)
+			}
 		case "/akasha/v2/sse/drive/files:plan":
 			raw, err := io.ReadAll(request.Body)
 			if err != nil {

--- a/internal/drive/upload_transport.go
+++ b/internal/drive/upload_transport.go
@@ -21,10 +21,8 @@ import (
 )
 
 const (
-	directUploadThreshold = 80 * 1024 * 1024
-	uploadPartSize        = 25 * 1024 * 1024
-	uploadRetryLimit      = 3
-	uploadCompleteLimit   = 15 * time.Minute
+	uploadRetryLimit    = 3
+	uploadCompleteLimit = 15 * time.Minute
 )
 
 type uploadHTTPResult struct {
@@ -47,8 +45,12 @@ func (r *uploadProgressReader) Read(buffer []byte) (int, error) {
 }
 
 func (d *Drive) uploadIntent(ctx context.Context, upload UploadPlanEntry, file FinalUploadFile, onProgress func(int64)) error {
-	if file.Size >= directUploadThreshold {
-		return d.uploadParts(ctx, upload, file, onProgress)
+	rules, err := d.UploadRules(ctx)
+	if err != nil {
+		return err
+	}
+	if file.Size >= rules.DirectThreshold() {
+		return d.uploadParts(ctx, upload, file, rules, onProgress)
 	}
 	data, compression, err := prepareDirectUpload(file)
 	if err != nil {
@@ -110,13 +112,17 @@ func (d *Drive) uploadPreparedDirect(ctx context.Context, upload UploadPlanEntry
 	return errors.New("direct upload exhausted retries")
 }
 
-func (d *Drive) uploadParts(ctx context.Context, upload UploadPlanEntry, file FinalUploadFile, onProgress func(int64)) (returnErr error) {
+func (d *Drive) uploadParts(ctx context.Context, upload UploadPlanEntry, file FinalUploadFile, rules UploadRules, onProgress func(int64)) (returnErr error) {
 	handle, err := os.Open(filepath.FromSlash(file.FullPath))
 	if err != nil {
 		return fmt.Errorf("open upload file %q: %w", file.Name, err)
 	}
 	defer func() { _ = handle.Close() }()
-	totalParts := int((file.Size + uploadPartSize - 1) / uploadPartSize)
+	partSize := rules.PartSize()
+	totalParts := int((file.Size + partSize - 1) / partSize)
+	if file.Size > rules.MaxFileSize || totalParts > rules.Parts.MaxParts {
+		return &UploadV2Error{Code: "file_too_large", Message: file.Name + ": file_too_large"}
+	}
 	reported := int64(0)
 	report := func(bytes int64) {
 		reported += bytes
@@ -131,8 +137,8 @@ func (d *Drive) uploadParts(ctx context.Context, upload UploadPlanEntry, file Fi
 	}()
 	sendAllParts := func() (bool, error) {
 		for index := range totalParts {
-			start := int64(index) * uploadPartSize
-			size := min(int64(uploadPartSize), file.Size-start)
+			start := int64(index) * partSize
+			size := min(partSize, file.Size-start)
 			completedEarly := false
 			for attempt := 0; attempt <= uploadRetryLimit; attempt++ {
 				attemptReported := int64(0)

--- a/internal/drive/upload_transport.go
+++ b/internal/drive/upload_transport.go
@@ -49,21 +49,18 @@ func (d *Drive) uploadIntent(ctx context.Context, upload UploadPlanEntry, file F
 	if err != nil {
 		return err
 	}
-	if file.Size >= rules.DirectThreshold() {
-		return d.uploadParts(ctx, upload, file, rules, onProgress)
-	}
-	data, compression, err := prepareDirectUpload(file)
+	data, compression, useParts, err := prepareUploadRoute(file, upload, rules.MaxUploadBodyBytes)
 	if err != nil {
 		return err
+	}
+	if useParts {
+		return d.uploadParts(ctx, upload, file, rules, onProgress)
 	}
 	return d.uploadPreparedDirect(ctx, upload, file, data, compression, onProgress)
 }
 
 func (d *Drive) uploadPreparedDirect(ctx context.Context, upload UploadPlanEntry, file FinalUploadFile, data []byte, compression string, onProgress func(int64)) error {
-	fields := [][2]string{{"token", upload.Form.Token}}
-	if compression != "" {
-		fields = append(fields, [2]string{"compAlg", compression})
-	}
+	fields := directUploadFields(upload, compression)
 	for attempt := 0; attempt <= uploadRetryLimit; attempt++ {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -118,11 +115,11 @@ func (d *Drive) uploadParts(ctx context.Context, upload UploadPlanEntry, file Fi
 		return fmt.Errorf("open upload file %q: %w", file.Name, err)
 	}
 	defer func() { _ = handle.Close() }()
-	partSize := rules.PartSize()
-	totalParts := int((file.Size + partSize - 1) / partSize)
-	if file.Size > rules.MaxFileSize || totalParts > rules.Parts.MaxParts {
+	partSize, ok := rules.partSizeForFile(file.Size)
+	if !ok || file.Size > rules.MaxFileSize {
 		return &UploadV2Error{Code: "file_too_large", Message: file.Name + ": file_too_large"}
 	}
+	totalParts := uploadPartCount(file.Size, partSize)
 	reported := int64(0)
 	report := func(bytes int64) {
 		reported += bytes
@@ -296,6 +293,52 @@ func infraFetchJSON(method string, body []byte) infra.FetchOptions {
 		Body:              bytes.NewReader(body),
 		DisableHTTPErrors: true,
 	}
+}
+
+func prepareUploadRoute(file FinalUploadFile, upload UploadPlanEntry, maxBody int64) ([]byte, string, bool, error) {
+	data, compression, err := prepareDirectUpload(file)
+	if err != nil {
+		return nil, "", false, err
+	}
+	if directUploadExceedsMaxBody(file, data, compression, upload, maxBody) {
+		return nil, "", true, nil
+	}
+	return data, compression, false, nil
+}
+
+func directUploadFields(upload UploadPlanEntry, compression string) [][2]string {
+	fields := [][2]string{{"token", upload.Form.Token}}
+	if compression != "" {
+		fields = append(fields, [2]string{"compAlg", compression})
+	}
+	return fields
+}
+
+func directUploadExceedsMaxBody(file FinalUploadFile, data []byte, compression string, upload UploadPlanEntry, maxBody int64) bool {
+	if maxBody <= 0 {
+		return true
+	}
+	size, err := multipartRequestSize(directUploadFields(upload, compression), int64(len(data)), file.Name, "file")
+	if err != nil {
+		return true
+	}
+	return size > maxBody
+}
+
+func multipartRequestSize(fields [][2]string, fileSize int64, filename, fieldName string) (int64, error) {
+	boundary := "----nahida-desktop-" + "00000000-0000-0000-0000-000000000000"
+	prefix, suffix, err := multipartEnvelope(boundary, fields, filename, fieldName)
+	if err != nil {
+		return 0, err
+	}
+	return int64(len(prefix)) + fileSize + int64(len(suffix)), nil
+}
+
+func uploadPartCount(fileSize, partSize int64) int {
+	if fileSize <= 0 || partSize <= 0 {
+		return 0
+	}
+	return int((fileSize-1)/partSize + 1)
 }
 
 func multipartEnvelope(boundary string, fields [][2]string, filename, fieldName string) ([]byte, []byte, error) {

--- a/internal/drive/upload_transport_test.go
+++ b/internal/drive/upload_transport_test.go
@@ -24,13 +24,15 @@ func (f uploadRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, e
 }
 
 func uploadTestDrive(server *httptest.Server) *Drive {
-	return NewWithOptions(Options{
+	drive := NewWithOptions(Options{
 		HTTP: infra.NewClientWithOptions(infra.ClientOptions{
 			HTTPClient: server.Client(),
 			Status:     infra.BackendOnline,
 		}),
 		Sleep: func(context.Context, time.Duration) error { return nil },
 	})
+	drive.setUploadRules(testUploadRules())
+	return drive
 }
 
 func TestUploadIntentSendsDirectMultipart(t *testing.T) {
@@ -170,6 +172,7 @@ func TestUploadIntentRetriesTransportError(t *testing.T) {
 		HTTP:  infra.NewClientWithOptions(infra.ClientOptions{HTTPClient: client, Status: infra.BackendOnline}),
 		Sleep: func(context.Context, time.Duration) error { return nil },
 	})
+	drive.setUploadRules(testUploadRules())
 	path := filepath.Join(t.TempDir(), "file.ini")
 	if err := os.WriteFile(path, content, 0o644); err != nil {
 		t.Fatal(err)
@@ -220,7 +223,7 @@ func TestUploadPartsResendsAfterMissingManifest(t *testing.T) {
 	progress := int64(0)
 	if err := uploadTestDrive(server).uploadParts(context.Background(), upload, FinalUploadFile{
 		UploadFile: UploadFile{Name: "file.bin", FullPath: filepath.ToSlash(path), Size: int64(len(content))},
-	}, func(bytes int64) { progress += bytes }); err != nil {
+	}, testUploadRules(), func(bytes int64) { progress += bytes }); err != nil {
 		t.Fatal(err)
 	}
 	if partRequests.Load() != 2 || completeRequests.Load() != 2 || progress != int64(len(content)) {

--- a/internal/drive/upload_transport_test.go
+++ b/internal/drive/upload_transport_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -187,6 +188,57 @@ func TestUploadIntentRetriesTransportError(t *testing.T) {
 	}
 	if requests.Load() != 2 || progress != int64(len(content)) {
 		t.Fatalf("requests = %d, progress = %d", requests.Load(), progress)
+	}
+}
+
+func TestUploadIntentUsesPartsWhenDirectBodyExceedsLimit(t *testing.T) {
+	content := []byte("small")
+	var partRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		switch {
+		case strings.HasSuffix(request.URL.Path, "/parts/0"):
+			partRequests.Add(1)
+			if err := request.ParseMultipartForm(1024); err != nil {
+				t.Fatal(err)
+			}
+			_, _ = io.WriteString(w, `{}`)
+		case strings.HasSuffix(request.URL.Path, "/complete"):
+			_, _ = io.WriteString(w, `{}`)
+		default:
+			t.Fatalf("unexpected path %s", request.URL.Path)
+		}
+	}))
+	defer server.Close()
+	path := filepath.Join(t.TempDir(), "file.ini")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	drive := uploadTestDrive(server)
+	rules := testUploadRules()
+	rules.MaxUploadBodyBytes = 32
+	drive.setUploadRules(rules)
+	upload := UploadPlanEntry{URL: server.URL}
+	upload.Form.Token = "token"
+	if err := drive.uploadIntent(context.Background(), upload, FinalUploadFile{
+		UploadFile: UploadFile{Name: "file.ini", FullPath: filepath.ToSlash(path), Size: int64(len(content))},
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if partRequests.Load() != 1 {
+		t.Fatalf("part requests = %d, want 1", partRequests.Load())
+	}
+}
+
+func TestDirectUploadExceedsMaxBodyIncludesMultipartOverhead(t *testing.T) {
+	upload := UploadPlanEntry{}
+	upload.Form.Token = "token"
+	file := FinalUploadFile{UploadFile: UploadFile{Name: "file.ini"}}
+	data := []byte("small")
+	if !directUploadExceedsMaxBody(file, data, "", upload, int64(len(data))) {
+		t.Fatal("payload equal to max body should still exceed after multipart overhead")
+	}
+	if directUploadExceedsMaxBody(file, data, "", upload, 1024) {
+		t.Fatal("small direct request should fit a 1KiB body limit")
 	}
 }
 

--- a/internal/drive/upload_v2.go
+++ b/internal/drive/upload_v2.go
@@ -152,7 +152,7 @@ func (d *Drive) planUploadV2(ctx context.Context, currentID, requestID string, f
 			return UploadPlan{}, &UploadV2Error{Code: "upload_file_too_large", Message: file.Name + ": upload_file_too_large"}
 		}
 	}
-	pages, err := paginateUploadFiles(files, rules.MaxPlanFiles)
+	pages, err := paginateUploadFiles(files, min(rules.MaxPlanFiles, max(len(files), 1)))
 	if err != nil {
 		return UploadPlan{}, err
 	}

--- a/internal/drive/upload_v2.go
+++ b/internal/drive/upload_v2.go
@@ -19,7 +19,6 @@ import (
 
 const (
 	uploadPlanPageSize = 500
-	maxUploadFileSize  = 1024 * 1024 * 1024
 )
 
 var (
@@ -140,12 +139,20 @@ func (d *Drive) planUploadV2(ctx context.Context, currentID, requestID string, f
 	if d == nil || d.http == nil {
 		return UploadPlan{}, errDriveHTTPUnconfigured
 	}
+	rules, err := d.UploadRules(ctx)
+	if err != nil {
+		return UploadPlan{}, err
+	}
 	for _, file := range files {
-		if file.Size > maxUploadFileSize {
+		maxSize := rules.MaxFileSize
+		if limit, ok := rules.MaxSizeFor(file.Name); ok {
+			maxSize = limit
+		}
+		if file.Size > maxSize {
 			return UploadPlan{}, &UploadV2Error{Code: "upload_file_too_large", Message: file.Name + ": upload_file_too_large"}
 		}
 	}
-	pages, err := paginateUploadFiles(files, uploadPlanPageSize)
+	pages, err := paginateUploadFiles(files, rules.MaxPlanFiles)
 	if err != nil {
 		return UploadPlan{}, err
 	}

--- a/internal/drive/upload_v2_test.go
+++ b/internal/drive/upload_v2_test.go
@@ -63,6 +63,7 @@ func TestPlanUploadV2ConsumesProgressAndCompleteEvents(t *testing.T) {
 	defer server.Close()
 	client := infra.NewClientWithOptions(infra.ClientOptions{BackendURL: server.URL, HTTPClient: server.Client(), Status: infra.BackendOnline})
 	drive := NewWithOptions(Options{HTTP: client})
+	drive.setUploadRules(testUploadRules())
 	var progress UploadPlanProgress
 	plan, err := drive.planUploadV2(context.Background(), "destination", "request-id", []FinalUploadFile{{
 		UploadFile: UploadFile{FID: "client", Name: "file.ini", Path: "file.ini", Size: 4},
@@ -92,6 +93,7 @@ func TestPlanUploadV2PreservesServerErrorCode(t *testing.T) {
 		HTTPClient: server.Client(),
 		Status:     infra.BackendOnline,
 	})})
+	drive.setUploadRules(testUploadRules())
 	_, err := drive.planUploadV2(context.Background(), "destination", "request-id", []FinalUploadFile{{
 		UploadFile: UploadFile{FID: "client", Name: "file.ini"},
 	}}, nil)

--- a/internal/drive/upload_v2_test.go
+++ b/internal/drive/upload_v2_test.go
@@ -81,6 +81,39 @@ func TestPlanUploadV2ConsumesProgressAndCompleteEvents(t *testing.T) {
 	}
 }
 
+func TestPlanUploadV2BoundsPageSizeToFileCount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/akasha/v2/sse/drive/files:plan" || request.Method != http.MethodPost {
+			t.Fatalf("request = %s %s", request.Method, request.URL.Path)
+		}
+		var body struct {
+			Files []json.RawMessage `json:"files"`
+		}
+		if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if len(body.Files) != 1 {
+			t.Fatalf("page size = %d, want 1", len(body.Files))
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "event: complete\ndata: {\"items\":[{\"clientId\":\"client\",\"status\":\"pending\",\"intentId\":\"intent\"}],\"uploads\":[],\"nteBundles\":[]}\n\n")
+	}))
+	defer server.Close()
+	drive := NewWithOptions(Options{HTTP: infra.NewClientWithOptions(infra.ClientOptions{
+		BackendURL: server.URL,
+		HTTPClient: server.Client(),
+		Status:     infra.BackendOnline,
+	})})
+	rules := testUploadRules()
+	rules.MaxPlanFiles = 1_000_000_000
+	drive.setUploadRules(rules)
+	if _, err := drive.planUploadV2(context.Background(), "destination", "request-id", []FinalUploadFile{{
+		UploadFile: UploadFile{FID: "client", Name: "file.ini"},
+	}}, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestPlanUploadV2PreservesServerErrorCode(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Upload behavior now depends on server rules and network fetch at start of uploads; routing and size validation changes affect all upload flows but are covered by expanded tests.
> 
> **Overview**
> Drive uploads no longer rely on hardcoded limits and extension lists. The client fetches **`UploadRules`** from `GET /akasha/v2/upload-rules`, caches them on **`Drive`**, and uses them for conflict scanning, preparation, planning, packing, and transport.
> 
> **Preparation and validation** — `PrepareUpload` and `GetUploadConflicts` / `StartUpload` load rules first. Allowed extensions and per-extension max sizes come from the server; oversized files are dropped during collection, and planning rejects files over the effective limit (extension-specific or global).
> 
> **Planning and execution** — Plan pagination respects `maxPlanFiles` (capped by actual file count). Pack batching uses server `pack` limits instead of local constants. Direct vs multipart routing uses `maxUploadBodyBytes`, accounting for multipart envelope overhead; part sizes follow server `parts` rules (with dynamic sizing when part count would exceed `maxParts`).
> 
> Upload paths without a configured HTTP client fail early with the existing unconfigured error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 699e7176c21fcfd235f83ac97c4710627c62b4dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload behavior now uses server-provided rules for file types, size limits, packing, multipart uploads, and planning.
  * Added support for extension-specific file size limits.
  * Upload rules are fetched and reused during subsequent operations.

* **Bug Fixes**
  * Oversized files are excluded or rejected with clear validation errors.
  * Upload operations now fail safely when the drive or network client is unavailable.
  * Upload planning and transfers honor configured limits instead of fixed defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->