### PR TITLE
fix(tools): persist ZZMI fixer release checks

### DIFF
--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -91,10 +91,6 @@ type Tools struct {
 	wuwaAutoCancel context.CancelFunc
 	wuwaAutoDone   chan struct{}
 
-	zzmiMu      sync.Mutex
-	zzmiLatest  *zzmiLatestRelease
-	zzmiChecked time.Time
-
 	textureRuntimeMu sync.Mutex
 	textureEventMu   sync.Mutex
 	textureMu        sync.Mutex
@@ -199,6 +195,22 @@ func (t *Tools) requireClient() (*db.Client, error) {
 		return nil, errors.New("tools service is not bound to a database")
 	}
 	return t.client, nil
+}
+
+func (t *Tools) getAppState(ctx context.Context, key string) (*string, error) {
+	client, err := t.requireClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.AppState.GetValue(ctx, key)
+}
+
+func (t *Tools) setAppState(ctx context.Context, key, value string) error {
+	client, err := t.requireClient()
+	if err != nil {
+		return err
+	}
+	return client.AppState.Upsert(ctx, key, value, time.Now().UTC().Format(time.RFC3339Nano))
 }
 
 func (t *Tools) emitEvent(name string, data any) {

--- a/internal/tools/wuwa_mod_fixer.go
+++ b/internal/tools/wuwa_mod_fixer.go
@@ -232,10 +232,10 @@ func (t *Tools) WuwaFixerInstallOrUpdate(ctx context.Context) (WuwaFixerStatus, 
 	if err := t.wuwaCleanupOldBinaries(finalPath); err != nil {
 		return WuwaFixerStatus{}, err
 	}
-	if err := t.wuwaSetAppState(ctx, wuwaInstalledVersionKey, release.Version); err != nil {
+	if err := t.setAppState(ctx, wuwaInstalledVersionKey, release.Version); err != nil {
 		return WuwaFixerStatus{}, err
 	}
-	if err := t.wuwaSetAppState(ctx, wuwaBinaryPathKey, finalPath); err != nil {
+	if err := t.setAppState(ctx, wuwaBinaryPathKey, finalPath); err != nil {
 		return WuwaFixerStatus{}, err
 	}
 	wwmi := "WWMI"
@@ -474,7 +474,7 @@ func (t *Tools) wuwaRefreshLatestRelease(ctx context.Context, force bool) (wuwaR
 	if err != nil {
 		return wuwaRefreshResult{}, err
 	}
-	lastCheck, err := t.wuwaGetAppState(ctx, wuwaLastCheckKey)
+	lastCheck, err := t.getAppState(ctx, wuwaLastCheckKey)
 	if err != nil {
 		return wuwaRefreshResult{}, err
 	}
@@ -513,10 +513,10 @@ func (t *Tools) wuwaRefreshLatestRelease(ctx context.Context, force bool) (wuwaR
 	now := time.Now().UTC()
 	latest.CheckedAt = now.Format(time.RFC3339Nano)
 	raw, _ := json.Marshal(latest)
-	if err := t.wuwaSetAppState(ctx, wuwaLastCheckKey, now.Format(time.RFC3339Nano)); err != nil {
+	if err := t.setAppState(ctx, wuwaLastCheckKey, now.Format(time.RFC3339Nano)); err != nil {
 		return wuwaRefreshResult{}, err
 	}
-	if err := t.wuwaSetAppState(ctx, wuwaLatestReleaseKey, string(raw)); err != nil {
+	if err := t.setAppState(ctx, wuwaLatestReleaseKey, string(raw)); err != nil {
 		return wuwaRefreshResult{}, err
 	}
 	next := now.Add(wuwaCheckCooldown).Format(time.RFC3339Nano)
@@ -566,11 +566,11 @@ func (t *Tools) wuwaEnsureLatestConfig(ctx context.Context) (string, error) {
 }
 
 func (t *Tools) wuwaGetInstalledBinaryInfo(ctx context.Context) (wuwaInstalledInfo, error) {
-	pathValue, err := t.wuwaGetAppState(ctx, wuwaBinaryPathKey)
+	pathValue, err := t.getAppState(ctx, wuwaBinaryPathKey)
 	if err != nil {
 		return wuwaInstalledInfo{}, err
 	}
-	version, err := t.wuwaGetAppState(ctx, wuwaInstalledVersionKey)
+	version, err := t.getAppState(ctx, wuwaInstalledVersionKey)
 	if err != nil {
 		return wuwaInstalledInfo{}, err
 	}
@@ -610,11 +610,11 @@ func (t *Tools) wuwaGetInstalledBinaryInfo(ctx context.Context) (wuwaInstalledIn
 	}
 	resolved := filepath.Join(toolDir, match)
 	version = extractWuwaVersion(match)
-	if err := t.wuwaSetAppState(ctx, wuwaBinaryPathKey, resolved); err != nil {
+	if err := t.setAppState(ctx, wuwaBinaryPathKey, resolved); err != nil {
 		return wuwaInstalledInfo{}, err
 	}
 	if version != nil {
-		if err := t.wuwaSetAppState(ctx, wuwaInstalledVersionKey, *version); err != nil {
+		if err := t.setAppState(ctx, wuwaInstalledVersionKey, *version); err != nil {
 			return wuwaInstalledInfo{}, err
 		}
 	}
@@ -679,24 +679,8 @@ func (t *Tools) wuwaSupportedImporter(importer *string) bool {
 	return importer == nil || strings.EqualFold(*importer, "WWMI")
 }
 
-func (t *Tools) wuwaGetAppState(ctx context.Context, key string) (*string, error) {
-	client, err := t.requireClient()
-	if err != nil {
-		return nil, err
-	}
-	return client.AppState.GetValue(ctx, key)
-}
-
-func (t *Tools) wuwaSetAppState(ctx context.Context, key, value string) error {
-	client, err := t.requireClient()
-	if err != nil {
-		return err
-	}
-	return client.AppState.Upsert(ctx, key, value, time.Now().UTC().Format(time.RFC3339Nano))
-}
-
 func (t *Tools) wuwaGetCachedLatestRelease(ctx context.Context) (*wuwaLatestReleaseCache, error) {
-	raw, err := t.wuwaGetAppState(ctx, wuwaLatestReleaseKey)
+	raw, err := t.getAppState(ctx, wuwaLatestReleaseKey)
 	if err != nil || raw == nil {
 		return nil, err
 	}
@@ -709,7 +693,7 @@ func (t *Tools) wuwaGetCachedLatestRelease(ctx context.Context) (*wuwaLatestRele
 }
 
 func (t *Tools) wuwaGetRateState(ctx context.Context) (*GitHubRateState, error) {
-	raw, err := t.wuwaGetAppState(ctx, githubCoreRateKey)
+	raw, err := t.getAppState(ctx, githubCoreRateKey)
 	if err != nil || raw == nil {
 		return nil, err
 	}
@@ -742,7 +726,7 @@ func (t *Tools) wuwaRefreshRateState(ctx context.Context) *GitHubRateState {
 		payload.Rate.Resource = "core"
 	}
 	raw, _ := json.Marshal(payload.Rate)
-	_ = t.wuwaSetAppState(ctx, githubCoreRateKey, string(raw))
+	_ = t.setAppState(ctx, githubCoreRateKey, string(raw))
 	return payload.Rate
 }
 
@@ -768,7 +752,7 @@ func (t *Tools) wuwaCaptureRate(ctx context.Context, header http.Header) (*GitHu
 	}
 	state := &GitHubRateState{Limit: limit, Remaining: remaining, Reset: reset, Used: used, Resource: resource, UpdatedAt: time.Now().UTC().Format(time.RFC3339Nano)}
 	raw, _ := json.Marshal(state)
-	if err := t.wuwaSetAppState(ctx, githubCoreRateKey, string(raw)); err != nil {
+	if err := t.setAppState(ctx, githubCoreRateKey, string(raw)); err != nil {
 		return nil, err
 	}
 	return state, nil

--- a/internal/tools/zzmi_mod_fixer.go
+++ b/internal/tools/zzmi_mod_fixer.go
@@ -32,7 +32,8 @@ const (
 	zzmiRulesCacheDirName = "rules"
 	zzmiRulesActiveName   = "active-rules"
 	zzmiMaxDownload       = 64 << 20
-	zzmiCheckCooldown     = 15 * time.Minute
+	zzmiCheckCooldown     = 1 * time.Hour
+	zzmiLatestReleaseKey  = "mod_tools:zzmi-mod-fixer:latest-release"
 )
 
 type ZZMIFixerRuleStatus struct {
@@ -119,11 +120,12 @@ type ZZMIFixerDeleteBackupInput struct {
 }
 
 type zzmiLatestRelease struct {
-	Tag       string
-	Commit    string
-	Zipball   string
-	Published string
-	Blobs     map[string]string
+	Tag       string            `json:"tag"`
+	Commit    string            `json:"commit"`
+	Zipball   string            `json:"zipball"`
+	Published string            `json:"published"`
+	Blobs     map[string]string `json:"blobs"`
+	CheckedAt string            `json:"checkedAt"`
 }
 
 type zzmiReleaseResponse struct {
@@ -513,14 +515,54 @@ func validSHA256Hex(value string) bool {
 	return validHex(value, sha256.Size*2)
 }
 
-func (t *Tools) zzmiCheckLatest(ctx context.Context, force bool) (*zzmiLatestRelease, bool, error) {
-	t.zzmiMu.Lock()
-	if !force && t.zzmiLatest != nil && time.Since(t.zzmiChecked) < zzmiCheckCooldown {
-		latest := t.zzmiLatest
-		t.zzmiMu.Unlock()
-		return latest, false, nil
+func (t *Tools) zzmiGetCachedLatestRelease(ctx context.Context) *zzmiLatestRelease {
+	raw, err := t.getAppState(ctx, zzmiLatestReleaseKey)
+	if err != nil || raw == nil {
+		return nil
 	}
-	t.zzmiMu.Unlock()
+	var release zzmiLatestRelease
+	if json.Unmarshal([]byte(*raw), &release) != nil || release.Tag == "" || release.Commit == "" || release.Zipball == "" {
+		return nil
+	}
+	return &release
+}
+
+func (t *Tools) zzmiRememberLatest(ctx context.Context, latest *zzmiLatestRelease) error {
+	stored := *latest
+	stored.CheckedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	raw, err := json.Marshal(stored)
+	if err != nil {
+		return err
+	}
+	if err := t.setAppState(ctx, zzmiLatestReleaseKey, string(raw)); err != nil {
+		return err
+	}
+	*latest = stored
+	return nil
+}
+
+func (t *Tools) zzmiCheckLatest(ctx context.Context, force bool) (*zzmiLatestRelease, bool, error) {
+	cached := t.zzmiGetCachedLatestRelease(ctx)
+	if !force && cached != nil && time.Since(parseRFC3339(cached.CheckedAt)) < zzmiCheckCooldown {
+		return cached, false, nil
+	}
+	latest, checked, err := t.zzmiFetchLatest(ctx)
+	if err != nil {
+		if !force && cached != nil {
+			if persistErr := t.zzmiRememberLatest(ctx, cached); persistErr != nil {
+				t.logError(persistErr, "ZZMIFixerCache")
+			}
+			return cached, false, nil
+		}
+		return nil, checked, err
+	}
+	if err := t.zzmiRememberLatest(ctx, latest); err != nil {
+		return nil, true, err
+	}
+	return latest, true, nil
+}
+
+func (t *Tools) zzmiFetchLatest(ctx context.Context) (*zzmiLatestRelease, bool, error) {
 	if t.githubRate != nil {
 		allowed, _, err := t.githubRate.CanUseGitHubAPI(ctx, infra.GitHubRateCheckOptions{RefreshIfMissing: true})
 		if err != nil {
@@ -572,12 +614,7 @@ func (t *Tools) zzmiCheckLatest(ctx context.Context, force bool) (*zzmiLatestRel
 			blobs[entry.Path] = entry.SHA
 		}
 	}
-	latest := &zzmiLatestRelease{Tag: release.TagName, Commit: commit, Zipball: release.ZipballURL, Published: release.PublishedAt, Blobs: blobs}
-	t.zzmiMu.Lock()
-	t.zzmiLatest = latest
-	t.zzmiChecked = time.Now()
-	t.zzmiMu.Unlock()
-	return latest, true, nil
+	return &zzmiLatestRelease{Tag: release.TagName, Commit: commit, Zipball: release.ZipballURL, Published: release.PublishedAt, Blobs: blobs}, true, nil
 }
 
 func (t *Tools) zzmiFetchJSON(ctx context.Context, rawURL string, target any) error {

--- a/internal/tools/zzmi_mod_fixer.go
+++ b/internal/tools/zzmi_mod_fixer.go
@@ -541,9 +541,17 @@ func (t *Tools) zzmiRememberLatest(ctx context.Context, latest *zzmiLatestReleas
 	return nil
 }
 
+func zzmiCacheFresh(checkedAt string, now time.Time) bool {
+	parsed, err := time.Parse(time.RFC3339Nano, checkedAt)
+	if err != nil || parsed.After(now) {
+		return false
+	}
+	return now.Sub(parsed) < zzmiCheckCooldown
+}
+
 func (t *Tools) zzmiCheckLatest(ctx context.Context, force bool) (*zzmiLatestRelease, bool, error) {
 	cached := t.zzmiGetCachedLatestRelease(ctx)
-	if !force && cached != nil && time.Since(parseRFC3339(cached.CheckedAt)) < zzmiCheckCooldown {
+	if !force && cached != nil && zzmiCacheFresh(cached.CheckedAt, time.Now().UTC()) {
 		return cached, false, nil
 	}
 	latest, checked, err := t.zzmiFetchLatest(ctx)

--- a/internal/tools/zzmi_mod_fixer_test.go
+++ b/internal/tools/zzmi_mod_fixer_test.go
@@ -407,6 +407,40 @@ func TestZZMIFixerPrepareFallsBackAndRefreshesCooldown(t *testing.T) {
 	}
 }
 
+func TestZZMIFixerPrepareTreatsInvalidOrFutureCheckedAtAsMiss(t *testing.T) {
+	cases := []struct {
+		name      string
+		checkedAt string
+	}{
+		{name: "invalid", checkedAt: "not-a-timestamp"},
+		{name: "future", checkedAt: time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano)},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			client := openToolsTestDB(t)
+			root := insertZZMITestTarget(t, client)
+			cached := sampleZZMILatestRelease(time.Time{})
+			cached.CheckedAt = test.checkedAt
+			seedZZMILatestRelease(t, client, cached)
+			remote := zzmiLatestRelease{
+				Tag:     "v9.9.9",
+				Commit:  "abcdef0123456789abcdef0123456789abcdef01",
+				Zipball: "https://api.github.com/repos/Vonksdesu/ZZZ-Mod-Fixer/zipball/v9.9.9",
+			}
+			service := newZZMIFixerTestService(t, client, zzmiRemoteReleaseHandler(remote.Tag, remote.Commit, nil))
+
+			result, err := service.ZZMIFixerPrepare(ctx, root, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !result.Rules.CheckedRemotely || result.Rules.LatestTag == nil || *result.Rules.LatestTag != remote.Tag {
+				t.Fatalf("%s timestamp did not refresh: %+v", test.name, result.Rules)
+			}
+		})
+	}
+}
+
 func TestZZMIFixerPrepareTreatsBrokenCacheAsMiss(t *testing.T) {
 	ctx := context.Background()
 	client := openToolsTestDB(t)

--- a/internal/tools/zzmi_mod_fixer_test.go
+++ b/internal/tools/zzmi_mod_fixer_test.go
@@ -3,12 +3,18 @@ package tools
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"nahida.live/desktop/internal/db"
+	"nahida.live/desktop/internal/infra"
 	zzmiengine "nahida.live/desktop/internal/tools/zzmi"
 )
 
@@ -229,5 +235,284 @@ func TestZZMIInactivePackDoesNotReplaceActivePack(t *testing.T) {
 	loaded, source, err := service.zzmiLoadActivePack()
 	if err != nil || source != "cached" || loaded.GeneratedAt != pack.GeneratedAt {
 		t.Fatalf("incomplete promotion replaced the active pack: source=%s pack=%+v err=%v", source, loaded, err)
+	}
+}
+
+func TestZZMIFixerPrepareUsesAppStateCache(t *testing.T) {
+	ctx := context.Background()
+	client := openToolsTestDB(t)
+	root := insertZZMITestTarget(t, client)
+	cached := sampleZZMILatestRelease(time.Now().UTC())
+	seedZZMILatestRelease(t, client, cached)
+
+	hits := 0
+	service := newZZMIFixerTestService(t, client, func(*http.Request) (int, string, error) {
+		hits++
+		return 0, "", fmt.Errorf("unexpected GitHub request")
+	})
+
+	result, err := service.ZZMIFixerPrepare(ctx, root, false)
+	if err != nil {
+		t.Fatalf("ZZMIFixerPrepare failed: %v", err)
+	}
+	if hits != 0 {
+		t.Fatalf("fresh cache still hit GitHub %d time(s)", hits)
+	}
+	if result.Rules.CheckedRemotely {
+		t.Fatal("expected CheckedRemotely to be false when app_state cache is valid")
+	}
+	if result.Rules.LatestTag == nil || *result.Rules.LatestTag != cached.Tag {
+		t.Fatalf("unexpected LatestTag: %v", result.Rules.LatestTag)
+	}
+	if result.Rules.LatestCommit == nil || *result.Rules.LatestCommit != cached.Commit {
+		t.Fatalf("unexpected LatestCommit: %v", result.Rules.LatestCommit)
+	}
+
+	service2 := newZZMIFixerTestService(t, client, func(*http.Request) (int, string, error) {
+		hits++
+		return 0, "", fmt.Errorf("unexpected GitHub request")
+	})
+	result2, err := service2.ZZMIFixerPrepare(ctx, root, false)
+	if err != nil {
+		t.Fatalf("ZZMIFixerPrepare on fresh service failed: %v", err)
+	}
+	if hits != 0 {
+		t.Fatalf("second service hit GitHub %d time(s)", hits)
+	}
+	if result2.Rules.CheckedRemotely || result2.Rules.LatestTag == nil || *result2.Rules.LatestTag != cached.Tag {
+		t.Fatalf("fresh service did not reuse app_state cache: %+v", result2.Rules)
+	}
+}
+
+func TestZZMIFixerPreparePersistsRemoteRelease(t *testing.T) {
+	ctx := context.Background()
+	client := openToolsTestDB(t)
+	root := insertZZMITestTarget(t, client)
+	remote := sampleZZMILatestRelease(time.Time{})
+	service := newZZMIFixerTestService(t, client, zzmiRemoteReleaseHandler(remote.Tag, remote.Commit, nil))
+
+	result, err := service.ZZMIFixerPrepare(ctx, root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Rules.CheckedRemotely || result.Rules.LatestTag == nil || *result.Rules.LatestTag != remote.Tag {
+		t.Fatalf("unexpected remote prepare: %+v", result.Rules)
+	}
+
+	stored := readZZMILatestRelease(t, client)
+	if stored.Tag != remote.Tag || stored.Commit != remote.Commit || stored.Zipball != remote.Zipball || stored.CheckedAt == "" {
+		t.Fatalf("persisted release = %#v", stored)
+	}
+
+	hits := 0
+	service2 := newZZMIFixerTestService(t, client, func(*http.Request) (int, string, error) {
+		hits++
+		return 0, "", fmt.Errorf("unexpected GitHub request")
+	})
+	result2, err := service2.ZZMIFixerPrepare(ctx, root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hits != 0 || result2.Rules.CheckedRemotely || result2.Rules.LatestTag == nil || *result2.Rules.LatestTag != remote.Tag {
+		t.Fatalf("persisted cache was not reused: hits=%d rules=%+v", hits, result2.Rules)
+	}
+}
+
+func TestZZMIFixerPrepareExpiredCacheHitsRemote(t *testing.T) {
+	ctx := context.Background()
+	client := openToolsTestDB(t)
+	root := insertZZMITestTarget(t, client)
+	seedZZMILatestRelease(t, client, sampleZZMILatestRelease(time.Now().UTC().Add(-2*time.Hour)))
+	remote := zzmiLatestRelease{
+		Tag:     "v9.9.9",
+		Commit:  "abcdef0123456789abcdef0123456789abcdef01",
+		Zipball: "https://api.github.com/repos/Vonksdesu/ZZZ-Mod-Fixer/zipball/v9.9.9",
+	}
+	service := newZZMIFixerTestService(t, client, zzmiRemoteReleaseHandler(remote.Tag, remote.Commit, nil))
+
+	result, err := service.ZZMIFixerPrepare(ctx, root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Rules.CheckedRemotely || result.Rules.LatestTag == nil || *result.Rules.LatestTag != remote.Tag {
+		t.Fatalf("expired cache did not refresh: %+v", result.Rules)
+	}
+}
+
+func TestZZMIFixerPrepareForceRefreshBypassesCache(t *testing.T) {
+	ctx := context.Background()
+	client := openToolsTestDB(t)
+	root := insertZZMITestTarget(t, client)
+	seedZZMILatestRelease(t, client, sampleZZMILatestRelease(time.Now().UTC()))
+	remote := zzmiLatestRelease{
+		Tag:     "v2.0.0",
+		Commit:  "fedcba9876543210fedcba9876543210fedcba98",
+		Zipball: "https://api.github.com/repos/Vonksdesu/ZZZ-Mod-Fixer/zipball/v2.0.0",
+	}
+	hits := 0
+	service := newZZMIFixerTestService(t, client, zzmiRemoteReleaseHandler(remote.Tag, remote.Commit, func() { hits++ }))
+
+	result, err := service.ZZMIFixerPrepare(ctx, root, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hits == 0 {
+		t.Fatal("force refresh did not contact GitHub")
+	}
+	if !result.Rules.CheckedRemotely || result.Rules.LatestTag == nil || *result.Rules.LatestTag != remote.Tag {
+		t.Fatalf("force refresh did not use remote release: %+v", result.Rules)
+	}
+}
+
+func TestZZMIFixerPrepareFallsBackAndRefreshesCooldown(t *testing.T) {
+	ctx := context.Background()
+	client := openToolsTestDB(t)
+	root := insertZZMITestTarget(t, client)
+	staleCheckedAt := time.Now().UTC().Add(-2 * time.Hour)
+	cached := sampleZZMILatestRelease(staleCheckedAt)
+	seedZZMILatestRelease(t, client, cached)
+
+	hits := 0
+	service := newZZMIFixerTestService(t, client, func(*http.Request) (int, string, error) {
+		hits++
+		return http.StatusServiceUnavailable, "unavailable", nil
+	})
+
+	result, err := service.ZZMIFixerPrepare(ctx, root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hits == 0 {
+		t.Fatal("expired cache did not attempt a remote check")
+	}
+	if result.Rules.CheckedRemotely || result.Rules.IncompatibilityReason != nil {
+		t.Fatalf("fallback should stay silent: %+v", result.Rules)
+	}
+	if result.Rules.LatestTag == nil || *result.Rules.LatestTag != cached.Tag {
+		t.Fatalf("fallback lost cached tag: %v", result.Rules.LatestTag)
+	}
+
+	stored := readZZMILatestRelease(t, client)
+	if parseRFC3339(stored.CheckedAt).Equal(staleCheckedAt) || time.Since(parseRFC3339(stored.CheckedAt)) > time.Minute {
+		t.Fatalf("fallback did not refresh CheckedAt: %q", stored.CheckedAt)
+	}
+
+	hits = 0
+	result2, err := service.ZZMIFixerPrepare(ctx, root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hits != 0 || result2.Rules.CheckedRemotely || result2.Rules.LatestTag == nil || *result2.Rules.LatestTag != cached.Tag {
+		t.Fatalf("refreshed cooldown still contacted GitHub: hits=%d rules=%+v", hits, result2.Rules)
+	}
+}
+
+func TestZZMIFixerPrepareTreatsBrokenCacheAsMiss(t *testing.T) {
+	ctx := context.Background()
+	client := openToolsTestDB(t)
+	root := insertZZMITestTarget(t, client)
+	if err := client.AppState.Upsert(ctx, zzmiLatestReleaseKey, "{not-json", time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	remote := sampleZZMILatestRelease(time.Time{})
+	service := newZZMIFixerTestService(t, client, zzmiRemoteReleaseHandler(remote.Tag, remote.Commit, nil))
+
+	result, err := service.ZZMIFixerPrepare(ctx, root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Rules.CheckedRemotely || result.Rules.LatestTag == nil || *result.Rules.LatestTag != remote.Tag {
+		t.Fatalf("broken cache was not treated as a miss: %+v", result.Rules)
+	}
+}
+
+func insertZZMITestTarget(t *testing.T, client *db.Client) string {
+	t.Helper()
+	root := t.TempDir()
+	importer := "ZZMI"
+	if err := client.GamePaths.Insert(context.Background(), db.GamePathRow{Game: "ZZZ", ModFolderPath: root, Importer: &importer}); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func sampleZZMILatestRelease(checkedAt time.Time) zzmiLatestRelease {
+	release := zzmiLatestRelease{
+		Tag:       "v1.2.3",
+		Commit:    "0123456789abcdef0123456789abcdef01234567",
+		Zipball:   "https://api.github.com/repos/Vonksdesu/ZZZ-Mod-Fixer/zipball/v1.2.3",
+		Published: "2026-09-03T12:00:00Z",
+		Blobs:     map[string]string{"Source Codes/Jane.remapper.py": "abc123"},
+	}
+	if !checkedAt.IsZero() {
+		release.CheckedAt = checkedAt.Format(time.RFC3339Nano)
+	}
+	return release
+}
+
+func seedZZMILatestRelease(t *testing.T, client *db.Client, release zzmiLatestRelease) {
+	t.Helper()
+	raw, err := json.Marshal(release)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updatedAt := release.CheckedAt
+	if updatedAt == "" {
+		updatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	if err := client.AppState.Upsert(context.Background(), zzmiLatestReleaseKey, string(raw), updatedAt); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readZZMILatestRelease(t *testing.T, client *db.Client) zzmiLatestRelease {
+	t.Helper()
+	raw, err := client.AppState.GetValue(context.Background(), zzmiLatestReleaseKey)
+	if err != nil || raw == nil {
+		t.Fatalf("stored release = %v, %v", raw, err)
+	}
+	var release zzmiLatestRelease
+	if err := json.Unmarshal([]byte(*raw), &release); err != nil {
+		t.Fatal(err)
+	}
+	return release
+}
+
+func newZZMIFixerTestService(t *testing.T, client *db.Client, handle func(*http.Request) (int, string, error)) *Tools {
+	t.Helper()
+	service := NewWithOptions(Options{
+		HTTP: infra.NewClientWithOptions(infra.ClientOptions{
+			HTTPClient: &http.Client{Transport: toolsRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+				status, body, err := handle(request)
+				if err != nil {
+					return nil, err
+				}
+				return &http.Response{StatusCode: status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body))}, nil
+			})},
+		}),
+	})
+	service.UseClient(client)
+	useToolsTestAppData(t, service, t.TempDir())
+	return service
+}
+
+func zzmiRemoteReleaseHandler(tag, commit string, onHit func()) func(*http.Request) (int, string, error) {
+	zipball := "https://api.github.com/repos/Vonksdesu/ZZZ-Mod-Fixer/zipball/" + tag
+	refURL := "https://api.github.com/repos/Vonksdesu/ZZZ-Mod-Fixer/git/ref/tags/" + tag
+	treeURL := "https://api.github.com/repos/Vonksdesu/ZZZ-Mod-Fixer/git/trees/" + commit + "?recursive=1"
+	return func(request *http.Request) (int, string, error) {
+		if onHit != nil {
+			onHit()
+		}
+		switch request.URL.String() {
+		case zzmiLatestReleaseURL:
+			return http.StatusOK, fmt.Sprintf(`{"tag_name":%q,"zipball_url":%q,"published_at":"2026-09-03T12:00:00Z"}`, tag, zipball), nil
+		case refURL:
+			return http.StatusOK, fmt.Sprintf(`{"object":{"type":"commit","sha":%q}}`, commit), nil
+		case treeURL:
+			return http.StatusOK, `{"truncated":false,"tree":[{"path":"Source Codes/Jane.remapper.py","type":"blob","sha":"abc123"}]}`, nil
+		default:
+			return 0, "", fmt.Errorf("unexpected request: %s", request.URL)
+		}
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how often GitHub is called and what happens when it fails during ZZMI prepare; shared app-state helpers affect Wuwa paths but are a straight replacement.
> 
> **Overview**
> **ZZMI Mod Fixer** no longer keeps “latest release” metadata only in process memory. It now reads and writes a JSON blob under `mod_tools:zzmi-mod-fixer:latest-release` via shared `getAppState` / `setAppState` on `Tools`, with a **1-hour** refresh cooldown (was 15 minutes). Fresh cache skips GitHub; `forceRefresh` always fetches; expired or bad cache triggers a remote check; if the network fails, it can still return the last good data and **bumps `CheckedAt`** so retries are not immediate.
> 
> **Wuwa Mod Fixer** is refactored to use the same app-state helpers instead of `wuwaGetAppState` / `wuwaSetAppState` (behavior unchanged). In-memory `zzmiMu` / `zzmiLatest` fields are removed from `Tools`.
> 
> New tests cover cache hits across service restarts, persistence after remote fetch, expiry, force refresh, outage fallback, and malformed cache entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 500d82d66446dd1327bdaa525fb588579e176074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Latest ZZMI release information is now cached persistently, reducing unnecessary refreshes.
  - Cached release data remains available when a refresh fails, when appropriate.
  - Forced refreshes and expired cache entries are handled automatically.

- **Bug Fixes**
  - Improved recovery from unavailable or malformed cached release data.

- **Tests**
  - Added coverage for caching, expiration, forced refreshes, fallback behavior, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->