### PR TITLE
feat(drive): support nzst uploads

### DIFF
--- a/internal/drive/upload_nzst.go
+++ b/internal/drive/upload_nzst.go
@@ -1,0 +1,134 @@
+package drive
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/klauspost/compress/zstd"
+
+	"nahida.live/desktop/internal/infra"
+)
+
+const (
+	uploadNZSTExtension = ".nzst"
+	uploadNZSTMaxSize   = int64(64 << 30)
+)
+
+func isUploadNZST(path string) bool {
+	return strings.HasSuffix(strings.ToLower(path), uploadNZSTExtension)
+}
+
+func uploadNZSTLimit(name string, allowed map[string]int64, limit int64) int64 {
+	if extensionLimit := allowed[strings.ToLower(filepath.Ext(name))]; extensionLimit > 0 {
+		limit = min(limit, extensionLimit)
+	}
+	return min(limit, uploadNZSTMaxSize)
+}
+
+// Return at most limit+1 bytes, allowing callers to distinguish an oversized
+// file from corrupt data without trusting optional frame size metadata.
+func copyUploadNZST(ctx context.Context, path string, output io.Writer, limit int64) (int64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	source, err := os.Open(filepath.FromSlash(path))
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = source.Close() }()
+	info, err := source.Stat()
+	if err != nil {
+		return 0, err
+	}
+	if info.Size() == 0 {
+		return 0, io.ErrUnexpectedEOF
+	}
+	decoder, err := zstd.NewReader(source, zstd.WithDecoderConcurrency(1))
+	if err != nil {
+		return 0, err
+	}
+	defer decoder.Close()
+	return io.Copy(output, io.LimitReader(&uploadNZSTReader{ctx: ctx, reader: decoder}, limit+1))
+}
+
+type uploadNZSTReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r *uploadNZSTReader) Read(buffer []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.reader.Read(buffer)
+}
+
+type uploadSourceError struct {
+	File     UploadFile
+	TempPath string
+	Err      error
+}
+
+func (e *uploadSourceError) Error() string {
+	return fmt.Sprintf("prepare upload source %q (%s): %v", e.File.Name, e.File.FullPath, e.Err)
+}
+
+func (e *uploadSourceError) Unwrap() error { return e.Err }
+
+func (d *Drive) reportUploadSourceFailure(destinationID, stage string, err error) error {
+	if errors.Is(err, context.Canceled) {
+		return err
+	}
+	fields := map[string]any{"destinationId": destinationID}
+	var sourceErr *uploadSourceError
+	if errors.As(err, &sourceErr) {
+		fields["name"] = sourceErr.File.Name
+		fields["inputPath"] = sourceErr.File.FullPath
+		fields["tempPath"] = sourceErr.TempPath
+		fields["cleanupRegistered"] = sourceErr.TempPath != ""
+	}
+	return infra.ReportError(d.log, err, "Drive", infra.Diagnostic{Operation: "upload", Stage: stage, Fields: fields})
+}
+
+// The caller owns cleanup even on failure. Restart data must retain source
+// paths; only this execution's copy may point at temporary decoded files.
+func restoreUploadSources(ctx context.Context, files []UploadFile, tempDir *string) ([]UploadFile, bool, error) {
+	restored := make([]UploadFile, len(files))
+	copy(restored, files)
+	hasNZST := false
+	for index, file := range files {
+		if !isUploadNZST(file.FullPath) {
+			continue
+		}
+		hasNZST = true
+		if err := ctx.Err(); err != nil {
+			return nil, hasNZST, err
+		}
+		if *tempDir == "" {
+			directory, err := os.MkdirTemp("", "nahida-drive-upload-*")
+			if err != nil {
+				return nil, hasNZST, &uploadSourceError{File: file, Err: err}
+			}
+			*tempDir = directory
+		}
+		temp, err := os.CreateTemp(*tempDir, "source-*")
+		if err != nil {
+			return nil, hasNZST, &uploadSourceError{File: file, TempPath: *tempDir, Err: err}
+		}
+		size, copyErr := copyUploadNZST(ctx, file.FullPath, temp, min(file.Size, uploadNZSTMaxSize))
+		closeErr := temp.Close()
+		if copyErr == nil && size != file.Size {
+			copyErr = fmt.Errorf("restored size changed: got %d, expected %d", size, file.Size)
+		}
+		if err := errors.Join(copyErr, closeErr); err != nil {
+			return nil, hasNZST, &uploadSourceError{File: file, TempPath: temp.Name(), Err: err}
+		}
+		restored[index].FullPath = filepath.ToSlash(temp.Name())
+	}
+	return restored, hasNZST, nil
+}

--- a/internal/drive/upload_nzst_service_test.go
+++ b/internal/drive/upload_nzst_service_test.go
@@ -1,0 +1,382 @@
+package drive
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+
+	"nahida.live/desktop/internal/infra"
+	"nahida.live/desktop/internal/transfer"
+)
+
+func TestUploadNZSTServiceTransportsAndRestartCleanup(t *testing.T) {
+	for _, mode := range []string{"direct", "parts", "pack", "failure", "pause", "cancel"} {
+		t.Run(mode, func(t *testing.T) {
+			tempRoot := t.TempDir()
+			t.Setenv("TMP", tempRoot)
+			t.Setenv("TEMP", tempRoot)
+			root := t.TempDir()
+			archive := filepath.Join(root, "file.ini.nzst")
+			content := []byte("payload")
+			writeUploadNZST(t, archive, content)
+			paths := []string{archive}
+			if mode == "pack" {
+				other := filepath.Join(root, "other.ini.nzst")
+				writeUploadNZST(t, other, content)
+				paths = append(paths, other)
+			}
+			transfers := transfer.New()
+			var pid string
+			var requests atomic.Int32
+			var restart atomic.Bool
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				switch {
+				case request.URL.Path == "/akasha/content/dest":
+					_, _ = io.WriteString(w, `{"children":[]}`)
+				case request.URL.Path == "/akasha/v2/sse/drive/files:plan":
+					var plan struct {
+						Files []struct {
+							ClientID, Name, SHA256 string
+							Size                   int64
+						}
+					}
+					if err := json.NewDecoder(request.Body).Decode(&plan); err != nil {
+						t.Error(err)
+						w.WriteHeader(500)
+						return
+					}
+					items := make([]map[string]any, 0, len(plan.Files))
+					uploads := make([]map[string]any, 0, len(plan.Files))
+					for index, file := range plan.Files {
+						if strings.HasSuffix(file.Name, ".nzst") || file.Size != int64(len(content)) || file.SHA256 != fmt.Sprintf("%x", sha256.Sum256(content)) {
+							t.Errorf("plan file = %+v", file)
+						}
+						intent := fmt.Sprintf("intent-%d", index)
+						items = append(items, map[string]any{"clientId": file.ClientID, "status": "pending", "intentId": intent})
+						uploads = append(uploads, map[string]any{"intentId": intent, "url": server.URL + "/v2/uploads/" + intent, "method": "POST", "form": map[string]string{"token": "test", "sha256": file.SHA256}})
+					}
+					payload, err := json.Marshal(map[string]any{"items": items, "uploads": uploads})
+					if err != nil {
+						t.Error(err)
+						return
+					}
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = fmt.Fprintf(w, "event: complete\ndata: %s\n\n", payload)
+				case strings.HasSuffix(request.URL.Path, "/complete"):
+					_, _ = io.WriteString(w, `{}`)
+				default:
+					requests.Add(1)
+					entries, err := filepath.Glob(filepath.Join(tempRoot, "nahida-drive-upload-*", "source-*"))
+					if err != nil || len(entries) != len(paths) {
+						t.Errorf("temporary sources during upload = %v, %v", entries, err)
+					}
+					if !restart.Load() {
+						switch mode {
+						case "failure":
+							w.WriteHeader(http.StatusBadRequest)
+							return
+						case "pause":
+							if err := transfers.Pause(pid); err != nil {
+								t.Error(err)
+							}
+							return
+						case "cancel":
+							if err := transfers.Cancel(pid); err != nil {
+								t.Error(err)
+							}
+							return
+						}
+					}
+					if err := request.ParseMultipartForm(1 << 20); err != nil {
+						t.Error(err)
+						return
+					}
+					defer func() { _ = request.MultipartForm.RemoveAll() }()
+					if mode == "pack" {
+						if request.URL.Path != "/v2/uploads:pack" {
+							t.Errorf("expected pack route, got %s", request.URL.Path)
+						}
+						var manifest struct {
+							Entries []struct {
+								IntentID, CompAlg string
+								PayloadBytes      int64
+							}
+						}
+						if err := json.Unmarshal([]byte(request.FormValue("manifest")), &manifest); err != nil {
+							t.Error(err)
+							return
+						}
+						file, _, err := request.FormFile("pack")
+						if err != nil {
+							t.Error(err)
+							return
+						}
+						defer func() { _ = file.Close() }()
+						results := make([]map[string]string, 0, len(manifest.Entries))
+						for _, entry := range manifest.Entries {
+							assertUploadNZSTPayload(t, io.LimitReader(file, entry.PayloadBytes), entry.CompAlg, content)
+							results = append(results, map[string]string{"intentId": entry.IntentID, "status": "completed"})
+						}
+						_ = json.NewEncoder(w).Encode(map[string]any{"results": results})
+						return
+					}
+					if mode == "parts" && !strings.HasSuffix(request.URL.Path, "/parts/0") {
+						t.Errorf("expected parts route, got %s", request.URL.Path)
+					}
+					file, header, err := request.FormFile("file")
+					if err != nil {
+						t.Error(err)
+						return
+					}
+					defer func() { _ = file.Close() }()
+					if header.Filename != "file.ini" {
+						t.Errorf("filename = %q", header.Filename)
+					}
+					assertUploadNZSTPayload(t, file, request.FormValue("compAlg"), content)
+					_, _ = io.WriteString(w, `{}`)
+				}
+			}))
+			defer server.Close()
+			drive := uploadServiceTestDrive(server, transfers)
+			rules := testUploadRules()
+			if mode == "parts" {
+				rules.MaxUploadBodyBytes = 32
+			}
+			drive.setUploadRules(rules)
+			conflicts, err := drive.GetUploadConflicts(t.Context(), GetUploadConflictsParams{DestID: "dest", Paths: paths})
+			if err != nil || len(conflicts.SkippedExtensions) != 0 {
+				t.Fatalf("conflicts = %+v, %v", conflicts, err)
+			}
+			result, err := drive.StartUpload(t.Context(), StartUploadParams{DestID: "dest", Paths: paths})
+			if err != nil {
+				t.Fatal(err)
+			}
+			pid = result.PID
+			expect := transfer.StatusCompleted
+			switch mode {
+			case "failure":
+				expect = transfer.StatusError
+			case "pause":
+				expect = transfer.StatusPaused
+			case "cancel":
+				expect = transfer.StatusCanceled
+			}
+			for range 2 {
+				if err := transfers.ProcessQueue(t.Context()); err != nil {
+					t.Fatal(err)
+				}
+				record, ok := transfers.Get(pid)
+				if !ok || record.Status != expect {
+					t.Fatalf("record = %+v, want %s", record, expect)
+				}
+				entries, err := filepath.Glob(filepath.Join(tempRoot, "nahida-drive-upload-*"))
+				if err != nil || len(entries) != 0 {
+					t.Fatalf("temporary sources leaked = %v, %v", entries, err)
+				}
+				if _, err := os.Stat(archive); err != nil {
+					t.Fatal(err)
+				}
+				if expect == transfer.StatusCompleted {
+					if record.TotalSize != int64(len(content)*len(paths)) || record.TransferredSize != record.TotalSize {
+						t.Fatalf("sizes = %+v", record)
+					}
+					break
+				}
+				// Same length, different bytes: a new decoded file must not reuse
+				// the previous execution's cached hash.
+				content = []byte("changed")
+				writeUploadNZST(t, archive, content)
+				restart.Store(true)
+				if mode == "pause" {
+					err = transfers.Resume(pid)
+				} else {
+					err = transfers.Retry(pid)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				expect = transfer.StatusCompleted
+			}
+			if requests.Load() == 0 {
+				t.Fatal("no upload request")
+			}
+		})
+	}
+}
+
+func assertUploadNZSTPayload(t *testing.T, reader io.Reader, compression string, want []byte) {
+	t.Helper()
+	if compression == "zstd" {
+		decoder, err := zstd.NewReader(reader)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer decoder.Close()
+		reader = decoder
+	}
+	got, err := io.ReadAll(reader)
+	if err != nil || !bytes.Equal(got, want) {
+		t.Errorf("uploaded content = %q, want %q, err = %v", got, want, err)
+	}
+}
+
+func TestUploadNZSTRestoreFailureCleansUpBeforeRemoteMutation(t *testing.T) {
+	tempRoot := t.TempDir()
+	t.Setenv("TMP", tempRoot)
+	t.Setenv("TEMP", tempRoot)
+	root := t.TempDir()
+	archive := filepath.Join(root, "file.ini.nzst")
+	writeUploadNZST(t, archive, []byte("original"))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/akasha/content/dest" {
+			t.Errorf("restore failure reached remote operation: %s", request.URL.Path)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, _ = io.WriteString(w, `{"children":[]}`)
+	}))
+	defer server.Close()
+	var logs bytes.Buffer
+	transfers := transfer.New()
+	drive := uploadServiceTestDrive(server, transfers)
+	drive.UseLog(infra.NewLogWithOptions(infra.LogOptions{Writer: &logs, DisableFile: true}))
+	drive.setUploadRules(testUploadRules())
+	result, err := drive.StartUpload(t.Context(), StartUploadParams{DestID: "dest", Paths: []string{root}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeUploadFile(t, archive, "corrupt after preparation")
+	if err := transfers.ProcessQueue(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	record, ok := transfers.Get(result.PID)
+	if !ok || record.Status != transfer.StatusError {
+		t.Fatalf("record = %+v", record)
+	}
+	entries, err := filepath.Glob(filepath.Join(tempRoot, "nahida-drive-upload-*"))
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("leaked temporary files: %v, %v", entries, err)
+	}
+	for _, field := range []string{`"stage":"restore-sources"`, `"destinationId":"dest"`, `"name":"file.ini"`, `"inputPath":`, `"tempPath":`, `"cleanupRegistered":true`} {
+		if !strings.Contains(logs.String(), field) {
+			t.Errorf("missing diagnostic %s: %s", field, logs.String())
+		}
+	}
+}
+
+func TestUploadNZSTResumeSkipsDeletedCompletedSources(t *testing.T) {
+	for _, completedName := range []string{"done.ini", "done.ini.nzst"} {
+		for _, allCompleted := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/all-completed=%t", completedName, allCompleted), func(t *testing.T) {
+				tempRoot := t.TempDir()
+				t.Setenv("TMP", tempRoot)
+				t.Setenv("TEMP", tempRoot)
+				root := t.TempDir()
+				done := filepath.Join(root, completedName)
+				pending := filepath.Join(root, "pending.ini.nzst")
+				if isUploadNZST(done) {
+					writeUploadNZST(t, done, []byte("done"))
+				} else {
+					writeUploadFile(t, done, "done")
+				}
+				writeUploadNZST(t, pending, []byte("pending"))
+				prep, err := PrepareUpload([]string{done, pending}, nil, "", testUploadRules(), nil, false)
+				if err != nil {
+					t.Fatal(err)
+				}
+				transfers := transfer.New()
+				restart := &uploadRestartData{Params: StartUploadParams{DestID: "dest"}, Preparation: prep, RequestID: "resume"}
+				_, err = transfers.Create(transfer.CreateParams{
+					PID: prep.PID, Type: "upload", InitialStatus: transfer.StatusPending, RestartData: restart,
+					Data: transfer.Data{Files: []transfer.DownloadFile{
+						{ID: prep.Files[0].FID, Name: "done.ini", Size: 4},
+						{ID: prep.Files[1].FID, Name: "pending.ini", Size: 7},
+					}},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := transfers.MarkFileCompleted(prep.PID, prep.Files[0].FID); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Remove(done); err != nil {
+					t.Fatal(err)
+				}
+				if allCompleted {
+					if err := transfers.MarkFileCompleted(prep.PID, prep.Files[1].FID); err != nil {
+						t.Fatal(err)
+					}
+					if err := os.Remove(pending); err != nil {
+						t.Fatal(err)
+					}
+				}
+				var planned atomic.Bool
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+					planned.Store(true)
+					if allCompleted {
+						t.Error("all-completed resume made a remote request")
+						w.WriteHeader(500)
+						return
+					}
+					var plan struct {
+						Files []struct {
+							ClientID, Name, SHA256 string
+							Size                   int64
+						}
+					}
+					if err := json.NewDecoder(request.Body).Decode(&plan); err != nil {
+						t.Error(err)
+						w.WriteHeader(500)
+						return
+					}
+					if len(plan.Files) != 1 || plan.Files[0].ClientID != prep.Files[1].FID || plan.Files[0].Name != "pending.ini" || plan.Files[0].Size != 7 || plan.Files[0].SHA256 != fmt.Sprintf("%x", sha256.Sum256([]byte("pending"))) {
+						t.Errorf("resume plan = %+v", plan)
+					}
+					record, _ := transfers.Get(prep.PID)
+					if record.TransferredFiles != 1 || record.TransferredSize != 4 {
+						t.Errorf("completed progress lost: %+v", record)
+					}
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = fmt.Fprintf(w, "event: complete\ndata: {\"items\":[{\"clientId\":%q,\"status\":\"exists\"}],\"uploads\":[]}\n\n", prep.Files[1].FID)
+				}))
+				defer server.Close()
+				drive := uploadServiceTestDrive(server, transfers)
+				drive.setUploadRules(testUploadRules())
+				state := &uploadRunnerState{hashes: map[string]string{prep.Files[0].FID: "cached-done", prep.Files[1].FID: "cached-pending"}}
+				if err := transfers.RegisterRunner(prep.PID, func(ctx context.Context, transfers *transfer.Transfer, pid string) error {
+					return drive.runUpload(ctx, transfers, pid, restart, state)
+				}); err != nil {
+					t.Fatal(err)
+				}
+				if err := transfers.ProcessQueue(t.Context()); err != nil {
+					t.Fatal(err)
+				}
+				record, ok := transfers.Get(prep.PID)
+				if !ok || record.Status != transfer.StatusCompleted || record.TransferredFiles != 2 || record.TransferredSize != 11 || record.TotalSize != 11 {
+					t.Fatalf("resume record = %+v", record)
+				}
+				if planned.Load() == allCompleted {
+					t.Fatalf("planned = %v, all completed = %v", planned.Load(), allCompleted)
+				}
+				entries, err := filepath.Glob(filepath.Join(tempRoot, "nahida-drive-upload-*"))
+				if err != nil || len(entries) != 0 {
+					t.Fatalf("leaked temporary sources = %v, %v", entries, err)
+				}
+			})
+		}
+	}
+}

--- a/internal/drive/upload_nzst_test.go
+++ b/internal/drive/upload_nzst_test.go
@@ -1,0 +1,226 @@
+package drive
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+func writeUploadNZST(t *testing.T, path string, content []byte) {
+	t.Helper()
+	encoder, err := zstd.NewWriter(nil, zstd.WithEncoderCRC(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = encoder.Close() }()
+	writeUploadFile(t, path, string(encoder.EncodeAll(content, nil)))
+}
+
+func TestPrepareUploadNZSTUsesOriginalNamesAndSizes(t *testing.T) {
+	root := t.TempDir()
+	archive := filepath.Join(root, "Character", "texture.dds.NZST")
+	content := bytes.Repeat([]byte("texture"), 1000)
+	writeUploadNZST(t, archive, content)
+	writeUploadFile(t, filepath.Join(root, "Character", "mod.ini"), "ini")
+	writeUploadFile(t, filepath.Join(root, "desktop.ini.nzst"), "invalid but excluded")
+	writeUploadFile(t, filepath.Join(root, "notes.exe.nzst"), "invalid but denied")
+	collected, err := collectUploadPaths([]string{root}, testUploadRules(), nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(collected.Files) != 2 || collected.SkippedCount != 1 || !reflect.DeepEqual(collected.SkippedExtensions, []string{".exe"}) {
+		t.Fatalf("collected = %+v", collected)
+	}
+	for _, file := range collected.Files {
+		if file.Name == "texture.dds" && (file.Size != int64(len(content)) || strings.HasSuffix(file.Path, ".NZST") || file.FullPath != filepath.ToSlash(archive)) {
+			t.Fatalf("file = %+v", file)
+		}
+	}
+	for _, strategy := range []UploadConflictStrategy{UploadConflictSkip, UploadConflictSuffix} {
+		prepared, err := PrepareUpload([]string{archive}, []string{"texture.dds"}, strategy, testUploadRules(), nil, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strategy == UploadConflictSkip {
+			if len(prepared.Files) != 0 {
+				t.Fatal("conflicting original was not skipped")
+			}
+		} else if len(prepared.Files) != 1 || prepared.Files[0].Name == "texture.dds" || prepared.TotalSize != int64(len(content)) {
+			t.Fatalf("prepared = %+v", prepared)
+		}
+	}
+}
+
+func TestUploadNZSTOriginalWinsRegardlessOfOrder(t *testing.T) {
+	root := t.TempDir()
+	original := filepath.Join(root, "TEXTURE.dds")
+	archive := filepath.Join(root, "texture.dds.nzst")
+	writeUploadFile(t, original, "original")
+	writeUploadFile(t, archive, "corrupt stale archive")
+	for _, paths := range [][]string{{archive, original}, {original, archive}, {root}} {
+		prepared, err := PrepareUpload(paths, nil, UploadConflictSuffix, testUploadRules(), nil, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(prepared.Files) != 1 || prepared.Files[0].FullPath != filepath.ToSlash(original) {
+			t.Fatalf("prepared = %+v", prepared)
+		}
+	}
+}
+
+func TestUploadNZSTLimitsAndAdditionalExtensions(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "file.xyz.nzst")
+	writeUploadNZST(t, path, []byte("12345"))
+	rules := testUploadRules()
+	rules.MaxFileSize = 5
+	for _, allowAll := range []bool{false, true} {
+		prepared, err := PrepareUpload([]string{path}, nil, "", rules, []string{"xyz"}, allowAll)
+		if err != nil || len(prepared.Files) != 1 || prepared.TotalSize != 5 {
+			t.Fatalf("prepared = %+v, err = %v", prepared, err)
+		}
+	}
+	rules.Extensions = append(rules.Extensions, UploadExtensionRule{Ext: ".xyz", MaxSize: 4})
+	prepared, err := PrepareUpload([]string{path}, nil, "", rules, nil, true)
+	if err != nil || len(prepared.Files) != 0 {
+		t.Fatalf("oversized = %+v, err = %v", prepared, err)
+	}
+	var output bytes.Buffer
+	size, err := copyUploadNZST(t.Context(), path, &output, 2)
+	if err != nil || size != 3 || output.Len() != 3 {
+		t.Fatalf("bounded decode = %d, %v", size, err)
+	}
+}
+
+func TestUploadNZSTCorruptionAndCancellation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "file.ini.nzst")
+	writeUploadFile(t, path, "")
+	if _, err := collectUploadPaths([]string{path}, testUploadRules(), nil, false); err == nil {
+		t.Fatal("empty archive accepted")
+	}
+	writeUploadFile(t, path, "broken")
+	if _, err := collectUploadPaths([]string{path}, testUploadRules(), nil, false); err == nil {
+		t.Fatal("corrupt archive accepted")
+	}
+	writeUploadNZST(t, path, bytes.Repeat([]byte("payload"), 20000))
+	ctx, cancel := context.WithCancel(t.Context())
+	writer := &cancelUploadNZSTWriter{cancel: cancel}
+	if _, err := copyUploadNZST(ctx, path, writer, uploadNZSTMaxSize); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancel error = %v", err)
+	}
+	if _, err := collectUploadPathsContext(ctx, []string{path}, testUploadRules(), nil, false); !errors.Is(err, context.Canceled) {
+		t.Fatalf("collection error = %v", err)
+	}
+	compressed, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compressed[len(compressed)-1] ^= 1
+	writeUploadFile(t, path, string(compressed))
+	if _, err := copyUploadNZST(t.Context(), path, io.Discard, uploadNZSTMaxSize); err == nil {
+		t.Fatal("checksum corruption accepted")
+	}
+}
+
+func TestUploadNZSTPreservesNTEGroupingAndOrdinaryZST(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"Game.pak.nzst", "Game.utoc.nzst", "Game_s1.ucas.nzst"} {
+		writeUploadNZST(t, filepath.Join(root, name), []byte("bundle"))
+	}
+	writeUploadFile(t, filepath.Join(root, "ordinary.zst"), "opaque zst contents")
+	prepared, err := PrepareUpload([]string{root}, nil, "", testUploadRules(), []string{"zst"}, false)
+	if err != nil || len(prepared.Files) != 4 {
+		t.Fatalf("prepared = %+v, %v", prepared, err)
+	}
+	for _, file := range prepared.Files {
+		if file.Name == "ordinary.zst" {
+			if file.Size != int64(len("opaque zst contents")) {
+				t.Fatal("ordinary zst was changed")
+			}
+			continue
+		}
+		if got := nteGroupKey(FinalUploadFile{UploadFile: file, ParentID: "parent"}); got != "parent\x00game" {
+			t.Fatalf("group key = %q for %s", got, file.Name)
+		}
+	}
+}
+
+type cancelUploadNZSTWriter struct{ cancel context.CancelFunc }
+
+func (w *cancelUploadNZSTWriter) Write(p []byte) (int, error) { w.cancel(); return len(p), nil }
+
+func TestRestoreUploadNZSTPreservesSourcesAndUsesUniqueTemporaryFiles(t *testing.T) {
+	root := t.TempDir()
+	for _, dir := range []string{"a", "b"} {
+		writeUploadNZST(t, filepath.Join(root, dir, "file.ini.nzst"), []byte(dir))
+	}
+	prepared, err := PrepareUpload([]string{root}, nil, "", testUploadRules(), nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tempDir := ""
+	defer func() {
+		if tempDir != "" {
+			_ = os.RemoveAll(tempDir)
+		}
+	}()
+	files, restored, err := restoreUploadSources(t.Context(), prepared.Files, &tempDir)
+	if err != nil || !restored || len(files) != 2 || files[0].FullPath == files[1].FullPath {
+		t.Fatalf("restore = %+v, %v", files, err)
+	}
+	hashed, err := HashUploadFiles(t.Context(), files, 2, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index, file := range hashed {
+		content := []byte(filepath.Base(filepath.Dir(prepared.Files[index].FullPath)))
+		if file.SHA256 != fmt.Sprintf("%x", sha256.Sum256(content)) || file.Name != "file.ini" || file.FID != prepared.Files[index].FID {
+			t.Fatalf("hashed = %+v", file)
+		}
+		if _, err := os.Stat(prepared.Files[index].FullPath); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(strings.TrimSuffix(prepared.Files[index].FullPath, ".nzst")); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("local original created: %v", err)
+		}
+	}
+	writeUploadNZST(t, prepared.Files[0].FullPath, []byte("changed size"))
+	if _, _, err := restoreUploadSources(t.Context(), prepared.Files, &tempDir); err == nil {
+		t.Fatal("changed source size accepted")
+	}
+	badTemp := filepath.Join(root, "not-a-directory")
+	writeUploadFile(t, badTemp, "file")
+	if _, _, err := restoreUploadSources(t.Context(), prepared.Files, &badTemp); err == nil {
+		t.Fatal("invalid temp directory accepted")
+	}
+}
+
+func TestUploadNZSTDecodesOnlyOneLayer(t *testing.T) {
+	root := t.TempDir()
+	inner := filepath.Join(root, "payload.ini.nzst")
+	writeUploadNZST(t, inner, []byte("payload"))
+	compressed, err := os.ReadFile(inner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outer := inner + ".nzst"
+	writeUploadNZST(t, outer, compressed)
+	prepared, err := PrepareUpload([]string{outer}, nil, "", testUploadRules(), nil, true)
+	if err != nil || len(prepared.Files) != 1 || prepared.Files[0].Name != "payload.ini.nzst" || prepared.TotalSize != int64(len(compressed)) {
+		t.Fatalf("prepared = %+v, %v", prepared, err)
+	}
+	plain, err := PrepareUpload([]string{inner}, nil, "", testUploadRules(), nil, false)
+	if err != nil || plain.TotalSize != 7 {
+		t.Fatalf("plain = %+v, %v", plain, err)
+	}
+}

--- a/internal/drive/upload_prepare.go
+++ b/internal/drive/upload_prepare.go
@@ -90,9 +90,9 @@ func (d *Drive) GetUploadConflicts(ctx context.Context, params GetUploadConflict
 	if err != nil {
 		return UploadConflictsResult{}, err
 	}
-	collected, err := collectUploadPaths(params.Paths, rules, nil, false)
+	collected, err := collectUploadPathsContext(ctx, params.Paths, rules, nil, false)
 	if err != nil {
-		return UploadConflictsResult{}, err
+		return UploadConflictsResult{}, d.reportUploadSourceFailure(params.DestID, "inspect", err)
 	}
 	files := collected.Files
 	directories := collected.Directories
@@ -141,13 +141,17 @@ func ensureUploadSourceReadable(path string) error {
 
 //wails:ignore
 func PrepareUpload(paths []string, existingNames []string, strategy UploadConflictStrategy, rules UploadRules, additionalExtensions []string, allowAllFiles bool) (UploadPreparation, error) {
+	return prepareUpload(context.Background(), paths, existingNames, strategy, rules, additionalExtensions, allowAllFiles)
+}
+
+func prepareUpload(ctx context.Context, paths []string, existingNames []string, strategy UploadConflictStrategy, rules UploadRules, additionalExtensions []string, allowAllFiles bool) (UploadPreparation, error) {
 	if strategy == "" {
 		strategy = UploadConflictSuffix
 	}
 	if strategy != UploadConflictSuffix && strategy != UploadConflictSkip {
 		return UploadPreparation{}, fmt.Errorf("unsupported upload conflict strategy %q", strategy)
 	}
-	collected, err := collectUploadPaths(paths, rules, additionalExtensions, allowAllFiles)
+	collected, err := collectUploadPathsContext(ctx, paths, rules, additionalExtensions, allowAllFiles)
 	if err != nil {
 		return UploadPreparation{}, err
 	}
@@ -234,6 +238,10 @@ func PrepareUpload(paths []string, existingNames []string, strategy UploadConfli
 }
 
 func collectUploadPaths(paths []string, rules UploadRules, additionalExtensions []string, allowAllFiles bool) (collectedUploadPaths, error) {
+	return collectUploadPathsContext(context.Background(), paths, rules, additionalExtensions, allowAllFiles)
+}
+
+func collectUploadPathsContext(ctx context.Context, paths []string, rules UploadRules, additionalExtensions []string, allowAllFiles bool) (collectedUploadPaths, error) {
 	allowed := extensionMaxSizes(rules, additionalExtensions)
 	files := make([]UploadFile, 0)
 	directories := make([]UploadDirectory, 0)
@@ -255,6 +263,9 @@ func collectUploadPaths(paths []string, rules UploadRules, additionalExtensions 
 		}
 	}
 	for _, rawPath := range paths {
+		if err := ctx.Err(); err != nil {
+			return collectedUploadPaths{}, err
+		}
 		absolute, err := filepath.EvalSymlinks(rawPath)
 		if err != nil {
 			continue
@@ -268,15 +279,10 @@ func collectUploadPaths(paths []string, rules UploadRules, additionalExtensions 
 			continue
 		}
 		if info.Mode().IsRegular() {
-			if considerFile(info.Name(), info.Size()) {
-				files = append(files, UploadFile{
-					Path:       info.Name(),
-					Name:       info.Name(),
-					Size:       info.Size(),
-					ParentPath: "",
-					FullPath:   filepath.ToSlash(absolute),
-				})
-			}
+			files = append(files, UploadFile{
+				Path: info.Name(), Name: info.Name(), Size: info.Size(),
+				FullPath: filepath.ToSlash(absolute),
+			})
 			continue
 		}
 		if !info.IsDir() {
@@ -284,6 +290,9 @@ func collectUploadPaths(paths []string, rules UploadRules, additionalExtensions 
 		}
 		rootParent := filepath.Dir(absolute)
 		walkErr := filepath.WalkDir(absolute, func(path string, entry fs.DirEntry, walkErr error) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			if walkErr != nil {
 				return walkErr
 			}
@@ -310,7 +319,7 @@ func collectUploadPaths(paths []string, rules UploadRules, additionalExtensions 
 			if infoErr != nil {
 				return infoErr
 			}
-			if !entryInfo.Mode().IsRegular() || !considerFile(entry.Name(), entryInfo.Size()) {
+			if !entryInfo.Mode().IsRegular() {
 				return nil
 			}
 			files = append(files, UploadFile{
@@ -326,6 +335,42 @@ func collectUploadPaths(paths []string, rules UploadRules, additionalExtensions 
 			return collectedUploadPaths{}, walkErr
 		}
 	}
+	// Resolve local originals before filtering so traversal order cannot make an
+	// archive supersede an existing original (or decode a stale, corrupt copy).
+	sources := make(map[string]struct{}, len(files))
+	for _, file := range files {
+		sources[strings.ToLower(filepath.Clean(file.FullPath))] = struct{}{}
+	}
+	accepted := files[:0]
+	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			return collectedUploadPaths{}, err
+		}
+		if isUploadNZST(file.FullPath) {
+			original := file.FullPath[:len(file.FullPath)-len(uploadNZSTExtension)]
+			if _, exists := sources[strings.ToLower(filepath.Clean(original))]; exists {
+				continue
+			}
+			file.Name = file.Name[:len(file.Name)-len(uploadNZSTExtension)]
+			file.Path = file.Path[:len(file.Path)-len(uploadNZSTExtension)]
+			if file.Name == "" || isSystemFile(file.Name) || !considerFile(file.Name, 0) {
+				continue
+			}
+			limit := uploadNZSTLimit(file.Name, allowed, rules.MaxFileSize)
+			size, err := copyUploadNZST(ctx, file.FullPath, io.Discard, limit)
+			if err != nil {
+				return collectedUploadPaths{}, &uploadSourceError{File: file, Err: err}
+			}
+			if size > limit {
+				continue
+			}
+			file.Size = size
+		}
+		if considerFile(file.Name, file.Size) {
+			accepted = append(accepted, file)
+		}
+	}
+	files = accepted
 	assignStableUploadFileIDs(files)
 	return collectedUploadPaths{
 		Files:             files,

--- a/internal/drive/upload_service.go
+++ b/internal/drive/upload_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -134,9 +135,9 @@ func (d *Drive) StartUpload(ctx context.Context, params StartUploadParams) (resu
 	if err != nil {
 		return StartUploadResult{}, err
 	}
-	preparation, err := PrepareUpload(params.Paths, slices.Collect(stringsMapKeys(childNames(item))), params.ConflictStrategy, rules, params.AdditionalExtensions, params.AllowAllFiles)
+	preparation, err := prepareUpload(ctx, params.Paths, slices.Collect(stringsMapKeys(childNames(item))), params.ConflictStrategy, rules, params.AdditionalExtensions, params.AllowAllFiles)
 	if err != nil {
-		return StartUploadResult{}, err
+		return StartUploadResult{}, d.reportUploadSourceFailure(params.DestID, "inspect", err)
 	}
 	if len(preparation.Files) == 0 {
 		return StartUploadResult{}, errors.New("NO_UPLOADABLE_FILES")
@@ -190,14 +191,40 @@ type uploadRunnerState struct {
 
 func (d *Drive) runUpload(ctx context.Context, transfers *transfer.Transfer, pid string, restart *uploadRestartData, state *uploadRunnerState) (returnErr error) {
 	preparation := restart.Preparation
+	var uploadedBytes int64
+	uploadedFiles := 0
+	pendingFiles := make([]UploadFile, 0, len(preparation.Files))
+	for _, file := range preparation.Files {
+		if transfers.IsFileCompleted(pid, file.FID) {
+			uploadedBytes += file.Size
+			uploadedFiles++
+			continue
+		}
+		pendingFiles = append(pendingFiles, file)
+	}
 	status := transfer.StatusPreparing
-	zero := 0
-	if err := transfers.Update(pid, transfer.Updates{Status: &status, TransferredFiles: &zero, ClearError: true, ClearErrorCode: true}); err != nil {
+	if err := transfers.Update(pid, transfer.Updates{Status: &status, TransferredSize: &uploadedBytes, TransferredFiles: &uploadedFiles, ClearError: true, ClearErrorCode: true}); err != nil {
 		return d.reportUploadFailure(transfers, pid, "prepare", err)
+	}
+	tempDir := ""
+	defer func() {
+		if tempDir == "" {
+			return
+		}
+		if err := os.RemoveAll(tempDir); err != nil {
+			_ = infra.ReportError(d.log, err, "Drive", infra.Diagnostic{
+				Operation: "upload", Stage: "cleanup-sources",
+				Fields: map[string]any{"pid": pid, "destinationId": restart.Params.DestID, "inputPaths": restart.Params.Paths, "tempPath": tempDir, "cleanupCompleted": false},
+			})
+		}
+	}()
+	parentFiles, restoredNZST, restoreErr := restoreUploadSources(ctx, pendingFiles, &tempDir)
+	if restoreErr != nil {
+		return d.failUploadTransfer(transfers, pid, "restore-sources", restoreErr)
 	}
 	created := []CreatedUploadDirectory{}
 	var err error
-	if len(preparation.Directories) > 0 {
+	if len(parentFiles) > 0 && len(preparation.Directories) > 0 {
 		created, err = d.CreateDirs(ctx, restart.Params.DestID, preparation.Directories)
 		if err != nil {
 			return d.failUploadTransfer(transfers, pid, "create-dirs", err)
@@ -207,14 +234,13 @@ func (d *Drive) runUpload(ctx context.Context, transfers *transfer.Transfer, pid
 	for _, directory := range created {
 		parentIDs[directory.Path] = directory.ID
 	}
-	parentFiles := make([]UploadFile, len(preparation.Files))
-	copy(parentFiles, preparation.Files)
 
 	state.mu.Lock()
 	hashes := state.hashes
 	state.mu.Unlock()
-	if len(hashes) != len(parentFiles) {
+	if restoredNZST || len(hashes) != len(parentFiles) {
 		hashed, hashErr := HashUploadFiles(ctx, parentFiles, uploadHashConcurrency(), func(count int) {
+			count += uploadedFiles
 			_ = transfers.Update(pid, transfer.Updates{TransferredFiles: &count})
 		})
 		if hashErr != nil {
@@ -228,7 +254,7 @@ func (d *Drive) runUpload(ctx context.Context, transfers *transfer.Transfer, pid
 		state.hashes = hashes
 		state.mu.Unlock()
 	}
-	finalFiles := make([]FinalUploadFile, len(parentFiles))
+	incomplete := make([]FinalUploadFile, len(parentFiles))
 	for index, file := range parentFiles {
 		parentID := restart.Params.DestID
 		if file.ParentPath != "" {
@@ -242,20 +268,9 @@ func (d *Drive) runUpload(ctx context.Context, transfers *transfer.Transfer, pid
 		if sha256 == "" {
 			return d.failUploadTransfer(transfers, pid, "hash", fmt.Errorf("hash missing for file %s", file.Name))
 		}
-		finalFiles[index] = FinalUploadFile{UploadFile: file, ParentID: parentID, SHA256: sha256}
+		incomplete[index] = FinalUploadFile{UploadFile: file, ParentID: parentID, SHA256: sha256}
 	}
 
-	var uploadedBytes int64
-	uploadedFiles := 0
-	incomplete := make([]FinalUploadFile, 0, len(finalFiles))
-	for _, file := range finalFiles {
-		if transfers.IsFileCompleted(pid, file.FID) {
-			uploadedBytes += file.Size
-			uploadedFiles++
-			continue
-		}
-		incomplete = append(incomplete, file)
-	}
 	progressStatus := transfer.StatusProgress
 	if err := transfers.Update(pid, transfer.Updates{Status: &progressStatus, TransferredSize: &uploadedBytes, TransferredFiles: &uploadedFiles}); err != nil {
 		return d.reportUploadFailure(transfers, pid, "prepare", err)
@@ -298,7 +313,7 @@ func (d *Drive) runUpload(ctx context.Context, transfers *transfer.Transfer, pid
 	if err := transfers.Update(pid, transfer.Updates{
 		Status:            &completed,
 		TransferredSize:   &total,
-		TransferredFiles:  ptrInt(len(finalFiles)),
+		TransferredFiles:  ptrInt(len(preparation.Files)),
 		Progress:          &hundred,
 		ClearPlanPhase:    true,
 		ClearPlanProgress: true,
@@ -369,10 +384,18 @@ func (d *Drive) reportUploadFailure(transfers *transfer.Transfer, pid, stage str
 	if errors.As(failure, &uploadErr) {
 		code = uploadErr.Code
 	}
+	fields := driveTransferFields(transfers, pid, code)
+	var sourceErr *uploadSourceError
+	if errors.As(failure, &sourceErr) {
+		fields["name"] = sourceErr.File.Name
+		fields["inputPath"] = sourceErr.File.FullPath
+		fields["tempPath"] = sourceErr.TempPath
+		fields["cleanupRegistered"] = sourceErr.TempPath != ""
+	}
 	return infra.ReportError(d.log, failure, "Drive", infra.Diagnostic{
 		Operation: "upload",
 		Stage:     stage,
-		Fields:    driveTransferFields(transfers, pid, code),
+		Fields:    fields,
 	})
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading `.nzst` compressed files while preserving original filenames and decompressed sizes.
  * Added automatic restoration of compressed upload sources for transfers, including restart and resume scenarios.
  * Added cancellation-aware upload preparation and processing.

* **Bug Fixes**
  * Improved handling of corrupted, oversized, unsupported, or unavailable upload sources with clearer diagnostics.
  * Ensured temporary restored files are cleaned up after successful, failed, paused, or canceled transfers.
  * Improved resume behavior when completed source files are no longer present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->