### PR TITLE
feat(mod): retain fix inspection badges

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.3",
     "@tanstack/router-plugin": "^1.168.35",
+    "@testing-library/react": "^16.3.3",
     "@types/node": "^26.4.0",
     "@types/path-browserify": "^1.0.3",
     "@types/react": "^19.2.18",
@@ -60,6 +61,7 @@
     "@types/three": "^0.185.4",
     "@types/validator": "^13.15.10",
     "@vitejs/plugin-react": "^6.1.1",
+    "jsdom": "^30.0.1",
     "oxfmt": "^0.65.0",
     "oxlint": "^1.80.0",
     "oxlint-tsgolint": "^7.0.2001",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@tanstack/router-plugin':
         specifier: ^1.168.35
         version: 1.168.35(@tanstack/react-router@1.170.32(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(rolldown@1.2.5)(vite@8.2.2(@types/node@26.4.0)(jiti@2.7.0))
+      '@testing-library/react':
+        specifier: ^16.3.3
+        version: 16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/node':
         specifier: ^26.4.0
         version: 26.4.0
@@ -135,6 +138,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.1.1
         version: 6.1.1(vite@8.2.2(@types/node@26.4.0)(jiti@2.7.0))
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
       oxfmt:
         specifier: ^0.65.0
         version: 0.65.0
@@ -158,9 +164,17 @@ importers:
         version: 8.2.2(@types/node@26.4.0)(jiti@2.7.0)
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@types/node@26.4.0)(vite@8.2.2(@types/node@26.4.0)(jiti@2.7.0))
+        version: 4.1.11(@types/node@26.4.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(jiti@2.7.0))
 
 packages:
+
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -263,6 +277,46 @@ packages:
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.2.2':
+    resolution: {integrity: sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.12':
+    resolution: {integrity: sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
   '@date-fns/tz@1.5.0':
     resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
 
@@ -273,6 +327,15 @@ packages:
     resolution: {integrity: sha512-3CKVD4ycVjB8nCNssfmhnUuq3SzSHkUES3v5PNCFr9LxIrx39/HVRAZ8z2sLxrFqzUs48dCBZaxoZzJ5UUVHDA==}
     peerDependencies:
       elysia: '>=1.4.19'
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.8.0':
     resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
@@ -932,6 +995,25 @@ packages:
     resolution: {integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==}
     engines: {node: '>=20.19'}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.3':
+    resolution: {integrity: sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -941,6 +1023,9 @@ packages:
 
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1167,9 +1252,20 @@ packages:
   '@wailsio/runtime@3.0.0-beta.16':
     resolution: {integrity: sha512-IzaYrUKYDmvWDXf3Pqfl0onT1R5T5YHTx+AnK9vX4MyuE1PF3lXZmQrtvtfYNAsBnL+9e+iCJvIROGhjyf1rew==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1240,8 +1336,16 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
@@ -1255,6 +1359,13 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-gpu@5.0.70:
     resolution: {integrity: sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==}
 
@@ -1265,6 +1376,9 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dompurify@3.4.14:
     resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
@@ -1293,6 +1407,10 @@ packages:
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-hangul@2.4.0:
     resolution: {integrity: sha512-9ouVct+rsUw7d5+JeyEV+Lf4PAytSK4cWnLGHM4FJDyG9BS5d3iSPnEmH/rVgmSyxyps5cWZ+NeDAlJyq8eKaw==}
@@ -1377,6 +1495,10 @@ packages:
   hls.js@1.7.1:
     resolution: {integrity: sha512-DlzIkeBAS9IIQ432k3BUf3HlwbsR0+trB1i2lDdN2gUkNkrehFurh0/48M5c1/EjlDkdGng1gwZIpwyPxvdZ/g==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-parse-stringify@4.0.1:
     resolution: {integrity: sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw==}
 
@@ -1393,6 +1515,9 @@ packages:
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-promise@2.2.2:
     resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
@@ -1415,6 +1540,15 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1577,6 +1711,10 @@ packages:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1584,6 +1722,10 @@ packages:
     resolution: {integrity: sha512-LPsB4rD1TD6wZu1djKOf9vUnS1jTNaHbolXebXDgiTdb6jeA1agIJhJsIybCmjKmQClcOaal1o1OaiYahEftyQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   maath@0.10.8:
     resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
@@ -1593,6 +1735,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   memoirist@0.4.0:
     resolution: {integrity: sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg==}
@@ -1671,6 +1816,9 @@ packages:
       vite-plus:
         optional: true
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -1700,8 +1848,16 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   promise-worker-transferable@1.0.4:
     resolution: {integrity: sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   react-day-picker@10.0.1:
     resolution: {integrity: sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==}
@@ -1733,6 +1889,9 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-use-measure@2.1.7:
     resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
@@ -1768,6 +1927,10 @@ packages:
     resolution: {integrity: sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -1835,6 +1998,9 @@ packages:
     peerDependencies:
       react: '>=17.0'
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
@@ -1877,9 +2043,24 @@ packages:
     resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.11:
+    resolution: {integrity: sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==}
+
+  tldts@7.4.11:
+    resolution: {integrity: sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==}
+    hasBin: true
+
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   troika-three-text@0.52.5:
     resolution: {integrity: sha512-Ry3jRhic9pzcY4JduSvRRyDmVOSqEW19gT4vtK+aCiPNVcDlmkxvGG0YbFd36RTDq1wExOupXnvNF/j1oiHHDA==}
@@ -1914,6 +2095,10 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  undici@8.10.1:
+    resolution: {integrity: sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==}
+    engines: {node: '>=22.19.0'}
 
   unplugin@3.3.0:
     resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
@@ -2051,14 +2236,34 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   webgl-constants@1.1.1:
     resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
 
   webgl-sdf-generator@1.1.1:
     resolution: {integrity: sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==}
 
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2069,6 +2274,13 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2110,6 +2322,21 @@ packages:
         optional: true
 
 snapshots:
+
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -2240,6 +2467,34 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.1': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.2.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.12(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@date-fns/tz@1.5.0': {}
 
   '@dimforge/rapier3d-compat@0.12.0': {}
@@ -2247,6 +2502,8 @@ snapshots:
   '@elysiajs/eden@1.4.9(elysia@1.4.29(@sinclair/typebox@0.34.52)(exact-mirror@1.2.4)(file-type@22.0.2)(openapi-types@12.1.3)(typescript@7.0.2))':
     dependencies:
       elysia: 1.4.29(@sinclair/typebox@0.34.52)(exact-mirror@1.2.4)(file-type@22.0.2)(openapi-types@12.1.3)(typescript@7.0.2)
+
+  '@exodus/bytes@1.15.1': {}
 
   '@floating-ui/core@1.8.0':
     dependencies:
@@ -2720,6 +2977,27 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.162.0': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.5(@types/react@19.2.18)
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -2730,6 +3008,8 @@ snapshots:
   '@tokenizer/token@0.3.0': {}
 
   '@tweenjs/tween.js@23.1.3': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -2895,7 +3175,15 @@ snapshots:
 
   '@wailsio/runtime@3.0.0-beta.16': {}
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
   ansis@4.3.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   assertion-error@2.0.1: {}
 
@@ -2963,13 +3251,29 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   date-fns@4.4.0: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
+
+  dequal@2.0.3: {}
 
   detect-gpu@5.0.70:
     dependencies:
@@ -2978,6 +3282,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   diff@8.0.4: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dompurify@3.4.14:
     optionalDependencies:
@@ -3003,6 +3309,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@8.0.0: {}
 
   es-hangul@2.4.0: {}
 
@@ -3061,6 +3369,12 @@ snapshots:
 
   hls.js@1.7.1: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-parse-stringify@4.0.1: {}
 
   i18next@26.4.0(typescript@7.0.2):
@@ -3070,6 +3384,8 @@ snapshots:
   ieee754@1.2.1: {}
 
   immediate@3.0.6: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-promise@2.2.2: {}
 
@@ -3087,6 +3403,32 @@ snapshots:
   jiti@2.7.0: {}
 
   js-tokens@4.0.0: {}
+
+  jsdom@30.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.12(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.1
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -3194,6 +3536,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.33.0
       lightningcss-win32-x64-msvc: 1.33.0
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -3201,6 +3545,8 @@ snapshots:
   lucide-react@1.37.0(react@19.2.8):
     dependencies:
       react: 19.2.8
+
+  lz-string@1.5.0: {}
 
   maath@0.10.8(@types/three@0.185.4)(three@0.185.1):
     dependencies:
@@ -3210,6 +3556,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.27.1: {}
 
   memoirist@0.4.0: {}
 
@@ -3299,6 +3647,10 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.80.0
       oxlint-tsgolint: 7.0.2001
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-browserify@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -3319,10 +3671,18 @@ snapshots:
 
   prettier@3.9.6: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   promise-worker-transferable@1.0.4:
     dependencies:
       is-promise: 2.2.2
       lie: 3.3.0
+
+  punycode@2.3.1: {}
 
   react-day-picker@10.0.1(@types/react@19.2.18)(react@19.2.8):
     dependencies:
@@ -3347,6 +3707,8 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.8(react@19.2.8)
       typescript: 7.0.2
+
+  react-is@17.0.2: {}
 
   react-use-measure@2.1.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -3387,6 +3749,10 @@ snapshots:
       '@rolldown/binding-openharmony-arm64': 1.2.5
       '@rolldown/binding-win32-arm64-msvc': 1.2.5
       '@rolldown/binding-win32-x64-msvc': 1.2.5
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -3434,6 +3800,8 @@ snapshots:
     dependencies:
       react: 19.2.8
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.3: {}
@@ -3469,11 +3837,25 @@ snapshots:
 
   tinyrainbow@3.1.1: {}
 
+  tldts-core@7.4.11: {}
+
+  tldts@7.4.11:
+    dependencies:
+      tldts-core: 7.4.11
+
   token-types@6.1.2:
     dependencies:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.11
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   troika-three-text@0.52.5(three@0.185.1):
     dependencies:
@@ -3528,6 +3910,8 @@ snapshots:
 
   undici-types@8.3.0: {}
 
+  undici@8.10.1: {}
+
   unplugin@3.3.0(rolldown@1.2.5)(vite@8.2.2(@types/node@26.4.0)(jiti@2.7.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -3563,7 +3947,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
 
-  vitest@4.1.11(@types/node@26.4.0)(vite@8.2.2(@types/node@26.4.0)(jiti@2.7.0)):
+  vitest@4.1.11(@types/node@26.4.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.4.0)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0)(jiti@2.7.0))
@@ -3587,14 +3971,39 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.4.0
+      jsdom: 30.0.1
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   webgl-constants@1.1.1: {}
 
   webgl-sdf-generator@1.1.1: {}
 
+  webidl-conversions@8.0.1: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which@2.0.2:
     dependencies:
@@ -3604,6 +4013,10 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/frontend/src/components/mod/character-sidebar.tsx
+++ b/frontend/src/components/mod/character-sidebar.tsx
@@ -1,6 +1,7 @@
 // oxlint-disable react/no-children-prop
 import { Mod } from "@bindings/mod";
 import { FS } from "@bindings/platform";
+import { Tools } from "@bindings/tools";
 import { ValidateName } from "@renderer/components/akasha/dialogs";
 import {
   AlertDialog,
@@ -355,6 +356,7 @@ export const CharacterSidebar = memo(function CharacterSidebar({
             parentGroupPath
               ? queryClient.invalidateQueries({ queryKey: ["subGroups", parentGroupPath] })
               : Promise.resolve(),
+            Tools.RefreshFixInspections(),
           ]);
         },
       });

--- a/frontend/src/components/titlebar/titlebar-activity-badges.tsx
+++ b/frontend/src/components/titlebar/titlebar-activity-badges.tsx
@@ -1,4 +1,13 @@
 import { Badge } from "@renderer/components/ui/badge";
+import { Button } from "@renderer/components/ui/button";
+import {
+  Popover,
+  PopoverClose,
+  PopoverContent,
+  PopoverDescription,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@renderer/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@renderer/components/ui/tooltip";
 import { useSetting } from "@renderer/hooks/use-settings";
 import { cn } from "@renderer/lib/utils";
@@ -7,6 +16,7 @@ import {
   useTitlebarActivityStore,
 } from "@renderer/store/titlebar-activity";
 import { useNavigate } from "@tanstack/react-router";
+import { WrenchIcon, XIcon } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -37,14 +47,16 @@ export function TitlebarActivityBadges() {
           }
         };
 
-        const isInteractive = clickNavigate && (!!activity.onClick || !!activity.href);
+        const isInteractive =
+          !activity.popover && clickNavigate && (!!activity.onClick || !!activity.href);
         const Icon = activity.icon;
         const badge = (
           <Badge
             variant="secondary"
             className={cn(
               "h-5 max-w-56 gap-1 truncate border-border/60 bg-muted/70 px-1.5 text-[11px] font-medium text-muted-foreground",
-              isInteractive && "no-drag cursor-pointer hover:bg-muted hover:text-foreground",
+              (isInteractive || !!activity.popover) &&
+                "no-drag cursor-pointer hover:bg-muted hover:text-foreground",
             )}
             render={isInteractive ? <button type="button" onClick={activate} /> : undefined}
           >
@@ -55,6 +67,70 @@ export function TitlebarActivityBadges() {
             </span>
           </Badge>
         );
+
+        if (activity.popover) {
+          const popover = activity.popover;
+          return (
+            <Popover key={activity.id} defaultOpen={popover.defaultOpen ?? true}>
+              <PopoverTrigger
+                render={
+                  <button
+                    type="button"
+                    className="no-drag flex min-w-0 shrink-0 cursor-pointer items-center outline-hidden"
+                  />
+                }
+              >
+                {badge}
+              </PopoverTrigger>
+              <PopoverContent align="start" side="bottom" className="w-80 gap-2.5 p-3 select-none">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex min-w-0 flex-col gap-1">
+                    <PopoverTitle className="text-sm leading-tight font-semibold break-words text-foreground">
+                      {popover.title}
+                    </PopoverTitle>
+                    {popover.description && (
+                      <PopoverDescription className="text-xs break-words text-muted-foreground">
+                        {popover.description}
+                      </PopoverDescription>
+                    )}
+                  </div>
+                  <PopoverClose
+                    className="no-drag inline-flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground"
+                    title={t("g.close", "닫기")}
+                  >
+                    <XIcon className="size-3.5" />
+                  </PopoverClose>
+                </div>
+                <div className="flex items-center justify-end gap-1.5 pt-1">
+                  <PopoverClose
+                    render={
+                      <Button
+                        size="xs"
+                        variant="ghost"
+                        className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
+                        onClick={() => popover.onDismiss?.()}
+                      />
+                    }
+                  >
+                    {popover.dismissLabel ?? t("titlebar.activity.dismiss", t("g.close", "닫기"))}
+                  </PopoverClose>
+                  {popover.actionLabel && (
+                    <Button
+                      size="xs"
+                      className="h-6 px-2.5 text-xs font-medium"
+                      onClick={() => {
+                        popover.onAction?.();
+                      }}
+                    >
+                      <WrenchIcon className="size-3" />
+                      {popover.actionLabel}
+                    </Button>
+                  )}
+                </div>
+              </PopoverContent>
+            </Popover>
+          );
+        }
 
         if (!activity.tooltip) {
           return (

--- a/frontend/src/components/titlebar/titlebar-activity.test.ts
+++ b/frontend/src/components/titlebar/titlebar-activity.test.ts
@@ -1,6 +1,9 @@
-import { buildTransferTitlebarActivity } from "@renderer/components/titlebar/titlebar-activity";
+import {
+    buildModFixTitlebarActivity,
+    buildTransferTitlebarActivity,
+} from "@renderer/components/titlebar/titlebar-activity";
 import type { TransferWithoutData } from "@shared/types";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const t = (key: string) => key;
 
@@ -97,5 +100,60 @@ describe("buildTransferTitlebarActivity", () => {
             t,
         );
         expect(activity).toBeNull();
+    });
+});
+
+describe("buildModFixTitlebarActivity", () => {
+    it("builds warning activity with defaultOpen popover and wiring", () => {
+        const onOpenFixer = vi.fn();
+        const activity = buildModFixTitlebarActivity({
+            modPath: "E:/Mods/TestMod",
+            displayName: "TestMod",
+            result: {
+                needsFix: true,
+                importer: "ZZMI",
+                toolName: "ZZMI Fixer",
+                summary: "1 file outdated",
+                details: ["mod.ini"],
+                affectedFiles: ["mod.ini"],
+                actionTool: "hash",
+            },
+            onOpenFixer,
+            t: (key) => key,
+        });
+
+        expect(activity.id).toBe("mod-fix:E:/Mods/TestMod");
+        expect(activity.status).toBe("warning");
+        expect(activity.order).toBe(5);
+        expect(activity.label).toBe("titlebar.activity.modFix.label");
+        expect(activity.detail).toBe("TestMod");
+        expect(activity.popover).toBeDefined();
+        expect(activity.popover?.defaultOpen).toBe(true);
+        expect(activity.popover?.title).toBe("page.mod.fix_needed_toast.title");
+        expect(activity.popover?.description).toBe("1 file outdated");
+        expect(activity.popover?.actionLabel).toBe("page.mod.fix_needed_toast.action");
+        expect(activity.popover?.dismissLabel).toBe("titlebar.activity.modFix.dismiss");
+
+        activity.popover?.onAction?.();
+        expect(onOpenFixer).toHaveBeenCalledWith("E:/Mods/TestMod", "hash");
+    });
+
+    it("truncates long mod names in detail", () => {
+        const activity = buildModFixTitlebarActivity({
+            modPath: "E:/Mods/Skimpier Burnice",
+            displayName: "Skimpier Burnice",
+            result: {
+                needsFix: true,
+                importer: "ZZMI",
+                toolName: "ZZMI Fixer",
+                summary: "outdated",
+                details: null,
+                affectedFiles: null,
+                actionTool: "hash",
+            },
+            t: (key) => key,
+        });
+
+        expect(activity.detail).toBe("Skimpier…");
     });
 });

--- a/frontend/src/components/titlebar/titlebar-activity.ts
+++ b/frontend/src/components/titlebar/titlebar-activity.ts
@@ -1,3 +1,4 @@
+import type { FixInspectionResult } from "@bindings/tools";
 import type { TitlebarActivity } from "@renderer/store/titlebar-activity";
 import { isTerminalFixerProgressCode } from "@shared/4001-fixer";
 import { getAggregateTransferProgress, isOpenTransferQueueStatus } from "@shared/transfer-progress";
@@ -161,5 +162,51 @@ export function buildTextureResizerTitlebarActivity(
         detail: detail || undefined,
         order: 30,
         href: "/tools",
+    };
+}
+
+function truncateModName(name: string, maxLength = 8): string {
+    const trimmed = name.trim();
+    if (trimmed.length <= maxLength) return trimmed;
+    return `${trimmed.slice(0, maxLength)}…`;
+}
+
+export function buildModFixTitlebarActivity({
+    modPath,
+    displayName,
+    result,
+    onOpenFixer,
+    t,
+}: {
+    modPath: string;
+    displayName: string;
+    result: FixInspectionResult;
+    onOpenFixer?: (modPath: string, actionTool?: string) => void;
+    t: (key: string, opts?: Record<string, unknown>) => string;
+}): TitlebarActivity {
+    const detail = truncateModName(displayName);
+
+    return {
+        id: `mod-fix:${modPath}`,
+        label: t("titlebar.activity.modFix.label"),
+        detail: detail || undefined,
+        status: "warning",
+        icon: WrenchIcon,
+        order: 5,
+        popover: {
+            title: t("page.mod.fix_needed_toast.title", {
+                name: displayName,
+                tool: result.toolName,
+            }),
+            description: result.summary,
+            actionLabel: onOpenFixer ? t("page.mod.fix_needed_toast.action") : undefined,
+            dismissLabel: t("titlebar.activity.modFix.dismiss"),
+            onAction: onOpenFixer
+                ? () => {
+                      onOpenFixer(modPath, result.actionTool);
+                  }
+                : undefined,
+            defaultOpen: true,
+        },
     };
 }

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -31,7 +31,7 @@ function PopoverContent({
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(
-            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover/50 p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden backdrop-blur-lg duration-100 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
             className,
           )}
           {...props}
@@ -71,4 +71,16 @@ function PopoverDescription({ className, ...props }: PopoverPrimitive.Descriptio
   );
 }
 
-export { Popover, PopoverContent, PopoverDescription, PopoverHeader, PopoverTitle, PopoverTrigger };
+function PopoverClose({ ...props }: PopoverPrimitive.Close.Props) {
+  return <PopoverPrimitive.Close data-slot="popover-close" {...props} />;
+}
+
+export {
+  Popover,
+  PopoverClose,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+};

--- a/frontend/src/hooks/use-mod-actions.tsx
+++ b/frontend/src/hooks/use-mod-actions.tsx
@@ -152,7 +152,12 @@ export function useModActions(selectedGroupPath?: string): ModActionApi {
       path: mod.path,
       title: t("page.mod.dialog.delete-mod.title"),
       description: t("page.mod.dialog.delete-mod.description"),
-      onSuccess: () => invalidateModGroup(queryClient, selectedGroupPath),
+      onSuccess: async () => {
+        await Promise.all([
+          invalidateModGroup(queryClient, selectedGroupPath),
+          Tools.RefreshFixInspections(),
+        ]);
+      },
     });
   };
 

--- a/frontend/src/hooks/use-mod-fix-inspection.test.ts
+++ b/frontend/src/hooks/use-mod-fix-inspection.test.ts
@@ -1,0 +1,77 @@
+import type { FixInspectionSnapshot } from "@bindings/tools";
+import { titlebarActivityStore } from "@renderer/store/titlebar-activity";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { syncFixInspectionActivities } from "./use-mod-fix-inspection";
+
+vi.mock("@renderer/lib/logger", () => ({
+    Logger: {
+        warn: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+const t = (key: string, opts?: Record<string, unknown>) =>
+    opts?.name ? `${key}:${String(opts.name)}` : key;
+
+const pendingSnapshot = (revision = 1): FixInspectionSnapshot => ({
+    revision,
+    inspections: [
+        {
+            modPath: "E:\\ZZZ\\ModA",
+            displayName: "ModA",
+            result: {
+                needsFix: true,
+                importer: "ZZMI",
+                toolName: "ZZMI Mod Fixer",
+                summary: "Found 1 file with an outdated hash",
+                details: ["outdated hash"],
+                affectedFiles: ["mod.ini"],
+                actionTool: "hash",
+            },
+        },
+    ],
+});
+
+describe("syncFixInspectionActivities", () => {
+    beforeEach(() => {
+        for (const id of Object.keys(titlebarActivityStore.getState().activities)) {
+            titlebarActivityStore.getState().removeActivity(id);
+        }
+    });
+
+    it("restores pending inspections and wires the fixer action", () => {
+        const onOpenFixer = vi.fn();
+        const snapshot = pendingSnapshot();
+
+        syncFixInspectionActivities(snapshot, onOpenFixer, t);
+
+        const activity = titlebarActivityStore.getState().activities["mod-fix:E:\\ZZZ\\ModA"];
+        expect(activity).toMatchObject({
+            label: "titlebar.activity.modFix.label",
+            detail: "ModA",
+            status: "warning",
+        });
+        expect(activity?.popover?.description).toBe("Found 1 file with an outdated hash");
+
+        activity?.popover?.onAction?.();
+        expect(onOpenFixer).toHaveBeenCalledWith(snapshot.inspections?.[0]);
+    });
+
+    it("removes only stale fix activities", () => {
+        syncFixInspectionActivities(pendingSnapshot(), vi.fn(), t);
+        titlebarActivityStore.getState().upsertActivity({
+            id: "unrelated",
+            label: "Unrelated",
+            status: "running",
+            icon: () => null,
+        });
+
+        syncFixInspectionActivities({ revision: 2, inspections: [] }, vi.fn(), t);
+
+        expect(
+            titlebarActivityStore.getState().activities["mod-fix:E:\\ZZZ\\ModA"],
+        ).toBeUndefined();
+        expect(titlebarActivityStore.getState().activities.unrelated).toBeDefined();
+    });
+});

--- a/frontend/src/hooks/use-mod-fix-inspection.test.ts
+++ b/frontend/src/hooks/use-mod-fix-inspection.test.ts
@@ -1,8 +1,31 @@
-import type { FixInspectionSnapshot } from "@bindings/tools";
+// @vitest-environment jsdom
+
+import { Tools, type FixInspectionSnapshot } from "@bindings/tools";
+import { Logger } from "@renderer/lib/logger";
+import { modStore } from "@renderer/store/mod";
 import { titlebarActivityStore } from "@renderer/store/titlebar-activity";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { syncFixInspectionActivities } from "./use-mod-fix-inspection";
+import {
+    syncFixInspectionActivities,
+    useModFixInspectionTitlebarActivity,
+} from "./use-mod-fix-inspection";
+
+const mocks = vi.hoisted(() => ({
+    listeners: new Map<string, (event: { data: unknown }) => void>(),
+    navigate: vi.fn(),
+    refresh: vi.fn(),
+    t: (key: string, opts?: Record<string, unknown>) =>
+        opts?.name ? `${key}:${String(opts.name)}` : key,
+    unsubscribers: new Map<string, ReturnType<typeof vi.fn>>(),
+}));
+
+vi.mock("@bindings/tools", () => ({
+    Tools: {
+        RefreshFixInspections: mocks.refresh,
+    },
+}));
 
 vi.mock("@renderer/lib/logger", () => ({
     Logger: {
@@ -11,8 +34,26 @@ vi.mock("@renderer/lib/logger", () => ({
     },
 }));
 
-const t = (key: string, opts?: Record<string, unknown>) =>
-    opts?.name ? `${key}:${String(opts.name)}` : key;
+vi.mock("@tanstack/react-router", () => ({
+    useNavigate: () => mocks.navigate,
+}));
+
+vi.mock("@wailsio/runtime", () => ({
+    Events: {
+        On: vi.fn((name: string, listener: (event: { data: unknown }) => void) => {
+            mocks.listeners.set(name, listener);
+            const unsubscribe = vi.fn();
+            mocks.unsubscribers.set(name, unsubscribe);
+            return unsubscribe;
+        }),
+    },
+}));
+
+vi.mock("react-i18next", () => ({
+    useTranslation: () => ({ t: mocks.t }),
+}));
+
+const t = mocks.t;
 
 const pendingSnapshot = (revision = 1): FixInspectionSnapshot => ({
     revision,
@@ -35,9 +76,7 @@ const pendingSnapshot = (revision = 1): FixInspectionSnapshot => ({
 
 describe("syncFixInspectionActivities", () => {
     beforeEach(() => {
-        for (const id of Object.keys(titlebarActivityStore.getState().activities)) {
-            titlebarActivityStore.getState().removeActivity(id);
-        }
+        resetStores();
     });
 
     it("restores pending inspections and wires the fixer action", () => {
@@ -75,3 +114,93 @@ describe("syncFixInspectionActivities", () => {
         expect(titlebarActivityStore.getState().activities.unrelated).toBeDefined();
     });
 });
+
+describe("useModFixInspectionTitlebarActivity", () => {
+    beforeEach(() => {
+        resetStores();
+        mocks.listeners.clear();
+        mocks.navigate.mockReset();
+        mocks.refresh.mockReset();
+        mocks.refresh.mockResolvedValue({ revision: 0, inspections: [] });
+        mocks.unsubscribers.clear();
+        vi.mocked(Logger.error).mockClear();
+    });
+
+    it("refreshes on mount and focus and unsubscribes on unmount", async () => {
+        mocks.refresh
+            .mockResolvedValueOnce(pendingSnapshot())
+            .mockResolvedValueOnce({ revision: 2, inspections: [] });
+
+        const { unmount } = renderHook(() => useModFixInspectionTitlebarActivity());
+
+        await waitFor(() => {
+            expect(Tools.RefreshFixInspections).toHaveBeenCalledTimes(1);
+            expect(
+                titlebarActivityStore.getState().activities["mod-fix:E:\\ZZZ\\ModA"],
+            ).toBeDefined();
+        });
+
+        act(() => mocks.listeners.get("window:focus")?.({ data: undefined }));
+
+        await waitFor(() => {
+            expect(Tools.RefreshFixInspections).toHaveBeenCalledTimes(2);
+            expect(
+                titlebarActivityStore.getState().activities["mod-fix:E:\\ZZZ\\ModA"],
+            ).toBeUndefined();
+        });
+
+        unmount();
+
+        expect(mocks.unsubscribers.get("tools:fix-inspections")).toHaveBeenCalledOnce();
+        expect(mocks.unsubscribers.get("window:focus")).toHaveBeenCalledOnce();
+    });
+
+    it("applies events and rejects snapshots with lower revisions", async () => {
+        mocks.refresh.mockResolvedValueOnce(pendingSnapshot(2));
+        renderHook(() => useModFixInspectionTitlebarActivity());
+
+        await waitFor(() => {
+            expect(
+                titlebarActivityStore.getState().activities["mod-fix:E:\\ZZZ\\ModA"],
+            ).toBeDefined();
+        });
+
+        const newest = pendingSnapshot(3);
+        newest.inspections![0].displayName = "Newest";
+        act(() => mocks.listeners.get("tools:fix-inspections")?.({ data: newest }));
+        act(() =>
+            mocks.listeners.get("tools:fix-inspections")?.({
+                data: { revision: 1, inspections: [] },
+            }),
+        );
+
+        const activity = titlebarActivityStore.getState().activities["mod-fix:E:\\ZZZ\\ModA"];
+        expect(activity?.detail).toBe("Newest");
+
+        act(() => activity?.popover?.onAction?.());
+        expect(modStore.getState().pendingModFixerRequest).toEqual({
+            modPath: "E:\\ZZZ\\ModA",
+            importer: "ZZMI",
+            actionTool: "hash",
+        });
+        expect(mocks.navigate).toHaveBeenCalledWith({ to: "/mod" });
+    });
+
+    it("logs refresh failures", async () => {
+        const error = new Error("refresh failed");
+        mocks.refresh.mockRejectedValueOnce(error);
+
+        renderHook(() => useModFixInspectionTitlebarActivity());
+
+        await waitFor(() => {
+            expect(Logger.error).toHaveBeenCalledWith(error, "ModFixInspection:restore");
+        });
+    });
+});
+
+function resetStores() {
+    for (const id of Object.keys(titlebarActivityStore.getState().activities)) {
+        titlebarActivityStore.getState().removeActivity(id);
+    }
+    modStore.getState().setPendingModFixerRequest(null);
+}

--- a/frontend/src/hooks/use-mod-fix-inspection.ts
+++ b/frontend/src/hooks/use-mod-fix-inspection.ts
@@ -1,0 +1,89 @@
+import { Tools, type FixInspectionRecord, type FixInspectionSnapshot } from "@bindings/tools";
+import { buildModFixTitlebarActivity } from "@renderer/components/titlebar/titlebar-activity";
+import { Logger } from "@renderer/lib/logger";
+import { modStore } from "@renderer/store/mod";
+import { titlebarActivityStore } from "@renderer/store/titlebar-activity";
+import { useNavigate } from "@tanstack/react-router";
+import { Events } from "@wailsio/runtime";
+import { useCallback, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+
+const fixInspectionEvent = "tools:fix-inspections";
+const fixActivityPrefix = "mod-fix:";
+
+export function useModFixInspectionTitlebarActivity() {
+    const navigate = useNavigate();
+    const { t } = useTranslation();
+    const latestRevision = useRef(-1);
+
+    const applySnapshot = useCallback(
+        (snapshot: FixInspectionSnapshot) => {
+            if (snapshot.revision < latestRevision.current) {
+                return;
+            }
+            latestRevision.current = snapshot.revision;
+            syncFixInspectionActivities(
+                snapshot,
+                (record) => {
+                    modStore.getState().setPendingModFixerRequest({
+                        modPath: record.modPath,
+                        importer: record.result.importer,
+                        actionTool: record.result.actionTool || undefined,
+                    });
+                    void navigate({ to: "/mod" });
+                },
+                t,
+            );
+        },
+        [navigate, t],
+    );
+
+    useEffect(() => {
+        const off = Events.On(fixInspectionEvent, (event) => {
+            applySnapshot(event.data as FixInspectionSnapshot);
+        });
+        const refresh = () => {
+            void Tools.RefreshFixInspections()
+                .then(applySnapshot)
+                .catch((error: unknown) => {
+                    Logger.error(error, "ModFixInspection:restore");
+                });
+        };
+        const offFocus = Events.On("window:focus", refresh);
+
+        refresh();
+
+        return () => {
+            off();
+            offFocus();
+        };
+    }, [applySnapshot]);
+}
+
+export function syncFixInspectionActivities(
+    snapshot: FixInspectionSnapshot,
+    onOpenFixer: (record: FixInspectionRecord) => void,
+    t: (key: string, opts?: Record<string, unknown>) => string,
+) {
+    const records = snapshot.inspections ?? [];
+    const activeIds = new Set(records.map((record) => `${fixActivityPrefix}${record.modPath}`));
+    const store = titlebarActivityStore.getState();
+
+    for (const id of Object.keys(store.activities)) {
+        if (id.startsWith(fixActivityPrefix) && !activeIds.has(id)) {
+            store.removeActivity(id);
+        }
+    }
+
+    for (const record of records) {
+        store.upsertActivity(
+            buildModFixTitlebarActivity({
+                modPath: record.modPath,
+                displayName: record.displayName,
+                result: record.result,
+                onOpenFixer: () => onOpenFixer(record),
+                t,
+            }),
+        );
+    }
+}

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -278,6 +278,10 @@
         "description": "Compressed files will be automatically extracted"
       },
       "download_completed": "Downloaded \"{{name}}\".",
+      "fix_needed_toast": {
+        "title": "\"{{name}}\" requires a fix to work properly.",
+        "action": "Open Fixer"
+      },
       "download_action_blocked": "A mod cannot be changed while it is downloading.",
       "download_overlay": {
         "queued": "Queued",
@@ -1681,6 +1685,8 @@
           },
           "searchModPreview": "Search Preview in Subfolders",
           "searchModPreviewDescription": "If no preview image exists in the character folder, search for preview images inside mod folders.",
+          "autoInspectFix": "Automatically inspect mods for required fixes",
+          "autoInspectFixDescription": "Inspects newly downloaded or added mods in the background and notifies you if a fix is recommended.",
           "autoResolveDownloadTarget": "Automatically select download target folder",
           "autoResolveDownloadTargetDescription": "Automatically select a mod folder with a name similar to the download.",
           "downloadSources": {
@@ -1896,6 +1902,10 @@
         "converting": "Converting texture format",
         "resizing_and_converting": "Resizing & converting texture",
         "upscaling_and_converting": "Upscaling & converting texture"
+      },
+      "modFix": {
+        "label": "Fix Needed",
+        "dismiss": "Dismiss"
       }
     }
   },

--- a/frontend/src/lib/i18n/locales/ja.json
+++ b/frontend/src/lib/i18n/locales/ja.json
@@ -262,6 +262,10 @@
         "description": "圧縮ファイルは自動的に解凍されます"
       },
       "download_completed": "\"{{name}}\" のダウンロードが完了しました。",
+      "fix_needed_toast": {
+        "title": "「{{name}}」MODに修正が必要な項目があります。",
+        "action": "Fixerを開く"
+      },
       "download_action_blocked": "ダウンロード中のMODは変更できません。",
       "download_overlay": {
         "queued": "待機中",
@@ -1864,6 +1868,10 @@
         "converting": "テクスチャフォーマット変換中",
         "resizing_and_converting": "テクスチャリサイズおよび変換中",
         "upscaling_and_converting": "テクスチャアップスケールおよび変換中"
+      },
+      "modFix": {
+        "label": "修正が必要",
+        "dismiss": "通知を閉じる"
       }
     }
   },

--- a/frontend/src/lib/i18n/locales/ja.json
+++ b/frontend/src/lib/i18n/locales/ja.json
@@ -1653,6 +1653,8 @@
           },
           "searchModPreview": "サブフォルダからモッドプレビューを検索",
           "searchModPreviewDescription": "キャラクター フォルダにプレビュー画像がない場合、モッド フォルダ内からプレビュー画像を検索します。",
+          "autoInspectFix": "MODに必要な修正を自動検査",
+          "autoInspectFixDescription": "新しくダウンロードまたは追加したMODをバックグラウンドで検査し、修正が推奨される場合に通知します。",
           "autoResolveDownloadTarget": "ダウンロード先フォルダーを自動選択",
           "autoResolveDownloadTargetDescription": "ダウンロード名に似たMODフォルダーを自動的に選択します。",
           "downloadSources": {

--- a/frontend/src/lib/i18n/locales/ko.json
+++ b/frontend/src/lib/i18n/locales/ko.json
@@ -261,6 +261,10 @@
         "description": "압축 파일은 자동으로 압축 해제됩니다"
       },
       "download_completed": "\"{{name}}\" 다운로드가 완료되었습니다.",
+      "fix_needed_toast": {
+        "title": "\"{{name}}\" 모드에 수정이 필요한 항목이 있습니다.",
+        "action": "Fixer 열기"
+      },
       "download_action_blocked": "다운로드 중인 모드는 변경할 수 없습니다.",
       "download_overlay": {
         "queued": "대기 중",
@@ -1667,6 +1671,8 @@
           },
           "searchModPreview": "하위 폴더에서 미리보기 검색",
           "searchModPreviewDescription": "캐릭터 폴더에 프리뷰 이미지가 없는 경우, 모드 폴더 내부에서 프리뷰 이미지를 검색합니다.",
+          "autoInspectFix": "모드 추가 시 Fix 필요 여부 자동 검사",
+          "autoInspectFixDescription": "모드를 다운로드하거나 추가할 때 수정(Fix)이 필요한지 백그라운드에서 검사하고 알립니다.",
           "autoResolveDownloadTarget": "다운로드 대상 폴더 자동 선택",
           "autoResolveDownloadTargetDescription": "다운로드 이름과 비슷한 모드 폴더를 자동으로 선택합니다.",
           "downloadSources": {
@@ -1882,6 +1888,10 @@
         "converting": "텍스처 포맷 변환 중",
         "resizing_and_converting": "텍스처 리사이즈 및 변환 중",
         "upscaling_and_converting": "텍스처 업스케일 및 변환 중"
+      },
+      "modFix": {
+        "label": "수정 필요",
+        "dismiss": "알림 닫기"
       }
     }
   },

--- a/frontend/src/lib/i18n/locales/zh.json
+++ b/frontend/src/lib/i18n/locales/zh.json
@@ -1652,6 +1652,8 @@
           },
           "searchModPreview": "在子文件夹中搜索模组预览",
           "searchModPreviewDescription": "如果角色文件夹中没有预览图像，则在模组文件夹内部搜索预览图像。",
+          "autoInspectFix": "自动检查模组是否需要修复",
+          "autoInspectFixDescription": "在后台检查新下载或添加的模组，并在建议修复时发出通知。",
           "autoResolveDownloadTarget": "自动选择下载目标文件夹",
           "autoResolveDownloadTargetDescription": "自动选择名称与下载内容相似的模组文件夹。",
           "downloadSources": {

--- a/frontend/src/lib/i18n/locales/zh.json
+++ b/frontend/src/lib/i18n/locales/zh.json
@@ -261,6 +261,10 @@
         "description": "压缩文件将自动解压"
       },
       "download_completed": "已下载 \"{{name}}\"。",
+      "fix_needed_toast": {
+        "title": "模组“{{name}}”存在需要修复的项目。",
+        "action": "打开修复工具"
+      },
       "download_action_blocked": "模组下载期间无法修改。",
       "download_overlay": {
         "queued": "等待中",
@@ -1863,6 +1867,10 @@
         "converting": "正在转换纹理格式",
         "resizing_and_converting": "正在调整纹理大小并转换",
         "upscaling_and_converting": "正在放大纹理并转换"
+      },
+      "modFix": {
+        "label": "需要修复",
+        "dismiss": "忽略"
       }
     }
   },

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -19,6 +19,7 @@ import { UpdateAlertDialog } from "@renderer/components/update-alert-dialog";
 import { DEFAULT_BG } from "@renderer/const";
 import { useGlobalEvents } from "@renderer/hooks/use-global-events";
 import { useDownloadArchiveExtractPromptHandler } from "@renderer/hooks/use-mod-events";
+import { useModFixInspectionTitlebarActivity } from "@renderer/hooks/use-mod-fix-inspection";
 import { useTitleBarOverlay } from "@renderer/hooks/use-title-bar-overlay";
 import { getSetting } from "@renderer/lib/settings";
 import { cn } from "@renderer/lib/utils";
@@ -67,6 +68,7 @@ function RootComponent() {
   use4001FixerTitlebarActivity();
   useModBisectTitlebarActivity();
   useTextureResizerTitlebarActivity();
+  useModFixInspectionTitlebarActivity();
 
   useDownloadArchiveExtractPromptHandler();
 

--- a/frontend/src/routes/mod/index.tsx
+++ b/frontend/src/routes/mod/index.tsx
@@ -56,6 +56,15 @@ function getParentGroupPath(groupPath: string) {
   return groupPath.slice(0, separatorIndex);
 }
 
+function isPathInside(parent: string, child: string) {
+  if (!parent) return false;
+  const normalizedParent = parent.replaceAll("/", "\\").replace(/\\+$/, "").toLowerCase();
+  const normalizedChild = child.replaceAll("/", "\\").toLowerCase();
+  return (
+    normalizedChild === normalizedParent || normalizedChild.startsWith(`${normalizedParent}\\`)
+  );
+}
+
 function ModRouteContent() {
   const { t } = useTranslation();
   const { queryClient } = Route.useRouteContext();
@@ -72,6 +81,8 @@ function ModRouteContent() {
   const userSelectedDuringDownload = useModStore((s) => s.userSelectedDuringDownload);
   const archiveExtractPrompt = useModStore((s) => s.archiveExtractPrompt);
   const setArchiveExtractPrompt = useModStore((s) => s.setArchiveExtractPrompt);
+  const pendingModFixerRequest = useModStore((s) => s.pendingModFixerRequest);
+  const setPendingModFixerRequest = useModStore((s) => s.setPendingModFixerRequest);
   const viewMode = useModStore((s) => s.viewMode);
 
   const runner = useModFixRunner();
@@ -86,6 +97,47 @@ function ModRouteContent() {
   } | null>(null);
   const [pendingTargetVersion, setPendingTargetVersion] = useState(0);
   const resolvedDownloadIdsRef = useRef(new Set<string>());
+
+  useEffect(() => {
+    if (!pendingModFixerRequest || games.length === 0) {
+      return;
+    }
+
+    const matchingGame =
+      games.find(
+        (game) =>
+          game.importer?.toLowerCase() === pendingModFixerRequest.importer.toLowerCase() &&
+          isPathInside(game.modFolderPath, pendingModFixerRequest.modPath),
+      ) ??
+      games.find(
+        (game) => game.importer?.toLowerCase() === pendingModFixerRequest.importer.toLowerCase(),
+      );
+    if (!matchingGame) {
+      return;
+    }
+    if (matchingGame.game !== selectedGame) {
+      setSelectedGame(matchingGame.game);
+      return;
+    }
+    if (!runner.modFixer) {
+      return;
+    }
+
+    setPendingModFixerRequest(null);
+    void runner.handleOpenModFixer(pendingModFixerRequest.modPath).then(() => {
+      const actionTool = pendingModFixerRequest.actionTool;
+      if (actionTool === "hash" || actionTool === "jane" || actionTool === "dialyn") {
+        runner.setZZMITab(actionTool);
+      }
+    });
+  }, [
+    games,
+    pendingModFixerRequest,
+    runner,
+    selectedGame,
+    setPendingModFixerRequest,
+    setSelectedGame,
+  ]);
 
   useModRefreshOnFocus(selectedGame, queryClient);
   useDownloadCompletionHandler(selectedGame, selectedGroupPath, queryClient);

--- a/frontend/src/routes/mod/index.tsx
+++ b/frontend/src/routes/mod/index.tsx
@@ -103,15 +103,11 @@ function ModRouteContent() {
       return;
     }
 
-    const matchingGame =
-      games.find(
-        (game) =>
-          game.importer?.toLowerCase() === pendingModFixerRequest.importer.toLowerCase() &&
-          isPathInside(game.modFolderPath, pendingModFixerRequest.modPath),
-      ) ??
-      games.find(
-        (game) => game.importer?.toLowerCase() === pendingModFixerRequest.importer.toLowerCase(),
-      );
+    const matchingGame = games.find(
+      (game) =>
+        game.importer?.toLowerCase() === pendingModFixerRequest.importer.toLowerCase() &&
+        isPathInside(game.modFolderPath, pendingModFixerRequest.modPath),
+    );
     if (!matchingGame) {
       return;
     }

--- a/frontend/src/routes/setting/mod.tsx
+++ b/frontend/src/routes/setting/mod.tsx
@@ -48,6 +48,8 @@ const settingsConfig = {
   gridFixedColumnCount: "mod.gridFixedColumnCount",
 } as const;
 
+const AUTO_INSPECT_FIX_LABEL_ID = "setting-mod-auto-inspect-fix-title";
+
 function RouteComponent() {
   return <ModSettingsRouteContent />;
 }
@@ -124,6 +126,17 @@ function ModSettingsRouteContent() {
     } catch (error) {
       Logger.error(error, "ModSettings:handleSidebarLayoutChange");
       toast.error("설정 저장에 실패했습니다.");
+    }
+  };
+
+  const handleAutoInspectFixChange = async (val: boolean) => {
+    const previous = settings.autoInspectFix;
+    try {
+      await update("autoInspectFix", val);
+    } catch (error) {
+      Logger.error(error, "ModSettings:handleAutoInspectFixChange");
+      await update("autoInspectFix", previous).catch(() => {});
+      toast.error(t("page.setting.tools.wuwaFixer.autoUpdateNotification.save_failed"));
     }
   };
 
@@ -243,7 +256,7 @@ function ModSettingsRouteContent() {
 
             <div className="flex items-center justify-between">
               <div className="space-y-0.5 pr-4">
-                <span className="text-sm font-medium">
+                <span id={AUTO_INSPECT_FIX_LABEL_ID} className="text-sm font-medium">
                   {t("page.setting.mod.mod_management.autoInspectFix")}
                 </span>
                 <p className="text-xs text-muted-foreground">
@@ -252,7 +265,8 @@ function ModSettingsRouteContent() {
               </div>
               <Switch
                 checked={settings.autoInspectFix}
-                onCheckedChange={(val) => update("autoInspectFix", val)}
+                aria-labelledby={AUTO_INSPECT_FIX_LABEL_ID}
+                onCheckedChange={(val) => void handleAutoInspectFixChange(val)}
               />
             </div>
 

--- a/frontend/src/routes/setting/mod.tsx
+++ b/frontend/src/routes/setting/mod.tsx
@@ -35,6 +35,7 @@ const settingsConfig = {
   archiveExtractPathMode: "mod.archiveExtractPathMode",
   deleteArchiveAfterExtract: "mod.deleteArchiveAfterExtract",
   moveFolderInsteadOfCopy: "mod.moveFolderInsteadOfCopy",
+  autoInspectFix: "mod.autoInspectFix",
   searchModPreview: "mod.searchModPreview",
   autoResolveDownloadTarget: "mod.autoResolveDownloadTarget",
   autoResolveDownloadTargetSources: "mod.autoResolveDownloadTargetSources",
@@ -235,6 +236,23 @@ function ModSettingsRouteContent() {
               <Switch
                 checked={settings.moveFolderInsteadOfCopy}
                 onCheckedChange={(val) => update("moveFolderInsteadOfCopy", val)}
+              />
+            </div>
+
+            <Separator />
+
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5 pr-4">
+                <span className="text-sm font-medium">
+                  {t("page.setting.mod.mod_management.autoInspectFix")}
+                </span>
+                <p className="text-xs text-muted-foreground">
+                  {t("page.setting.mod.mod_management.autoInspectFixDescription")}
+                </p>
+              </div>
+              <Switch
+                checked={settings.autoInspectFix}
+                onCheckedChange={(val) => update("autoInspectFix", val)}
               />
             </div>
 

--- a/frontend/src/shared/settings.ts
+++ b/frontend/src/shared/settings.ts
@@ -36,6 +36,7 @@ export interface AppSettings {
     "mod.gridFixedColumnCount": number;
     "mod.disabledPrefixStyle": DisabledPrefixStyle;
     "mod.returnToGamebananaAfterDownload": boolean;
+    "mod.autoInspectFix": boolean;
 
     "tools.touchProfileLlmProtocol": TouchProfileLlmProtocol;
     "tools.touchProfileLlmEndpoint": string;
@@ -205,6 +206,11 @@ export const APP_SETTINGS = {
         publicKey: "mod.returnToGamebananaAfterDownload",
         scope: "mod",
         storageKey: "mod_return_to_gamebanana_after_download",
+    },
+    "mod.autoInspectFix": {
+        publicKey: "mod.autoInspectFix",
+        scope: "mod",
+        storageKey: "mod_auto_inspect_fix",
     },
 
     "tools.touchProfileLlmProtocol": {

--- a/frontend/src/store/mod.ts
+++ b/frontend/src/store/mod.ts
@@ -6,6 +6,11 @@ import { createStore, useStore } from "zustand";
 export type FolderSortKey = "name" | "mod-count" | "enabled-mod-count";
 export type FolderSortDirection = "ascending" | "descending";
 export type DownloadMode = NonNullable<ModState["downloadMode"]>;
+export type PendingModFixerRequest = {
+    modPath: string;
+    importer: string;
+    actionTool?: string;
+};
 
 interface ModState {
     selectedGame: string;
@@ -55,6 +60,8 @@ interface ModState {
     resetUserSelectedDuringDownload: () => void;
     archiveExtractPrompt: { requestId: string; fileName: string } | null;
     setArchiveExtractPrompt: (prompt: { requestId: string; fileName: string } | null) => void;
+    pendingModFixerRequest: PendingModFixerRequest | null;
+    setPendingModFixerRequest: (request: PendingModFixerRequest | null) => void;
     searchQuery: string;
     setSearchQuery: (query: string) => void;
     viewMode: "grid" | "list";
@@ -133,6 +140,8 @@ export const modStore = createStore<ModState>((set) => ({
     resetUserSelectedDuringDownload: () => set({ userSelectedDuringDownload: false }),
     archiveExtractPrompt: null,
     setArchiveExtractPrompt: (archiveExtractPrompt) => set({ archiveExtractPrompt }),
+    pendingModFixerRequest: null,
+    setPendingModFixerRequest: (pendingModFixerRequest) => set({ pendingModFixerRequest }),
     searchQuery: "",
     setSearchQuery: (searchQuery) => set({ searchQuery }),
     viewMode: "grid",

--- a/frontend/src/store/titlebar-activity.ts
+++ b/frontend/src/store/titlebar-activity.ts
@@ -1,7 +1,17 @@
 import type { LucideIcon } from "lucide-react";
 import { createStore, useStore } from "zustand";
 
-export type TitlebarActivityStatus = "running" | "paused" | "error";
+export type TitlebarActivityStatus = "running" | "paused" | "error" | "warning";
+
+export type TitlebarActivityPopover = {
+    title: string;
+    description?: string;
+    actionLabel?: string;
+    dismissLabel?: string;
+    onAction?: () => void;
+    onDismiss?: () => void;
+    defaultOpen?: boolean;
+};
 
 export type TitlebarActivity = {
     id: string;
@@ -10,6 +20,7 @@ export type TitlebarActivity = {
     icon: LucideIcon;
     detail?: string;
     tooltip?: string;
+    popover?: TitlebarActivityPopover;
     progress?: number;
     order?: number;
     href?: string;
@@ -34,7 +45,14 @@ function isSameActivity(a: TitlebarActivity, b: TitlebarActivity) {
         a.progress === b.progress &&
         a.order === b.order &&
         a.href === b.href &&
-        a.onClick === b.onClick
+        a.onClick === b.onClick &&
+        a.popover?.title === b.popover?.title &&
+        a.popover?.description === b.popover?.description &&
+        a.popover?.actionLabel === b.popover?.actionLabel &&
+        a.popover?.dismissLabel === b.popover?.dismissLabel &&
+        a.popover?.defaultOpen === b.popover?.defaultOpen &&
+        a.popover?.onAction === b.popover?.onAction &&
+        a.popover?.onDismiss === b.popover?.onDismiss
     );
 }
 

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -176,6 +176,15 @@ func newRuntime() *runtime {
 	if rt.drive != nil && rt.mod != nil {
 		rt.drive.UsePathSelector(rt.mod)
 	}
+	if rt.tools != nil {
+		queueFixInspections := rt.tools.QueueFixInspections
+		if rt.mod != nil {
+			rt.mod.UseFixInspection(queueFixInspections)
+		}
+		if rt.drive != nil {
+			rt.drive.UseFixInspection(queueFixInspections)
+		}
+	}
 	settings.UseHooks(runtimeSettingHooks(log, transferService, updaterService, rt.tools, rt.window, nil, eventEmit))
 	return rt
 }

--- a/internal/drive/download_service.go
+++ b/internal/drive/download_service.go
@@ -487,10 +487,19 @@ func (d *Drive) executeDownload(ctx context.Context, transfers *transfer.Transfe
 	if err := transfers.Update(pid, transfer.Updates{Status: &completed, TransferredSize: &total, TransferredFiles: &totalFiles, Progress: &hundred}); err != nil {
 		return err
 	}
+	inspectionPaths := make([]string, 0, len(record.DestinationTargets))
+	for _, target := range record.DestinationTargets {
+		if target.Kind == transfer.DestinationDirectory {
+			inspectionPaths = append(inspectionPaths, target.Path)
+		}
+	}
+	if d.inspectAddedMods != nil && len(inspectionPaths) > 0 {
+		d.inspectAddedMods(inspectionPaths)
+	}
 	if d.eventEmit != nil {
 		name := metadata.Root.Name
-		if record, ok := transfers.Get(pid); ok && record.Name != "" {
-			name = record.Name
+		if latest, ok := transfers.Get(pid); ok && latest.Name != "" {
+			name = latest.Name
 		}
 		d.eventEmit("download:completed", map[string]any{"path": params.TargetPath, "name": name})
 	}

--- a/internal/drive/download_service_test.go
+++ b/internal/drive/download_service_test.go
@@ -269,6 +269,46 @@ func TestStartDownloadRunsProvidedMetadataThroughTransferQueue(t *testing.T) {
 	}
 }
 
+func TestFolderDownloadCompletionUsesCreatedDirectoryForInspection(t *testing.T) {
+	content := []byte("downloaded content")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(content)
+	}))
+	defer server.Close()
+
+	transfers := transfer.New()
+	drive := downloadServiceTestDrive(server, transfers)
+	var inspectionPaths []string
+	drive.UseFixInspection(func(paths []string) {
+		inspectionPaths = slices.Clone(paths)
+	})
+	rootID := "root"
+	metadata := DownloadMetadata{
+		Root:       transfer.Root{ID: rootID, Name: "package"},
+		TotalBytes: int64(len(content)),
+		Files: []transfer.DownloadFile{{
+			ID: "file", FileID: "file", ParentID: &rootID, Name: "mod.ini", Size: int64(len(content)), URL: server.URL,
+		}},
+		Dirs: []transfer.Directory{{ID: rootID, Name: "package"}},
+	}
+	target := t.TempDir()
+	if _, err := drive.StartDownload(context.Background(), StartDownloadParams{
+		Items:      []DownloadItem{{ID: rootID, Name: "package", IsDir: true}},
+		TargetPath: target,
+		Data:       &metadata,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := transfers.ProcessQueue(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(target, "package")
+	if len(inspectionPaths) != 1 || inspectionPaths[0] != want {
+		t.Fatalf("queued folder inspection paths = %#v, want %q", inspectionPaths, want)
+	}
+}
+
 func TestQueuedDownloadReservesDestinationBeforeRunnerStarts(t *testing.T) {
 	content := []byte("queued content")
 	requestStarted := make(chan struct{})

--- a/internal/drive/drive.go
+++ b/internal/drive/drive.go
@@ -60,6 +60,7 @@ type Drive struct {
 	settings         UploadSettings
 	paths            PathSelector
 	eventEmit        func(string, ...any)
+	inspectAddedMods func([]string)
 	sleep            func(context.Context, time.Duration) error
 	now              func() time.Time
 	dirRetries       int
@@ -173,6 +174,13 @@ func (d *Drive) UsePathSelector(paths PathSelector) {
 		return
 	}
 	d.paths = paths
+}
+
+//wails:ignore
+func (d *Drive) UseFixInspection(fn func([]string)) {
+	if d != nil {
+		d.inspectAddedMods = fn
+	}
 }
 
 func (d *Drive) GetItem(ctx context.Context, itemID string) (result any, err error) {

--- a/internal/mod/custom_download.go
+++ b/internal/mod/custom_download.go
@@ -308,7 +308,7 @@ func (m *Mod) runGroupDownload(
 		return m.finishDownloadError(ctx, transfers, pid, err, "CustomDownloader:downloadToGroup")
 	}
 	_ = finalized.Commit()
-	return m.finishDownloadOK(transfers, pid, head, downloaded, groupPath, suggested)
+	return m.finishDownloadOK(transfers, pid, head, downloaded, groupPath, suggested, finalized.DestinationPaths)
 }
 
 func (m *Mod) runGameBananaDownload(
@@ -365,7 +365,7 @@ func (m *Mod) runGameBananaDownload(
 		return m.finishDownloadError(ctx, transfers, pid, err, "GameBanana:downloadFromGB:context")
 	}
 	_ = finalized.Commit()
-	return m.finishDownloadOK(transfers, pid, head, downloaded, destination, finalName)
+	return m.finishDownloadOK(transfers, pid, head, downloaded, destination, finalName, finalized.DestinationPaths)
 }
 
 func (m *Mod) runHuiCustomDownload(
@@ -403,7 +403,7 @@ func (m *Mod) runHuiCustomDownload(
 		return m.finishDownloadError(ctx, transfers, pid, err, "GameBanana:downloadFromGB")
 	}
 	_ = finalized.Commit()
-	return m.finishDownloadOK(transfers, pid, head, downloaded, destination, finalName)
+	return m.finishDownloadOK(transfers, pid, head, downloaded, destination, finalName, finalized.DestinationPaths)
 }
 
 func (m *Mod) downloadFileTo(
@@ -499,7 +499,14 @@ func (m *Mod) promptArchiveExtractMode(archivePath string) (string, error) {
 	return mode, nil
 }
 
-func (m *Mod) finishDownloadOK(transfers *transfer.Transfer, pid string, head downloadHead, downloaded int64, dest, name string) error {
+func (m *Mod) finishDownloadOK(
+	transfers *transfer.Transfer,
+	pid string,
+	head downloadHead,
+	downloaded int64,
+	dest, name string,
+	inspectionPaths []string,
+) error {
 	_ = transfers.MarkFileCompleted(pid, pid)
 	completed := transfer.StatusCompleted
 	hundred := 100.0
@@ -509,10 +516,22 @@ func (m *Mod) finishDownloadOK(transfers *transfer.Transfer, pid string, head do
 	}
 	one := 1
 	_ = transfers.Update(pid, transfer.Updates{Status: &completed, Progress: &hundred, TransferredSize: &transferred, TransferredFiles: &one})
+	directories := existingDownloadDirectories(inspectionPaths)
+	m.queueFixInspection(directories...)
 	if m.emit != nil {
 		m.emit("download:completed", map[string]string{"path": dest, "name": name})
 	}
 	return nil
+}
+
+func existingDownloadDirectories(paths []string) []string {
+	directories := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if info, err := os.Stat(path); err == nil && info.IsDir() {
+			directories = append(directories, path)
+		}
+	}
+	return directories
 }
 
 func (m *Mod) finishDownloadError(ctx context.Context, transfers *transfer.Transfer, pid string, err error, where string) error {

--- a/internal/mod/custom_download_test.go
+++ b/internal/mod/custom_download_test.go
@@ -76,12 +76,19 @@ func TestCustomDownloadPublicRunnersEndToEnd(t *testing.T) {
 	t.Run("custom URL", func(t *testing.T) {
 		destination := t.TempDir()
 		service, transfers := customDownloadTestService(t, server, destination, "", false)
+		var inspectionPaths []string
+		service.UseFixInspection(func(paths []string) {
+			inspectionPaths = append([]string(nil), paths...)
+		})
 		status, err := service.DownloadFromURL(context.Background(), server.URL+"/custom.zip", destination)
 		if err != nil || status != "started" {
 			t.Fatalf("DownloadFromURL = %q, %v", status, err)
 		}
 		processCustomDownloadQueue(t, transfers, int64(len(customArchive)))
 		assertCustomDownloadFile(t, filepath.Join(destination, "CustomRoot", "mod.ini"), "custom")
+		if len(inspectionPaths) != 1 || inspectionPaths[0] != filepath.Join(destination, "CustomRoot") {
+			t.Fatalf("queued inspection paths = %#v", inspectionPaths)
+		}
 	})
 
 	t.Run("GameBanana", func(t *testing.T) {

--- a/internal/mod/imports.go
+++ b/internal/mod/imports.go
@@ -131,6 +131,7 @@ func (m *Mod) ExtractArchiveToGroup(
 	if err != nil {
 		return "", err
 	}
+	m.queueFixInspection(target)
 	deleteAfter := false
 	if m.settings != nil {
 		deleteAfter, err = m.settings.GetDeleteArchiveAfterExtract(ctx)
@@ -176,6 +177,7 @@ func (m *Mod) CopyFolderToGroup(
 	}
 	if move {
 		if err := os.Rename(source, target); err == nil {
+			m.queueFixInspection(target)
 			return target, nil
 		}
 	}
@@ -192,6 +194,7 @@ func (m *Mod) CopyFolderToGroup(
 			return target, err
 		}
 	}
+	m.queueFixInspection(target)
 	return target, nil
 }
 

--- a/internal/mod/mod.go
+++ b/internal/mod/mod.go
@@ -84,6 +84,7 @@ type Mod struct {
 	gameWatcher       *managedWatcher
 	characterWatcher  *managedWatcher
 	emit              func(string, ...any)
+	inspectAddedMods  func([]string)
 	nteSigBypasserURL string
 	nteASILoaderURL   string
 }
@@ -145,6 +146,19 @@ func (m *Mod) UseFocus(fn func()) {
 func (m *Mod) UseWindowReady(fn func(context.Context) (bool, error)) {
 	if m != nil && m.paths != nil {
 		m.paths.waitReady = fn
+	}
+}
+
+//wails:ignore
+func (m *Mod) UseFixInspection(fn func([]string)) {
+	if m != nil {
+		m.inspectAddedMods = fn
+	}
+}
+
+func (m *Mod) queueFixInspection(paths ...string) {
+	if m != nil && m.inspectAddedMods != nil && len(paths) > 0 {
+		m.inspectAddedMods(paths)
 	}
 }
 

--- a/internal/setting/keys.go
+++ b/internal/setting/keys.go
@@ -31,6 +31,7 @@ const (
 	KeyModGridFixedColumnCount             = "mod.gridFixedColumnCount"
 	KeyModDisabledPrefixStyle              = "mod.disabledPrefixStyle"
 	KeyModReturnToGamebananaAfterDownload  = "mod.returnToGamebananaAfterDownload"
+	KeyModAutoInspectFix                   = "mod.autoInspectFix"
 
 	KeyToolsTouchProfileLlmProtocol     = "tools.touchProfileLlmProtocol"
 	KeyToolsTouchProfileLlmEndpoint     = "tools.touchProfileLlmEndpoint"
@@ -104,6 +105,7 @@ var allDefinitions = []Definition{
 	{KeyModGridFixedColumnCount, ScopeMod, "mod_grid_fixed_column_count"},
 	{KeyModDisabledPrefixStyle, ScopeMod, "mod_disabled_prefix_style"},
 	{KeyModReturnToGamebananaAfterDownload, ScopeMod, "mod_return_to_gamebanana_after_download"},
+	{KeyModAutoInspectFix, ScopeMod, "mod_auto_inspect_fix"},
 
 	{KeyToolsTouchProfileLlmProtocol, ScopeTools, "tools_touch_profile_llm_protocol"},
 	{KeyToolsTouchProfileLlmEndpoint, ScopeTools, "tools_touch_profile_llm_endpoint"},

--- a/internal/setting/setting.go
+++ b/internal/setting/setting.go
@@ -407,6 +407,14 @@ func (s *Setting) SetSearchModPreview(ctx context.Context, enabled bool) error {
 	return s.Set(ctx, KeyModSearchModPreview, enabled)
 }
 
+func (s *Setting) GetAutoInspectFix(ctx context.Context) (bool, error) {
+	return s.getBool(ctx, KeyModAutoInspectFix)
+}
+
+func (s *Setting) SetAutoInspectFix(ctx context.Context, enabled bool) error {
+	return s.Set(ctx, KeyModAutoInspectFix, enabled)
+}
+
 func (s *Setting) GetBisectPreserveD3dx(ctx context.Context) (bool, error) {
 	return s.getBool(ctx, KeyGeneralBisectPreserveD3dx)
 }

--- a/internal/setting/specs.go
+++ b/internal/setting/specs.go
@@ -211,6 +211,7 @@ func buildSpecs() map[string]spec {
 		),
 		KeyModDisabledPrefixStyle:             enumSpec(definitionsByKey[KeyModDisabledPrefixStyle], defaultDisabledPrefix, disabledPrefixStyles),
 		KeyModReturnToGamebananaAfterDownload: boolSpec(definitionsByKey[KeyModReturnToGamebananaAfterDownload], false),
+		KeyModAutoInspectFix:                  boolSpec(definitionsByKey[KeyModAutoInspectFix], true),
 
 		KeyToolsTouchProfileLlmProtocol: {
 			def: definitionsByKey[KeyToolsTouchProfileLlmProtocol],

--- a/internal/tools/fix_inspection_state.go
+++ b/internal/tools/fix_inspection_state.go
@@ -1,0 +1,535 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"nahida.live/desktop/internal/watcher"
+)
+
+const (
+	fixInspectionChangedEvent = "tools:fix-inspections"
+	fixInspectionSettleDelay  = 800 * time.Millisecond
+)
+
+var fixInspectionDisabledPrefixRE = regexp.MustCompile(`(?i)^(?:disabled[\s_]*)+[\s_]+`)
+
+// Fix inspection records are process-local and intentionally never persisted.
+type FixInspectionRecord struct {
+	ModPath     string              `json:"modPath"`
+	DisplayName string              `json:"displayName"`
+	Result      FixInspectionResult `json:"result"`
+}
+
+// Revision lets renderers reject an initial snapshot that loses a race with a watcher event.
+type FixInspectionSnapshot struct {
+	Revision    uint64                `json:"revision"`
+	Inspections []FixInspectionRecord `json:"inspections"`
+}
+
+type trackedFixInspection struct {
+	record         FixInspectionRecord
+	identity       fs.FileInfo
+	contentWatcher *watcher.Watcher
+	parentWatcher  *watcher.Watcher
+}
+
+// Only actionable results are retained and watched for changes.
+func (t *Tools) InspectModForFix(ctx context.Context, modPath, importer string) (*FixInspectionResult, error) {
+	if t == nil || t.fixInspectors == nil {
+		return &FixInspectionResult{Importer: strings.ToUpper(importer)}, nil
+	}
+
+	resolved, err := filepath.Abs(modPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve fix inspection target %q: %w", modPath, err)
+	}
+	resolved = filepath.Clean(resolved)
+
+	t.fixInspectionRunMu.Lock()
+	defer t.fixInspectionRunMu.Unlock()
+
+	result, err := t.fixInspectors.Inspect(ctx, resolved, importer)
+	if err != nil {
+		return nil, err
+	}
+	if !result.NeedsFix {
+		changed, stopped := t.removeFixInspection(resolved)
+		t.logError(closeFixInspectionWatchers(stopped), "FixInspector.stopWatch")
+		if changed {
+			t.emitFixInspectionSnapshot()
+		}
+		return result, nil
+	}
+
+	record := FixInspectionRecord{
+		ModPath:     resolved,
+		DisplayName: filepath.Base(resolved),
+		Result:      cloneFixInspectionResult(*result),
+	}
+	changed, watchErr := t.storeFixInspection(record)
+	if watchErr != nil {
+		t.logError(watchErr, "FixInspector.watch")
+	}
+	refreshed, stopped := t.refreshFixInspectionLocked(ctx, fixInspectionKey(resolved))
+	changed = changed || refreshed
+	t.logError(closeFixInspectionWatchers(stopped), "FixInspector.stopWatch")
+	if changed {
+		t.emitFixInspectionSnapshot()
+	}
+	return result, nil
+}
+
+// Refresh also catches ancestor moves that Windows cannot report through an open child handle.
+func (t *Tools) RefreshFixInspections(ctx context.Context) FixInspectionSnapshot {
+	if t == nil {
+		return FixInspectionSnapshot{Inspections: []FixInspectionRecord{}}
+	}
+	t.fixInspectionRunMu.Lock()
+	changed, stopped := t.refreshAllFixInspectionsLocked(ctx)
+	t.fixInspectionRunMu.Unlock()
+	t.logError(closeFixInspectionWatchers(stopped), "FixInspector.stopWatch")
+	if changed {
+		t.emitFixInspectionSnapshot()
+	}
+	return t.fixInspectionSnapshot()
+}
+
+//wails:ignore
+func (t *Tools) QueueFixInspections(paths []string) {
+	if t == nil {
+		return
+	}
+	targets := make([]string, 0, len(paths))
+	seen := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		if strings.TrimSpace(path) == "" {
+			continue
+		}
+		key := fixInspectionKey(path)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		targets = append(targets, path)
+	}
+	if len(targets) == 0 {
+		return
+	}
+
+	t.fixInspectionMu.Lock()
+	if t.fixInspectionClosed {
+		t.fixInspectionMu.Unlock()
+		return
+	}
+	t.fixInspectionWG.Add(1)
+	t.fixInspectionMu.Unlock()
+
+	go func() {
+		defer t.fixInspectionWG.Done()
+		for _, path := range targets {
+			if err := t.inspectAddedModForFix(context.Background(), path); err != nil {
+				t.logError(fmt.Errorf("inspect added mod %q: %w", path, err), "FixInspector.addedMod")
+			}
+		}
+	}()
+}
+
+func (t *Tools) inspectAddedModForFix(ctx context.Context, modPath string) error {
+	if settings, ok := t.settings.(FixInspectionSettings); ok {
+		enabled, err := settings.GetAutoInspectFix(ctx)
+		if err != nil {
+			return fmt.Errorf("read automatic fix inspection setting: %w", err)
+		}
+		if !enabled {
+			return nil
+		}
+	}
+
+	importer, err := t.resolveFixInspectionImporter(ctx, modPath)
+	if err != nil {
+		return err
+	}
+	_, err = t.InspectModForFix(ctx, modPath, importer)
+	return err
+}
+
+func (t *Tools) resolveFixInspectionImporter(ctx context.Context, modPath string) (string, error) {
+	client, err := t.requireClient()
+	if err != nil {
+		return "", err
+	}
+	target, err := filepath.EvalSymlinks(modPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve added mod path %q: %w", modPath, err)
+	}
+	target, err = filepath.Abs(target)
+	if err != nil {
+		return "", fmt.Errorf("resolve absolute added mod path %q: %w", target, err)
+	}
+
+	games, err := client.GamePaths.List(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list game paths for fix inspection: %w", err)
+	}
+	var importer string
+	bestRootLength := -1
+	for _, game := range games {
+		if game.Importer == nil || strings.TrimSpace(*game.Importer) == "" {
+			continue
+		}
+		root, resolveErr := filepath.EvalSymlinks(game.ModFolderPath)
+		if resolveErr != nil {
+			continue
+		}
+		root, resolveErr = filepath.Abs(root)
+		if resolveErr != nil || !sameOrChildPath(root, target) || len(root) <= bestRootLength {
+			continue
+		}
+		importer = *game.Importer
+		bestRootLength = len(root)
+	}
+	if importer == "" {
+		return "", fmt.Errorf("added mod path is outside configured game folders: %s", target)
+	}
+	return importer, nil
+}
+
+func (t *Tools) storeFixInspection(record FixInspectionRecord) (bool, error) {
+	key := fixInspectionKey(record.ModPath)
+	t.fixInspectionMu.Lock()
+	if t.fixInspectionClosed {
+		t.fixInspectionMu.Unlock()
+		return false, nil
+	}
+	if current := t.fixInspections[key]; current != nil {
+		changed := !equalFixInspectionRecord(current.record, record)
+		current.record = record
+		if changed {
+			t.fixInspectionRevision++
+		}
+		t.fixInspectionMu.Unlock()
+		return changed, nil
+	}
+	t.fixInspectionMu.Unlock()
+
+	identity, identityErr := fixInspectionIdentity(record.ModPath)
+	tracked := &trackedFixInspection{record: record, identity: identity}
+	contentWatcher, contentErr := watcher.WatchTree(
+		[]string{record.ModPath},
+		watcher.TreeConfig{
+			Depth:    -1,
+			Ops:      watcher.All,
+			Debounce: fixInspectionSettleDelay,
+			OnError: func(err error) {
+				t.logError(fmt.Errorf("watch fix inspection contents %q: %w", record.ModPath, err), "FixInspector.watch")
+			},
+		},
+		func(watcher.Event) { t.queueFixInspectionRefresh(key) },
+	)
+	tracked.contentWatcher = contentWatcher
+
+	parentWatcher, parentErr := watcher.WatchTree(
+		[]string{filepath.Dir(record.ModPath)},
+		watcher.TreeConfig{
+			Depth:    0,
+			Ops:      watcher.Remove | watcher.Rename,
+			Debounce: fixInspectionSettleDelay,
+			Filter: func(event watcher.Event) bool {
+				return watcher.SamePath(event.Path, record.ModPath)
+			},
+			OnError: func(err error) {
+				t.logError(fmt.Errorf("watch fix inspection parent for %q: %w", record.ModPath, err), "FixInspector.watch")
+			},
+		},
+		func(watcher.Event) { t.queueFixInspectionRefresh(key) },
+	)
+	tracked.parentWatcher = parentWatcher
+
+	t.fixInspectionMu.Lock()
+	if t.fixInspectionClosed {
+		t.fixInspectionMu.Unlock()
+		closeErr := closeFixInspectionWatchers([]*trackedFixInspection{tracked})
+		return false, errors.Join(identityErr, contentErr, parentErr, closeErr)
+	}
+	if current := t.fixInspections[key]; current != nil {
+		changed := !equalFixInspectionRecord(current.record, record)
+		current.record = record
+		if changed {
+			t.fixInspectionRevision++
+		}
+		t.fixInspectionMu.Unlock()
+		closeErr := closeFixInspectionWatchers([]*trackedFixInspection{tracked})
+		return changed, errors.Join(identityErr, contentErr, parentErr, closeErr)
+	}
+	t.fixInspections[key] = tracked
+	t.fixInspectionRevision++
+	t.fixInspectionMu.Unlock()
+	return true, errors.Join(identityErr, contentErr, parentErr)
+}
+
+func (t *Tools) queueFixInspectionRefresh(key string) {
+	t.fixInspectionMu.Lock()
+	if t.fixInspectionClosed || t.fixInspections[key] == nil {
+		t.fixInspectionMu.Unlock()
+		return
+	}
+	t.fixInspectionWG.Add(1)
+	t.fixInspectionMu.Unlock()
+
+	go func() {
+		defer t.fixInspectionWG.Done()
+		t.fixInspectionRunMu.Lock()
+		changed, stopped := t.refreshFixInspectionLocked(context.Background(), key)
+		t.fixInspectionRunMu.Unlock()
+		t.logError(closeFixInspectionWatchers(stopped), "FixInspector.stopWatch")
+		if changed {
+			t.emitFixInspectionSnapshot()
+		}
+	}()
+}
+
+func (t *Tools) refreshAllFixInspectionsLocked(ctx context.Context) (bool, []*trackedFixInspection) {
+	t.fixInspectionMu.Lock()
+	keys := make([]string, 0, len(t.fixInspections))
+	for key := range t.fixInspections {
+		keys = append(keys, key)
+	}
+	t.fixInspectionMu.Unlock()
+
+	var changed bool
+	var stopped []*trackedFixInspection
+	for _, key := range keys {
+		itemChanged, itemStopped := t.refreshFixInspectionLocked(ctx, key)
+		changed = changed || itemChanged
+		stopped = append(stopped, itemStopped...)
+		if ctx.Err() != nil {
+			break
+		}
+	}
+	return changed, stopped
+}
+
+func (t *Tools) refreshFixInspectionLocked(ctx context.Context, key string) (bool, []*trackedFixInspection) {
+	t.fixInspectionMu.Lock()
+	if t.fixInspectionClosed {
+		t.fixInspectionMu.Unlock()
+		return false, nil
+	}
+	tracked := t.fixInspections[key]
+	if tracked == nil {
+		t.fixInspectionMu.Unlock()
+		return false, nil
+	}
+	record := cloneFixInspectionRecord(tracked.record)
+	identity := tracked.identity
+	t.fixInspectionMu.Unlock()
+
+	var changed bool
+	var stopped []*trackedFixInspection
+	info, err := os.Stat(record.ModPath)
+	if err != nil || !info.IsDir() {
+		if err != nil && errors.Is(err, fs.ErrNotExist) {
+			renamedPath := findDisabledFixInspectionRename(record.ModPath, identity)
+			if renamedPath == "" {
+				return t.removeFixInspection(record.ModPath)
+			}
+			_, stopped = t.removeFixInspection(record.ModPath)
+			record.ModPath = renamedPath
+			record.DisplayName = filepath.Base(renamedPath)
+			_, watchErr := t.storeFixInspection(record)
+			t.logError(watchErr, "FixInspector.watch")
+			key = fixInspectionKey(renamedPath)
+			changed = true
+		} else {
+			if err == nil {
+				return t.removeFixInspection(record.ModPath)
+			}
+			t.logError(fmt.Errorf("stat fix inspection target %q: %w", record.ModPath, err), "FixInspector.refresh")
+			return false, nil
+		}
+	}
+
+	result, err := t.fixInspectors.Inspect(ctx, record.ModPath, record.Result.Importer)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			removed, removedWatchers := t.removeFixInspection(record.ModPath)
+			return changed || removed, append(stopped, removedWatchers...)
+		}
+		t.logError(fmt.Errorf("refresh fix inspection target %q: %w", record.ModPath, err), "FixInspector.refresh")
+		return changed, stopped
+	}
+	if !result.NeedsFix {
+		removed, removedWatchers := t.removeFixInspection(record.ModPath)
+		return changed || removed, append(stopped, removedWatchers...)
+	}
+
+	record.Result = cloneFixInspectionResult(*result)
+	t.fixInspectionMu.Lock()
+	current := t.fixInspections[key]
+	if t.fixInspectionClosed || current == nil {
+		t.fixInspectionMu.Unlock()
+		return changed, stopped
+	}
+	recordChanged := !equalFixInspectionRecord(current.record, record)
+	if recordChanged {
+		current.record = record
+		t.fixInspectionRevision++
+	}
+	t.fixInspectionMu.Unlock()
+	return changed || recordChanged, stopped
+}
+
+func findDisabledFixInspectionRename(previousPath string, identity fs.FileInfo) string {
+	if identity == nil {
+		return ""
+	}
+	entries, err := os.ReadDir(filepath.Dir(previousPath))
+	if err != nil {
+		return ""
+	}
+	previousName := filepath.Base(previousPath)
+	for _, entry := range entries {
+		if !entry.IsDir() || !isDisabledFixInspectionRename(previousName, entry.Name()) {
+			continue
+		}
+		candidate := filepath.Join(filepath.Dir(previousPath), entry.Name())
+		info, statErr := os.Stat(candidate)
+		if statErr == nil && info.IsDir() && os.SameFile(identity, info) {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func fixInspectionIdentity(path string) (fs.FileInfo, error) {
+	directory, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	info, statErr := directory.Stat()
+	return info, errors.Join(statErr, directory.Close())
+}
+
+func isDisabledFixInspectionRename(previousName, candidateName string) bool {
+	previousName = strings.TrimSpace(previousName)
+	candidateName = strings.TrimSpace(candidateName)
+	previousDisabled := fixInspectionDisabledPrefixRE.MatchString(previousName)
+	candidateDisabled := fixInspectionDisabledPrefixRE.MatchString(candidateName)
+	if !previousDisabled && !candidateDisabled {
+		return false
+	}
+	previousBase := strings.TrimSpace(fixInspectionDisabledPrefixRE.ReplaceAllString(previousName, ""))
+	candidateBase := strings.TrimSpace(fixInspectionDisabledPrefixRE.ReplaceAllString(candidateName, ""))
+	return previousBase != "" && strings.EqualFold(previousBase, candidateBase)
+}
+
+func (t *Tools) removeFixInspection(modPath string) (bool, []*trackedFixInspection) {
+	key := fixInspectionKey(modPath)
+	t.fixInspectionMu.Lock()
+	tracked := t.fixInspections[key]
+	if tracked != nil {
+		delete(t.fixInspections, key)
+		t.fixInspectionRevision++
+	}
+	t.fixInspectionMu.Unlock()
+	if tracked == nil {
+		return false, nil
+	}
+	return true, []*trackedFixInspection{tracked}
+}
+
+func (t *Tools) fixInspectionSnapshot() FixInspectionSnapshot {
+	if t == nil {
+		return FixInspectionSnapshot{Inspections: []FixInspectionRecord{}}
+	}
+	t.fixInspectionMu.Lock()
+	defer t.fixInspectionMu.Unlock()
+	items := make([]FixInspectionRecord, 0, len(t.fixInspections))
+	for _, tracked := range t.fixInspections {
+		items = append(items, cloneFixInspectionRecord(tracked.record))
+	}
+	slices.SortFunc(items, func(left, right FixInspectionRecord) int {
+		return strings.Compare(strings.ToLower(left.ModPath), strings.ToLower(right.ModPath))
+	})
+	return FixInspectionSnapshot{Revision: t.fixInspectionRevision, Inspections: items}
+}
+
+func (t *Tools) emitFixInspectionSnapshot() {
+	t.emitEvent(fixInspectionChangedEvent, t.fixInspectionSnapshot())
+}
+
+func (t *Tools) shutdownFixInspections() error {
+	if t == nil {
+		return nil
+	}
+	t.fixInspectionMu.Lock()
+	t.fixInspectionClosed = true
+	tracked := make([]*trackedFixInspection, 0, len(t.fixInspections))
+	for _, item := range t.fixInspections {
+		tracked = append(tracked, item)
+	}
+	t.fixInspections = make(map[string]*trackedFixInspection)
+	t.fixInspectionMu.Unlock()
+
+	err := closeFixInspectionWatchers(tracked)
+	t.fixInspectionWG.Wait()
+	t.fixInspectionRunMu.Lock()
+	defer t.fixInspectionRunMu.Unlock()
+	return err
+}
+
+func closeFixInspectionWatchers(tracked []*trackedFixInspection) error {
+	var result error
+	for _, item := range tracked {
+		if item == nil {
+			continue
+		}
+		if item.contentWatcher != nil {
+			result = errors.Join(result, item.contentWatcher.Close())
+		}
+		if item.parentWatcher != nil {
+			result = errors.Join(result, item.parentWatcher.Close())
+		}
+	}
+	return result
+}
+
+func fixInspectionKey(path string) string {
+	resolved, err := filepath.Abs(path)
+	if err == nil {
+		path = resolved
+	}
+	return strings.ToLower(filepath.Clean(path))
+}
+
+func cloneFixInspectionRecord(record FixInspectionRecord) FixInspectionRecord {
+	record.Result = cloneFixInspectionResult(record.Result)
+	return record
+}
+
+func cloneFixInspectionResult(result FixInspectionResult) FixInspectionResult {
+	result.Details = slices.Clone(result.Details)
+	result.AffectedFiles = slices.Clone(result.AffectedFiles)
+	return result
+}
+
+func equalFixInspectionRecord(left, right FixInspectionRecord) bool {
+	return left.ModPath == right.ModPath &&
+		left.DisplayName == right.DisplayName &&
+		left.Result.NeedsFix == right.Result.NeedsFix &&
+		left.Result.Importer == right.Result.Importer &&
+		left.Result.ToolName == right.Result.ToolName &&
+		left.Result.Summary == right.Result.Summary &&
+		left.Result.ActionTool == right.Result.ActionTool &&
+		slices.Equal(left.Result.Details, right.Result.Details) &&
+		slices.Equal(left.Result.AffectedFiles, right.Result.AffectedFiles)
+}

--- a/internal/tools/fix_inspection_state.go
+++ b/internal/tools/fix_inspection_state.go
@@ -79,7 +79,7 @@ func (t *Tools) InspectModForFix(ctx context.Context, modPath, importer string) 
 	if watchErr != nil {
 		t.logError(watchErr, "FixInspector.watch")
 	}
-	refreshed, stopped := t.refreshFixInspectionLocked(ctx, fixInspectionKey(resolved))
+	refreshed, stopped := t.refreshFixInspectionLocked(ctx, fixInspectionKey(resolved), result)
 	changed = changed || refreshed
 	t.logError(closeFixInspectionWatchers(stopped), "FixInspector.stopWatch")
 	if changed {
@@ -131,12 +131,19 @@ func (t *Tools) QueueFixInspections(paths []string) {
 		return
 	}
 	t.fixInspectionWG.Add(1)
+	ctx := t.fixInspectionCtx
 	t.fixInspectionMu.Unlock()
 
 	go func() {
 		defer t.fixInspectionWG.Done()
 		for _, path := range targets {
-			if err := t.inspectAddedModForFix(context.Background(), path); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			if err := t.inspectAddedModForFix(ctx, path); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
 				t.logError(fmt.Errorf("inspect added mod %q: %w", path, err), "FixInspector.addedMod")
 			}
 		}
@@ -283,12 +290,13 @@ func (t *Tools) queueFixInspectionRefresh(key string) {
 		return
 	}
 	t.fixInspectionWG.Add(1)
+	ctx := t.fixInspectionCtx
 	t.fixInspectionMu.Unlock()
 
 	go func() {
 		defer t.fixInspectionWG.Done()
 		t.fixInspectionRunMu.Lock()
-		changed, stopped := t.refreshFixInspectionLocked(context.Background(), key)
+		changed, stopped := t.refreshFixInspectionLocked(ctx, key, nil)
 		t.fixInspectionRunMu.Unlock()
 		t.logError(closeFixInspectionWatchers(stopped), "FixInspector.stopWatch")
 		if changed {
@@ -308,7 +316,7 @@ func (t *Tools) refreshAllFixInspectionsLocked(ctx context.Context) (bool, []*tr
 	var changed bool
 	var stopped []*trackedFixInspection
 	for _, key := range keys {
-		itemChanged, itemStopped := t.refreshFixInspectionLocked(ctx, key)
+		itemChanged, itemStopped := t.refreshFixInspectionLocked(ctx, key, nil)
 		changed = changed || itemChanged
 		stopped = append(stopped, itemStopped...)
 		if ctx.Err() != nil {
@@ -318,7 +326,7 @@ func (t *Tools) refreshAllFixInspectionsLocked(ctx context.Context) (bool, []*tr
 	return changed, stopped
 }
 
-func (t *Tools) refreshFixInspectionLocked(ctx context.Context, key string) (bool, []*trackedFixInspection) {
+func (t *Tools) refreshFixInspectionLocked(ctx context.Context, key string, inspected *FixInspectionResult) (bool, []*trackedFixInspection) {
 	t.fixInspectionMu.Lock()
 	if t.fixInspectionClosed {
 		t.fixInspectionMu.Unlock()
@@ -358,14 +366,20 @@ func (t *Tools) refreshFixInspectionLocked(ctx context.Context, key string) (boo
 		}
 	}
 
-	result, err := t.fixInspectors.Inspect(ctx, record.ModPath, record.Result.Importer)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			removed, removedWatchers := t.removeFixInspection(record.ModPath)
-			return changed || removed, append(stopped, removedWatchers...)
+	result := inspected
+	if result == nil {
+		result, err = t.fixInspectors.Inspect(ctx, record.ModPath, record.Result.Importer)
+		if err != nil {
+			if ctx.Err() != nil {
+				return changed, stopped
+			}
+			if errors.Is(err, fs.ErrNotExist) {
+				removed, removedWatchers := t.removeFixInspection(record.ModPath)
+				return changed || removed, append(stopped, removedWatchers...)
+			}
+			t.logError(fmt.Errorf("refresh fix inspection target %q: %w", record.ModPath, err), "FixInspector.refresh")
+			return changed, stopped
 		}
-		t.logError(fmt.Errorf("refresh fix inspection target %q: %w", record.ModPath, err), "FixInspector.refresh")
-		return changed, stopped
 	}
 	if !result.NeedsFix {
 		removed, removedWatchers := t.removeFixInspection(record.ModPath)
@@ -478,8 +492,10 @@ func (t *Tools) shutdownFixInspections() error {
 		tracked = append(tracked, item)
 	}
 	t.fixInspections = make(map[string]*trackedFixInspection)
+	cancel := t.fixInspectionCancel
 	t.fixInspectionMu.Unlock()
 
+	cancel()
 	err := closeFixInspectionWatchers(tracked)
 	t.fixInspectionWG.Wait()
 	t.fixInspectionRunMu.Lock()

--- a/internal/tools/fix_inspection_state_test.go
+++ b/internal/tools/fix_inspection_state_test.go
@@ -1,0 +1,282 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"nahida.live/desktop/internal/db"
+	"nahida.live/desktop/internal/watcher"
+)
+
+type fixInspectionTestSettings struct {
+	enabled bool
+}
+
+func (s fixInspectionTestSettings) GetAutoInspectFix(context.Context) (bool, error) {
+	return s.enabled, nil
+}
+
+func (fixInspectionTestSettings) GetBisectPreserveD3dx(context.Context) (bool, error) {
+	return false, nil
+}
+
+func (fixInspectionTestSettings) GetDisabledPrefixStyle(context.Context) (string, error) {
+	return "space", nil
+}
+
+func TestQueueFixInspectionsResolvesImporterFromManagedPath(t *testing.T) {
+	service := newMarkerInspectionService()
+	service.UseClient(openToolsTestDB(t))
+	service.settings = fixInspectionTestSettings{enabled: true}
+	t.Cleanup(func() {
+		if err := service.ServiceShutdown(); err != nil {
+			t.Errorf("shutdown tools service: %v", err)
+		}
+	})
+
+	root := t.TempDir()
+	importer := "TEST"
+	if err := service.client.GamePaths.Insert(context.Background(), db.GamePathRow{
+		Game:          "test",
+		ModFolderPath: root,
+		Importer:      &importer,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "NeedsFix")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "needs-fix"), []byte("pending"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	service.QueueFixInspections([]string{target})
+	waitForFixInspectionCount(t, service, 1)
+
+	record := service.fixInspectionSnapshot().Inspections[0]
+	if record.ModPath != target || record.Result.Importer != importer {
+		t.Fatalf("queued inspection = %+v", record)
+	}
+}
+
+func TestQueueFixInspectionsHonorsDisabledSetting(t *testing.T) {
+	service := newMarkerInspectionService()
+	service.UseClient(openToolsTestDB(t))
+	service.settings = fixInspectionTestSettings{enabled: false}
+	t.Cleanup(func() {
+		if err := service.ServiceShutdown(); err != nil {
+			t.Errorf("shutdown tools service: %v", err)
+		}
+	})
+
+	root := t.TempDir()
+	importer := "TEST"
+	if err := service.client.GamePaths.Insert(context.Background(), db.GamePathRow{
+		Game:          "test",
+		ModFolderPath: root,
+		Importer:      &importer,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "NeedsFix")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "needs-fix"), []byte("pending"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	service.QueueFixInspections([]string{target})
+	service.fixInspectionWG.Wait()
+	if snapshot := service.fixInspectionSnapshot(); len(snapshot.Inspections) != 0 {
+		t.Fatalf("disabled inspection retained results: %+v", snapshot)
+	}
+}
+
+func TestFixInspectionStateWatchesExternalChanges(t *testing.T) {
+	service := newMarkerInspectionService()
+	t.Cleanup(func() {
+		if err := service.ServiceShutdown(); err != nil {
+			t.Errorf("shutdown tools service: %v", err)
+		}
+	})
+
+	root := t.TempDir()
+	target := filepath.Join(root, "NeedsFix")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(target, "needs-fix")
+	if err := os.WriteFile(marker, []byte("pending"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := service.InspectModForFix(context.Background(), target, "TEST")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.NeedsFix || len(service.fixInspectionSnapshot().Inspections) != 1 {
+		t.Fatalf("expected one retained inspection, got result=%+v snapshot=%+v", result, service.fixInspectionSnapshot())
+	}
+
+	if err := os.Remove(marker); err != nil {
+		t.Fatal(err)
+	}
+	waitForFixInspectionCount(t, service, 0)
+
+	second := filepath.Join(root, "MovedMod")
+	if err := os.Mkdir(second, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(second, "needs-fix"), []byte("pending"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.InspectModForFix(context.Background(), second, "TEST"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(second, filepath.Join(root, "MovedElsewhere")); err != nil {
+		t.Fatal(err)
+	}
+	waitForFixInspectionCount(t, service, 0)
+
+	removed := filepath.Join(root, "RemovedMod")
+	if err := os.Mkdir(removed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(removed, "needs-fix"), []byte("pending"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.InspectModForFix(context.Background(), removed, "TEST"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(removed); err != nil {
+		t.Fatal(err)
+	}
+	waitForFixInspectionCount(t, service, 0)
+}
+
+func TestFixInspectionStateFollowsDisabledFolderRenames(t *testing.T) {
+	service := newMarkerInspectionService()
+	t.Cleanup(func() {
+		if err := service.ServiceShutdown(); err != nil {
+			t.Errorf("shutdown tools service: %v", err)
+		}
+	})
+
+	root := t.TempDir()
+	active := filepath.Join(root, "[LL] Cunning Soldier Anby - Skimpy Ver")
+	if err := os.Mkdir(active, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(active, "needs-fix"), []byte("pending"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.InspectModForFix(context.Background(), active, "TEST"); err != nil {
+		t.Fatal(err)
+	}
+	disabledSpace := filepath.Join(root, "DISABLED [LL] Cunning Soldier Anby - Skimpy Ver")
+	if err := os.Rename(active, disabledSpace); err != nil {
+		t.Fatal(err)
+	}
+	waitForFixInspectionPath(t, service, disabledSpace)
+
+	if err := os.Rename(disabledSpace, active); err != nil {
+		t.Fatal(err)
+	}
+	waitForFixInspectionPath(t, service, active)
+
+	disabledUnderscore := filepath.Join(root, "DISABLED_[LL] Cunning Soldier Anby - Skimpy Ver")
+	if err := os.Rename(active, disabledUnderscore); err != nil {
+		t.Fatal(err)
+	}
+	waitForFixInspectionPath(t, service, disabledUnderscore)
+
+	if err := os.Remove(filepath.Join(disabledUnderscore, "needs-fix")); err != nil {
+		t.Fatal(err)
+	}
+	waitForFixInspectionCount(t, service, 0)
+}
+
+func TestFixInspectionStateIsNotSharedWithNewService(t *testing.T) {
+	first := newMarkerInspectionService()
+	root := t.TempDir()
+	target := filepath.Join(root, "NeedsFix")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "needs-fix"), []byte("pending"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := first.InspectModForFix(context.Background(), target, "TEST"); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(first.fixInspectionSnapshot().Inspections); got != 1 {
+		t.Fatalf("expected first process state to contain one inspection, got %d", got)
+	}
+
+	second := newMarkerInspectionService()
+	if got := len(second.fixInspectionSnapshot().Inspections); got != 0 {
+		t.Fatalf("new service inherited %d in-memory inspections", got)
+	}
+
+	if err := first.ServiceShutdown(); err != nil {
+		t.Fatal(err)
+	}
+	if err := second.ServiceShutdown(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type markerFixInspector struct{}
+
+func (*markerFixInspector) CanInspect(importer string) bool { return importer == "TEST" }
+
+func (*markerFixInspector) Inspect(_ context.Context, modPath string) (*FixInspectionResult, error) {
+	_, err := os.Stat(filepath.Join(modPath, "needs-fix"))
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	return &FixInspectionResult{
+		NeedsFix:   err == nil,
+		Importer:   "TEST",
+		ToolName:   "Test Fixer",
+		Summary:    "marker requires a fix",
+		ActionTool: "marker",
+	}, nil
+}
+
+func newMarkerInspectionService() *Tools {
+	service := New()
+	service.fixInspectors = NewFixInspectorRegistry()
+	service.fixInspectors.Register(&markerFixInspector{})
+	return service
+}
+
+func waitForFixInspectionCount(t *testing.T, service *Tools, expected int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(service.fixInspectionSnapshot().Inspections) == expected {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d fix inspections; snapshot=%+v", expected, service.fixInspectionSnapshot())
+}
+
+func waitForFixInspectionPath(t *testing.T, service *Tools, expected string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		snapshot := service.fixInspectionSnapshot()
+		if len(snapshot.Inspections) == 1 && watcher.SamePath(snapshot.Inspections[0].ModPath, expected) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for fix inspection path %q; snapshot=%+v", expected, service.fixInspectionSnapshot())
+}

--- a/internal/tools/fix_inspection_state_test.go
+++ b/internal/tools/fix_inspection_state_test.go
@@ -159,6 +159,58 @@ func TestFixInspectionStateWatchesExternalChanges(t *testing.T) {
 	waitForFixInspectionCount(t, service, 0)
 }
 
+func TestInspectModForFixRunsInspectorOnce(t *testing.T) {
+	inspector := &countingFixInspector{}
+	service := New()
+	service.fixInspectors = NewFixInspectorRegistry()
+	service.fixInspectors.Register(inspector)
+	t.Cleanup(func() {
+		if err := service.ServiceShutdown(); err != nil {
+			t.Errorf("shutdown tools service: %v", err)
+		}
+	})
+
+	target := t.TempDir()
+	if _, err := service.InspectModForFix(context.Background(), target, "COUNT"); err != nil {
+		t.Fatal(err)
+	}
+	if inspector.calls != 1 {
+		t.Fatalf("inspector ran %d times, want 1", inspector.calls)
+	}
+}
+
+func TestShutdownFixInspectionsCancelsActiveRefresh(t *testing.T) {
+	inspector := &blockingFixInspector{started: make(chan struct{}), stopped: make(chan struct{})}
+	service := New()
+	service.fixInspectors = NewFixInspectorRegistry()
+	service.fixInspectors.Register(inspector)
+
+	target := t.TempDir()
+	key := fixInspectionKey(target)
+	service.fixInspections[key] = &trackedFixInspection{record: FixInspectionRecord{
+		ModPath: target,
+		Result:  FixInspectionResult{Importer: "BLOCK"},
+	}}
+	service.queueFixInspectionRefresh(key)
+	<-inspector.started
+
+	shutdown := make(chan error, 1)
+	go func() { shutdown <- service.ServiceShutdown() }()
+	select {
+	case err := <-shutdown:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("service shutdown did not cancel the active inspector")
+	}
+	select {
+	case <-inspector.stopped:
+	default:
+		t.Fatal("active inspector did not observe lifecycle cancellation")
+	}
+}
+
 func TestFixInspectionStateFollowsDisabledFolderRenames(t *testing.T) {
 	service := newMarkerInspectionService()
 	t.Cleanup(func() {
@@ -247,6 +299,35 @@ func (*markerFixInspector) Inspect(_ context.Context, modPath string) (*FixInspe
 		Summary:    "marker requires a fix",
 		ActionTool: "marker",
 	}, nil
+}
+
+type countingFixInspector struct {
+	calls int
+}
+
+func (*countingFixInspector) CanInspect(importer string) bool { return importer == "COUNT" }
+
+func (i *countingFixInspector) Inspect(_ context.Context, _ string) (*FixInspectionResult, error) {
+	i.calls++
+	return &FixInspectionResult{
+		NeedsFix: true,
+		Importer: "COUNT",
+		ToolName: "Counting Fixer",
+	}, nil
+}
+
+type blockingFixInspector struct {
+	started chan struct{}
+	stopped chan struct{}
+}
+
+func (*blockingFixInspector) CanInspect(importer string) bool { return importer == "BLOCK" }
+
+func (i *blockingFixInspector) Inspect(ctx context.Context, _ string) (*FixInspectionResult, error) {
+	close(i.started)
+	<-ctx.Done()
+	close(i.stopped)
+	return nil, ctx.Err()
 }
 
 func newMarkerInspectionService() *Tools {

--- a/internal/tools/fix_inspector.go
+++ b/internal/tools/fix_inspector.go
@@ -1,0 +1,55 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"sync"
+)
+
+type FixInspectionResult struct {
+	NeedsFix      bool     `json:"needsFix"`
+	Importer      string   `json:"importer"`
+	ToolName      string   `json:"toolName"`
+	Summary       string   `json:"summary"`
+	Details       []string `json:"details"`
+	AffectedFiles []string `json:"affectedFiles"`
+	ActionTool    string   `json:"actionTool"`
+}
+
+type FixInspector interface {
+	CanInspect(importer string) bool
+	Inspect(ctx context.Context, modPath string) (*FixInspectionResult, error)
+}
+
+type FixInspectorRegistry struct {
+	mu         sync.RWMutex
+	inspectors []FixInspector
+}
+
+func NewFixInspectorRegistry() *FixInspectorRegistry {
+	return &FixInspectorRegistry{
+		inspectors: make([]FixInspector, 0),
+	}
+}
+
+func (r *FixInspectorRegistry) Register(inspector FixInspector) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.inspectors = append(r.inspectors, inspector)
+}
+
+func (r *FixInspectorRegistry) Inspect(ctx context.Context, modPath, importer string) (*FixInspectionResult, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, inspector := range r.inspectors {
+		if inspector.CanInspect(importer) {
+			return inspector.Inspect(ctx, modPath)
+		}
+	}
+
+	return &FixInspectionResult{
+		NeedsFix: false,
+		Importer: strings.ToUpper(importer),
+	}, nil
+}

--- a/internal/tools/fix_inspector_test.go
+++ b/internal/tools/fix_inspector_test.go
@@ -1,0 +1,258 @@
+package tools
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"nahida.live/desktop/internal/db"
+	zzmiengine "nahida.live/desktop/internal/tools/zzmi"
+)
+
+func TestFixInspectorRegistry(t *testing.T) {
+	registry := NewFixInspectorRegistry()
+	ctx := context.Background()
+
+	res, err := registry.Inspect(ctx, "some/path", "ZZMI")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.NeedsFix {
+		t.Fatal("expected NeedsFix to be false for empty registry")
+	}
+
+	dummy := &dummyInspector{supported: "GIMI"}
+	registry.Register(dummy)
+
+	res, err = registry.Inspect(ctx, "some/path", "ZZMI")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.NeedsFix {
+		t.Fatal("expected NeedsFix to be false for unsupported importer")
+	}
+
+	res, err = registry.Inspect(ctx, "some/path", "GIMI")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.NeedsFix || res.ToolName != "Dummy Fixer" {
+		t.Fatalf("unexpected result from dummy inspector: %+v", res)
+	}
+}
+
+type dummyInspector struct {
+	supported string
+}
+
+func (d *dummyInspector) CanInspect(importer string) bool {
+	return importer == d.supported
+}
+
+func (d *dummyInspector) Inspect(_ context.Context, _ string) (*FixInspectionResult, error) {
+	return &FixInspectionResult{
+		NeedsFix:   true,
+		Importer:   d.supported,
+		ToolName:   "Dummy Fixer",
+		Summary:    "Dummy fix required",
+		ActionTool: "dummy",
+	}, nil
+}
+
+func TestZZMIFixInspector(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+
+	service := New()
+	service.UseClient(openToolsTestDB(t))
+	useToolsTestAppData(t, service, t.TempDir())
+	importer := "ZZMI"
+	if err := service.client.GamePaths.Insert(ctx, db.GamePathRow{
+		Game:          "ZZZ",
+		ModFolderPath: root,
+		Importer:      &importer,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	pack, err := zzmiengine.LoadEmbedded()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cleanTarget := filepath.Join(root, "CleanMod")
+	if err := os.Mkdir(cleanTarget, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cleanTarget, "mod.ini"), []byte("[TextureOverrideClean]\nhash = aabbccdd\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := service.InspectModForFix(ctx, cleanTarget, "ZZMI")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.NeedsFix {
+		t.Fatalf("expected NeedsFix: false for clean mod, got %+v", res)
+	}
+
+	janeTarget := filepath.Join(root, "JaneMod")
+	if err := os.Mkdir(janeTarget, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ini := `[TextureOverrideJane]
+hash = 33a09cfe
+vb2 = ResourceHairBlend
+
+[ResourceHairBlend]
+type = Buffer
+stride = 32
+filename = hair.buf
+`
+	if err := os.WriteFile(filepath.Join(janeTarget, "mod.ini"), []byte(ini), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bufferPath := filepath.Join(janeTarget, "hair.buf")
+	buffer := make([]byte, 32)
+	binary.LittleEndian.PutUint32(buffer[16:], 26) // Index 26 maps to 4 in Jane rules
+	if err := os.WriteFile(bufferPath, buffer, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err = service.InspectModForFix(ctx, janeTarget, "ZZMI")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.NeedsFix || !slices.Contains(res.Details, "Jane Doe blend remapping required") {
+		t.Fatalf("expected NeedsFix: true with Jane Doe remap in details, got %+v", res)
+	}
+
+	originalContent, err := os.ReadFile(bufferPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binary.LittleEndian.Uint32(originalContent[16:]) != 26 {
+		t.Fatal("inspection modified the file on disk! Dry-run invariant violated")
+	}
+
+	var outdatedHash string
+	for hash, cmds := range pack.HashCommands {
+		for _, cmd := range cmds {
+			if cmd.Op == "update_hash" {
+				outdatedHash = hash
+				break
+			}
+		}
+		if outdatedHash != "" {
+			break
+		}
+	}
+	if outdatedHash != "" {
+		hashTarget := filepath.Join(root, "OutdatedHashMod")
+		if err := os.Mkdir(hashTarget, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		hashIni := "[TextureOverrideOld]\nhash = " + outdatedHash + "\n"
+		if err := os.WriteFile(filepath.Join(hashTarget, "mod.ini"), []byte(hashIni), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		res, err = service.InspectModForFix(ctx, hashTarget, "ZZMI")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !res.NeedsFix || res.ActionTool != "hash" {
+			t.Fatalf("expected NeedsFix: true with ActionTool: 'hash', got %+v", res)
+		}
+	}
+
+	otherTarget := filepath.Join(root, "OtherMod")
+	if err := os.Mkdir(otherTarget, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	otherIni := `[TextureOverrideHair]
+hash = 12345678
+vb2 = ResourceHairBlend
+
+[ResourceHairBlend]
+type = Buffer
+stride = 32
+filename = hair.buf
+`
+	if err := os.WriteFile(filepath.Join(otherTarget, "mod.ini"), []byte(otherIni), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	otherBuf := make([]byte, 32)
+	binary.LittleEndian.PutUint32(otherBuf[16:], 18) // Dialyn remapping candidate
+	if err := os.WriteFile(filepath.Join(otherTarget, "hair.buf"), otherBuf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err = service.InspectModForFix(ctx, otherTarget, "ZZMI")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.NeedsFix {
+		t.Fatalf("expected NeedsFix: false when ini lacks Jane/Dialyn hashes, got %+v", res)
+	}
+
+	dialynTarget := filepath.Join(root, "DialynMod")
+	if err := os.Mkdir(dialynTarget, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dialynIni := `[TextureOverrideCustom]
+hash = ff36809b
+vb2 = ResourceBlend
+
+[ResourceBlend]
+type = Buffer
+stride = 32
+filename = body.buf
+`
+	if err := os.WriteFile(filepath.Join(dialynTarget, "mod.ini"), []byte(dialynIni), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dialynBuf := make([]byte, 32)
+	binary.LittleEndian.PutUint32(dialynBuf[16:], 18)
+	if err := os.WriteFile(filepath.Join(dialynTarget, "body.buf"), dialynBuf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err = service.InspectModForFix(ctx, dialynTarget, "ZZMI")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.NeedsFix || !slices.Contains(res.Details, "Dialyn blend remapping required") {
+		t.Fatalf("expected NeedsFix: true with Dialyn remap in details, got %+v", res)
+	}
+
+	legacyJaneTarget := filepath.Join(root, "LegacyJaneMod")
+	if err := os.Mkdir(legacyJaneTarget, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacyJaneIni := `[TextureOverrideHair]
+hash = e7a3b7dc
+vb2 = ResourceHairBlend
+
+[ResourceHairBlend]
+type = Buffer
+stride = 32
+filename = hair.buf
+`
+	if err := os.WriteFile(filepath.Join(legacyJaneTarget, "mod.ini"), []byte(legacyJaneIni), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	legacyBuf := make([]byte, 32)
+	binary.LittleEndian.PutUint32(legacyBuf[16:], 26)
+	if err := os.WriteFile(filepath.Join(legacyJaneTarget, "hair.buf"), legacyBuf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err = service.InspectModForFix(ctx, legacyJaneTarget, "ZZMI")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.NeedsFix || !slices.Contains(res.Details, "Jane Doe blend remapping required") {
+		t.Fatalf("expected NeedsFix: true with Jane remap for legacy hash, got %+v", res)
+	}
+}

--- a/internal/tools/fix_inspector_test.go
+++ b/internal/tools/fix_inspector_test.go
@@ -65,10 +65,17 @@ func (d *dummyInspector) Inspect(_ context.Context, _ string) (*FixInspectionRes
 func TestZZMIFixInspector(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
+	appDataDir := t.TempDir()
+	client := openToolsTestDB(t)
 
 	service := New()
-	service.UseClient(openToolsTestDB(t))
-	useToolsTestAppData(t, service, t.TempDir())
+	t.Cleanup(func() {
+		if err := service.ServiceShutdown(); err != nil {
+			t.Errorf("shutdown tools service: %v", err)
+		}
+	})
+	service.UseClient(client)
+	useToolsTestAppData(t, service, appDataDir)
 	importer := "ZZMI"
 	if err := service.client.GamePaths.Insert(ctx, db.GamePathRow{
 		Game:          "ZZZ",

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -18,6 +18,10 @@ type BisectSettings interface {
 	GetDisabledPrefixStyle(context.Context) (string, error)
 }
 
+type FixInspectionSettings interface {
+	GetAutoInspectFix(context.Context) (bool, error)
+}
+
 type ModDisabler interface {
 	Disable(context.Context, string) (string, error)
 	Enable(context.Context, string) (string, error)
@@ -109,6 +113,14 @@ type Tools struct {
 	modelViewerMu       sync.Mutex
 	modelViewerSessions map[string]*modelViewerSession
 	persist             *persistEngine
+
+	fixInspectors         *FixInspectorRegistry
+	fixInspectionRunMu    sync.Mutex
+	fixInspectionMu       sync.Mutex
+	fixInspections        map[string]*trackedFixInspection
+	fixInspectionRevision uint64
+	fixInspectionClosed   bool
+	fixInspectionWG       sync.WaitGroup
 }
 
 type toolRun struct {
@@ -136,7 +148,10 @@ func NewWithOptions(opts Options) *Tools {
 		bodyShapeSessions:   make(map[string]*bodyShapeSession),
 		modelViewerSessions: make(map[string]*modelViewerSession),
 		persist:             newPersistEngine(),
+		fixInspectors:       NewFixInspectorRegistry(),
+		fixInspections:      make(map[string]*trackedFixInspection),
 	}
+	t.fixInspectors.Register(NewZZMIFixInspector(t))
 	t.persist.emit = func(logs []string) { t.emitEvent("setting:xxmi:persistLogs", logs) }
 	t.persist.infoFn = func(message string) {
 		if t.log != nil {
@@ -241,5 +256,5 @@ func (t *Tools) ServiceShutdown() error {
 			err = errors.New("timed out waiting for tools process to stop")
 		}
 	}
-	return errors.Join(err, t.shutdownBisect(), t.stopWuwaAutoUpdateCheck(), t.shutdownTouchProfiles(), t.shutdownBodyShape(), t.shutdownModelViewer(), t.shutdownPersistWatcher())
+	return errors.Join(err, t.shutdownFixInspections(), t.shutdownBisect(), t.stopWuwaAutoUpdateCheck(), t.shutdownTouchProfiles(), t.shutdownBodyShape(), t.shutdownModelViewer(), t.shutdownPersistWatcher())
 }

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -120,6 +120,8 @@ type Tools struct {
 	fixInspections        map[string]*trackedFixInspection
 	fixInspectionRevision uint64
 	fixInspectionClosed   bool
+	fixInspectionCtx      context.Context
+	fixInspectionCancel   context.CancelFunc
 	fixInspectionWG       sync.WaitGroup
 }
 
@@ -138,6 +140,7 @@ func NewWithOptions(opts Options) *Tools {
 	if opts.Protocol == nil {
 		opts.Protocol = infra.NewProtocol()
 	}
+	fixInspectionCtx, fixInspectionCancel := context.WithCancel(context.Background())
 	t := &Tools{
 		log: opts.Log, emit: opts.EventEmit, notify: opts.Notify, settings: opts.Settings, xxmi: opts.XXMI,
 		fs: opts.FS, http: opts.HTTP, download: opts.Download, archive: opts.Archive, protocol: opts.Protocol, githubRate: opts.GitHubRate, mod: opts.Mod,
@@ -150,6 +153,8 @@ func NewWithOptions(opts Options) *Tools {
 		persist:             newPersistEngine(),
 		fixInspectors:       NewFixInspectorRegistry(),
 		fixInspections:      make(map[string]*trackedFixInspection),
+		fixInspectionCtx:    fixInspectionCtx,
+		fixInspectionCancel: fixInspectionCancel,
 	}
 	t.fixInspectors.Register(NewZZMIFixInspector(t))
 	t.persist.emit = func(logs []string) { t.emitEvent("setting:xxmi:persistLogs", logs) }

--- a/internal/tools/zzmi_inspector.go
+++ b/internal/tools/zzmi_inspector.go
@@ -1,0 +1,233 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	zzmiengine "nahida.live/desktop/internal/tools/zzmi"
+)
+
+var inspectorHashPattern = regexp.MustCompile(`(?i)^\s*hash\s*=\s*([a-f0-9]{8})\b`)
+
+type ZZMIFixInspector struct {
+	tools *Tools
+}
+
+func NewZZMIFixInspector(tools *Tools) *ZZMIFixInspector {
+	return &ZZMIFixInspector{tools: tools}
+}
+
+func (z *ZZMIFixInspector) CanInspect(importer string) bool {
+	return strings.EqualFold(importer, "ZZMI")
+}
+
+func (z *ZZMIFixInspector) Inspect(ctx context.Context, modPath string) (*FixInspectionResult, error) {
+	var target string
+	if z.tools.client != nil {
+		resolved, _, err := z.tools.zzmiRequireTarget(ctx, modPath)
+		if err != nil {
+			return nil, err
+		}
+		target = resolved
+	} else {
+		info, err := os.Stat(modPath)
+		if err != nil {
+			return nil, err
+		}
+		if !info.IsDir() {
+			return &FixInspectionResult{
+				NeedsFix: false,
+				Importer: "ZZMI",
+				ToolName: "ZZMI Mod Fixer",
+			}, nil
+		}
+		target = modPath
+	}
+
+	pack, _, err := z.tools.zzmiLoadActivePack()
+	if err != nil {
+		return nil, err
+	}
+
+	janeHashes, dialynHashes := collectRemapperHashes(pack)
+	hasJane, hasDialyn, err := z.checkRemapperHashes(ctx, target, janeHashes, dialynHashes)
+	if err != nil {
+		return nil, err
+	}
+
+	var actions []string
+	var summaries []string
+	var allAffected []string
+
+	hashResult, err := zzmiengine.Run(ctx, target, zzmiengine.ToolHash, pack, nil)
+	if err != nil {
+		return nil, fmt.Errorf("inspect ZZMI hash fixes: %w", err)
+	}
+	if len(hashResult.Changes) > 0 {
+		actions = append(actions, zzmiengine.ToolHash)
+		summaries = append(summaries, fmt.Sprintf("%d outdated hash file(s)", len(hashResult.Changes)))
+		for _, c := range hashResult.Changes {
+			rel, relErr := filepath.Rel(target, c.Path)
+			if relErr != nil {
+				rel = filepath.Base(c.Path)
+			}
+			allAffected = append(allAffected, rel)
+		}
+	}
+
+	if hasJane {
+		janeResult, err := zzmiengine.Run(ctx, target, zzmiengine.ToolJane, pack, nil)
+		if err != nil {
+			return nil, fmt.Errorf("inspect ZZMI Jane remapping: %w", err)
+		}
+		if len(janeResult.Changes) > 0 {
+			actions = append(actions, zzmiengine.ToolJane)
+			summaries = append(summaries, "Jane Doe blend remapping required")
+			for _, c := range janeResult.Changes {
+				rel, relErr := filepath.Rel(target, c.Path)
+				if relErr != nil {
+					rel = filepath.Base(c.Path)
+				}
+				allAffected = append(allAffected, rel)
+			}
+		}
+	}
+
+	if hasDialyn {
+		dialynResult, err := zzmiengine.Run(ctx, target, zzmiengine.ToolDialyn, pack, nil)
+		if err != nil {
+			return nil, fmt.Errorf("inspect ZZMI Dialyn remapping: %w", err)
+		}
+		if len(dialynResult.Changes) > 0 {
+			actions = append(actions, zzmiengine.ToolDialyn)
+			summaries = append(summaries, "Dialyn blend remapping required")
+			for _, c := range dialynResult.Changes {
+				rel, relErr := filepath.Rel(target, c.Path)
+				if relErr != nil {
+					rel = filepath.Base(c.Path)
+				}
+				allAffected = append(allAffected, rel)
+			}
+		}
+	}
+
+	if len(actions) > 0 {
+		return &FixInspectionResult{
+			NeedsFix:      true,
+			Importer:      "ZZMI",
+			ToolName:      "ZZMI Mod Fixer",
+			Summary:       strings.Join(summaries, ", "),
+			Details:       summaries,
+			AffectedFiles: allAffected,
+			ActionTool:    actions[0],
+		}, nil
+	}
+
+	return &FixInspectionResult{
+		NeedsFix: false,
+		Importer: "ZZMI",
+		ToolName: "ZZMI Mod Fixer",
+	}, nil
+}
+
+func collectRemapperHashes(pack *zzmiengine.RulePack) (janeHashes, dialynHashes map[string]bool) {
+	janeHashes = make(map[string]bool)
+	dialynHashes = make(map[string]bool)
+
+	for pos, blend := range pack.Jane.PositionToBlend {
+		janeHashes[strings.ToLower(pos)] = true
+		janeHashes[strings.ToLower(blend)] = true
+	}
+	for _, hash := range pack.Jane.ValidHashes {
+		janeHashes[strings.ToLower(hash)] = true
+	}
+
+	for pos, blend := range pack.Dialyn.PositionToBlend {
+		dialynHashes[strings.ToLower(pos)] = true
+		dialynHashes[strings.ToLower(blend)] = true
+	}
+	for _, hash := range pack.Dialyn.ValidHashes {
+		dialynHashes[strings.ToLower(hash)] = true
+	}
+
+	// Follow update_hash chains so indirect legacy hashes inherit remapper ownership.
+	for {
+		added := false
+		for oldHash, commands := range pack.HashCommands {
+			lowerOld := strings.ToLower(oldHash)
+			for _, cmd := range commands {
+				if cmd.Op == "update_hash" && len(cmd.Args) > 0 {
+					if targetHash, ok := cmd.Args[0].(string); ok {
+						lowerTarget := strings.ToLower(targetHash)
+						if janeHashes[lowerTarget] && !janeHashes[lowerOld] {
+							janeHashes[lowerOld] = true
+							added = true
+						}
+						if dialynHashes[lowerTarget] && !dialynHashes[lowerOld] {
+							dialynHashes[lowerOld] = true
+							added = true
+						}
+					}
+				}
+			}
+		}
+		if !added {
+			break
+		}
+	}
+
+	return janeHashes, dialynHashes
+}
+
+func (z *ZZMIFixInspector) checkRemapperHashes(ctx context.Context, target string, janeHashes, dialynHashes map[string]bool) (hasJane bool, hasDialyn bool, err error) {
+	err = filepath.WalkDir(target, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if path != target && entry.Type()&os.ModeSymlink != 0 {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		upper := strings.ToUpper(entry.Name())
+		if path != target && entry.IsDir() && (strings.HasPrefix(upper, "DISABLED") || strings.HasPrefix(upper, "DESKTOP")) {
+			return filepath.SkipDir
+		}
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".ini") || strings.HasPrefix(upper, "DISABLED") || strings.HasPrefix(upper, "DESKTOP") {
+			return nil
+		}
+
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+
+		lines := strings.Split(string(data), "\n")
+		for _, line := range lines {
+			match := inspectorHashPattern.FindStringSubmatch(line)
+			if len(match) == 2 {
+				hash := strings.ToLower(match[1])
+				if janeHashes[hash] {
+					hasJane = true
+				}
+				if dialynHashes[hash] {
+					hasDialyn = true
+				}
+				if hasJane && hasDialyn {
+					return filepath.SkipAll
+				}
+			}
+		}
+		return nil
+	})
+	return hasJane, hasDialyn, err
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches mod download/import paths and new filesystem watchers plus ZZMI inspection logic; UI changes are additive but drive navigation into the fixer from global chrome.
> 
> **Overview**
> Adds **background mod fix inspection** when mods are downloaded, imported, extracted, or copied, gated by a new **`mod.autoInspectFix`** setting (default on). The tools service keeps in-memory inspection state, watches folders for changes, emits **`tools:fix-inspections`**, and exposes **`RefreshFixInspections`** for the UI after deletes.
> 
> The title bar shows **warning badges** for mods that need fixes, with a **popover** (summary, dismiss, **Open Fixer**) instead of relying only on transient toasts. Choosing the fix action sets a **pending fixer request**, switches to the matching game, and opens the mod fixer with the suggested ZZMI tab when applicable.
> 
> **Tests** add `@testing-library/react` and `jsdom` for hook coverage; backend tests cover inspection queueing, watchers, and ZZMI dry-run inspection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 532762dbaa97a1c69dd19e40f99df8acf3005df2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic mod fix inspections when mods are downloaded, imported, moved, or changed.
  * Added title-bar notifications showing mods that need fixes, with details, dismissal, and direct actions in the Fixer.
  * Added support for automatically opening the appropriate game, mod, and repair action.
  * Added a setting to enable or disable automatic fix inspections.
  * Added localized notifications and controls in English, Japanese, Korean, and Chinese.
* **Bug Fixes**
  * Fix inspection results now refresh after mod deletion and when the application regains focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->