### PR TITLE
fix(gamebanana): preserve login failure diagnostics

### DIFF
--- a/internal/app/gamebanana_login.go
+++ b/internal/app/gamebanana_login.go
@@ -44,12 +44,13 @@ type gameBananaLogin struct {
 	parent *Window
 	log    *infra.Log
 
-	factory       loginWindowFactory
-	logoutFactory loginWindowFactory
-	pollWait      time.Duration
-	profile       loginWindow
-	window        loginWindow
-	cancel        context.CancelFunc
+	factory        loginWindowFactory
+	logoutFactory  loginWindowFactory
+	pollWait       time.Duration
+	pollDiagnostic infra.DiagnosticThrottle
+	profile        loginWindow
+	window         loginWindow
+	cancel         context.CancelFunc
 
 	pollInFlight   bool
 	opening        bool
@@ -147,13 +148,9 @@ func (l *gameBananaLogin) Open(ctx context.Context, validate gamebanana.CookieVa
 			l.mu.Lock()
 			l.opening = false
 			l.mu.Unlock()
-			if l.log != nil {
-				l.log.Warn(map[string]any{
-					"stage": "logout-shared-webview-profile",
-					"error": err.Error(),
-				}, "GameBananaLogin.Open")
-			}
-			return "", classifyLoginWindowError(err)
+			return "", infra.ReportError(l.log, classifyLoginWindowError(err), "GameBananaLogin.Open", infra.Diagnostic{
+				Severity: infra.DiagnosticWarn, Operation: "login", Stage: "logout-shared-webview-profile",
+			})
 		}
 
 		window, err := factory()
@@ -161,7 +158,9 @@ func (l *gameBananaLogin) Open(ctx context.Context, validate gamebanana.CookieVa
 			l.mu.Lock()
 			l.opening = false
 			l.mu.Unlock()
-			return "", classifyLoginWindowError(err)
+			return "", infra.AnnotateError(classifyLoginWindowError(err), infra.Diagnostic{
+				Severity: infra.DiagnosticWarn, Operation: "login", Stage: "create-login-window",
+			})
 		}
 		if window == nil {
 			l.mu.Lock()
@@ -182,6 +181,7 @@ func (l *gameBananaLogin) Open(ctx context.Context, validate gamebanana.CookieVa
 		l.ready = false
 		l.pollInFlight = false
 		l.lastCandidates = nil
+		l.pollDiagnostic.Report(l.log, nil, "GameBananaLogin", infra.Diagnostic{})
 		l.result = ""
 		l.err = nil
 		l.opening = false
@@ -470,18 +470,17 @@ func (l *gameBananaLogin) pollOnce(ctx context.Context, validate gamebanana.Cook
 	}
 	l.mu.Unlock()
 	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		if errors.Is(err, context.Canceled) {
 			return false
 		}
 		if errors.Is(err, application.ErrWebviewCookiesUnsupported) {
-			l.settle("", gamebanana.ErrAutoLoginUnsupported)
+			l.settle("", infra.AnnotateError(classifyLoginWindowError(err), l.cookieDiagnostic(ctx, "poll-cookies")))
 			return false
 		}
-		if l.log != nil {
-			l.log.Warn("gamebanana cookie poll failed", "GameBananaLogin")
-		}
-		return true
+		l.pollDiagnostic.Report(l.log, err, "GameBananaLogin", l.cookieDiagnostic(ctx, "poll-cookies"))
+		return !errors.Is(err, context.DeadlineExceeded)
 	}
+	l.pollDiagnostic.Report(l.log, nil, "GameBananaLogin", infra.Diagnostic{})
 
 	candidates := make([]string, 0, len(cookies))
 	unique := make(map[string]struct{}, len(cookies))
@@ -532,7 +531,10 @@ func (l *gameBananaLogin) pollOnce(ctx context.Context, validate gamebanana.Cook
 			if errors.Is(verr, context.Canceled) {
 				return false
 			}
-			l.settle("", gamebanana.ClassifyLoginError(verr))
+			l.settle("", infra.AnnotateError(
+				infra.WithCause(gamebanana.ClassifyLoginError(verr), verr),
+				l.cookieDiagnostic(ctx, "validate-cookie"),
+			))
 			return false
 		}
 		if valid {
@@ -544,10 +546,26 @@ func (l *gameBananaLogin) pollOnce(ctx context.Context, validate gamebanana.Cook
 		l.mu.Lock()
 		l.lastCandidates = nil
 		l.mu.Unlock()
-	} else if l.log != nil {
-		l.log.Warn("gamebanana invalid cookie cleanup failed", "GameBananaLogin")
+	} else {
+		diagnostic := l.cookieDiagnostic(ctx, "delete-invalid-cookie")
+		diagnostic.Fields["cleanupFailed"] = true
+		diagnostic.Fields["candidateCount"] = len(untried)
+		_ = infra.ReportError(l.log, err, "GameBananaLogin", diagnostic)
 	}
 	return true
+}
+
+func (l *gameBananaLogin) cookieDiagnostic(ctx context.Context, stage string) infra.Diagnostic {
+	l.mu.Lock()
+	fields := map[string]any{
+		"uri": gameBananaCookieURI, "cookieName": "rmc",
+		"windowClosed": l.closed, "settled": l.settled,
+	}
+	l.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		fields["contextError"] = err.Error()
+	}
+	return infra.Diagnostic{Severity: infra.DiagnosticWarn, Operation: "login", Stage: stage, Fields: fields}
 }
 
 func (l *gameBananaLogin) pollInterval() time.Duration {
@@ -646,7 +664,7 @@ func classifyLoginWindowError(err error) error {
 		return nil
 	}
 	if errors.Is(err, application.ErrWebviewCookiesUnsupported) {
-		return gamebanana.ErrAutoLoginUnsupported
+		return infra.WithCause(gamebanana.ErrAutoLoginUnsupported, err)
 	}
-	return gamebanana.ClassifyLoginError(err)
+	return infra.WithCause(gamebanana.ClassifyLoginError(err), err)
 }

--- a/internal/app/gamebanana_login.go
+++ b/internal/app/gamebanana_login.go
@@ -546,7 +546,7 @@ func (l *gameBananaLogin) pollOnce(ctx context.Context, validate gamebanana.Cook
 		l.mu.Lock()
 		l.lastCandidates = nil
 		l.mu.Unlock()
-	} else {
+	} else if !errors.Is(err, context.Canceled) {
 		diagnostic := l.cookieDiagnostic(ctx, "delete-invalid-cookie")
 		diagnostic.Fields["cleanupFailed"] = true
 		diagnostic.Fields["candidateCount"] = len(untried)

--- a/internal/app/gamebanana_login_diagnostic_test.go
+++ b/internal/app/gamebanana_login_diagnostic_test.go
@@ -1,0 +1,174 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+
+	"nahida.live/desktop/internal/gamebanana"
+	"nahida.live/desktop/internal/infra"
+)
+
+func TestGameBananaCookieCleanupDiagnostic(t *testing.T) {
+	var output bytes.Buffer
+	win := newFakeLoginWindow(application.WebviewCookie{Name: "rmc", Value: "candidate-secret"})
+	win.deleteErr = errors.New("DeleteCookies E_INVALIDARG rmc=error-secret")
+	login := newGameBananaLogin()
+	login.window = win
+	login.log = infra.NewLogWithOptions(infra.LogOptions{Writer: &output, DisableFile: true})
+	validations := 0
+	validate := func(context.Context, string) (bool, error) {
+		validations++
+		return false, nil
+	}
+	for range 2 {
+		if !login.pollOnce(context.Background(), validate) {
+			t.Fatal("cleanup failure stopped polling")
+		}
+	}
+	for _, want := range []string{"DeleteCookies E_INVALIDARG", `"stage":"delete-invalid-cookie"`, `"operation":"login"`, `"cookieName":"rmc"`, gameBananaCookieURI, `"cleanupFailed":true`, `"candidateCount":1`, `"windowClosed":false`, `"settled":false`} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("missing %q: %s", want, output.String())
+		}
+	}
+	if strings.Contains(output.String(), "candidate-secret") || strings.Contains(output.String(), "error-secret") {
+		t.Fatal("cookie value leaked")
+	}
+	if validations != 1 || win.closed.Load() || strings.Count(output.String(), "\n") != 1 {
+		t.Fatalf("cleanup behavior changed: validations=%d, closed=%v, log=%s", validations, win.closed.Load(), output.String())
+	}
+}
+
+func TestGameBananaCookiePollDiagnosticThrottle(t *testing.T) {
+	var output bytes.Buffer
+	now := time.Now()
+	win := newFakeLoginWindow()
+	win.getErr = errors.New("GetCookies E_FAIL Cookie: poll-secret")
+	login := newGameBananaLogin()
+	login.window = win
+	login.log = infra.NewLogWithOptions(infra.LogOptions{Writer: &output, DisableFile: true, Now: func() time.Time { return now }})
+	poll := func() {
+		t.Helper()
+		if !login.pollOnce(context.Background(), nil) {
+			t.Fatal("recoverable poll stopped")
+		}
+	}
+	poll()
+	poll()
+	if strings.Count(output.String(), "\n") != 1 {
+		t.Fatalf("identical failures were not throttled: %s", output.String())
+	}
+	now = now.Add(5 * time.Minute)
+	poll()
+	if !strings.Contains(output.String(), `"suppressedCount":1`) {
+		t.Fatalf("missing suppressed count: %s", output.String())
+	}
+	win.getErr = errors.New("GetCookies changed failure rmc=changed-secret")
+	poll()
+	win.getErr = nil
+	poll()
+	win.getErr = errors.New("GetCookies changed failure rmc=changed-secret")
+	poll()
+	if strings.Count(output.String(), "\n") != 4 {
+		t.Fatalf("changed/recovered failure was suppressed: %s", output.String())
+	}
+	for _, want := range []string{"GetCookies E_FAIL", `"stage":"poll-cookies"`, gameBananaCookieURI} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("missing %q: %s", want, output.String())
+		}
+	}
+	if strings.Contains(output.String(), "poll-secret") || strings.Contains(output.String(), "changed-secret") {
+		t.Fatal("cookie value leaked")
+	}
+}
+
+func TestGameBananaCookieDiagnosticsIgnoreCancellation(t *testing.T) {
+	for _, stage := range []string{"poll", "cleanup"} {
+		t.Run(stage, func(t *testing.T) {
+			var output bytes.Buffer
+			win := newFakeLoginWindow(application.WebviewCookie{Name: "rmc", Value: "secret"})
+			if stage == "poll" {
+				win.getErr = context.Canceled
+			} else {
+				win.deleteErr = context.Canceled
+			}
+			login := newGameBananaLogin()
+			login.window = win
+			login.log = infra.NewLogWithOptions(infra.LogOptions{Writer: &output, DisableFile: true})
+			login.pollOnce(context.Background(), func(context.Context, string) (bool, error) { return false, nil })
+			if output.Len() != 0 {
+				t.Fatalf("normal cancellation logged: %s", output.String())
+			}
+		})
+	}
+}
+
+func TestGameBananaCookiePollDeadlineDiagnostic(t *testing.T) {
+	var output bytes.Buffer
+	win := newFakeLoginWindow()
+	win.getErr = context.DeadlineExceeded
+	login := newGameBananaLogin()
+	login.window = win
+	login.log = infra.NewLogWithOptions(infra.LogOptions{Writer: &output, DisableFile: true})
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	if login.pollOnce(ctx, nil) {
+		t.Fatal("deadline did not stop polling")
+	}
+	if !strings.Contains(output.String(), `"contextError":"context deadline exceeded"`) {
+		t.Fatalf("deadline context missing: %s", output.String())
+	}
+}
+
+func TestGameBananaLoginDiagnosticPreservesClassifiedCause(t *testing.T) {
+	for _, stage := range []string{"validate-cookie", "create-login-window", "logout-shared-webview-profile", "poll-cookies"} {
+		t.Run(stage, func(t *testing.T) {
+			var output bytes.Buffer
+			log := infra.NewLogWithOptions(infra.LogOptions{Writer: &output, DisableFile: true})
+			login := newGameBananaLogin()
+			login.log = log
+			cause := infra.AnnotateError(errors.New("native failure rmc=private-value"), infra.Diagnostic{Fields: map[string]any{"status": 503}})
+			wantCode := gamebanana.ErrAuthFailed
+			var err error
+			switch stage {
+			case "validate-cookie", "poll-cookies":
+				win := newFakeLoginWindow(application.WebviewCookie{Name: "rmc", Value: "candidate-secret"})
+				login.window = win
+				if stage == "poll-cookies" {
+					win.getErr = fmt.Errorf("native failure: %w", application.ErrWebviewCookiesUnsupported)
+					wantCode = gamebanana.ErrAutoLoginUnsupported
+				}
+				login.pollOnce(context.Background(), func(context.Context, string) (bool, error) { return false, cause })
+				err = login.err
+			case "create-login-window":
+				login.factory = func() (loginWindow, error) { return nil, cause }
+				_, err = login.Open(context.Background(), nil)
+			case "logout-shared-webview-profile":
+				login.factory = func() (loginWindow, error) { return newFakeLoginWindow(), nil }
+				login.logoutFactory = func() (loginWindow, error) { return nil, cause }
+				_, err = login.Open(context.Background(), nil)
+			}
+			if err == nil || err.Error() != wantCode.Error() || !errors.Is(err, wantCode) {
+				t.Fatalf("public contract changed: %v", err)
+			}
+			_ = infra.ReportError(log, infra.WithCause(gamebanana.ClassifyLoginError(err), err), "GameBananaService.login", infra.Diagnostic{Severity: infra.DiagnosticWarn, Operation: "login", Stage: "open-login"})
+			for _, want := range []string{"native failure", stage} {
+				if !strings.Contains(output.String(), want) {
+					t.Fatalf("missing %q: %s", want, output.String())
+				}
+			}
+			if stage != "poll-cookies" && !strings.Contains(output.String(), `"status":503`) {
+				t.Fatalf("inner diagnostic lost: %s", output.String())
+			}
+			if strings.Contains(output.String(), "private-value") || strings.Contains(output.String(), "candidate-secret") {
+				t.Fatal("cookie value leaked")
+			}
+		})
+	}
+}

--- a/internal/app/gamebanana_login_test.go
+++ b/internal/app/gamebanana_login_test.go
@@ -19,6 +19,8 @@ import (
 type fakeLoginWindow struct {
 	mu                 sync.Mutex
 	cookies            []application.WebviewCookie
+	getErr             error
+	deleteErr          error
 	gets               atomic.Int32
 	inFlight           atomic.Int32
 	maxFlight          atomic.Int32
@@ -82,6 +84,9 @@ func (w *fakeLoginWindow) GetCookies(ctx context.Context, uri string) ([]applica
 	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if w.getErr != nil {
+		return nil, w.getErr
+	}
 	if w.cookieScopeURI != "" && uri != w.cookieScopeURI {
 		return nil, nil
 	}
@@ -90,6 +95,9 @@ func (w *fakeLoginWindow) GetCookies(ctx context.Context, uri string) ([]applica
 func (w *fakeLoginWindow) DeleteCookies(_ context.Context, uri string, names ...string) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if w.deleteErr != nil {
+		return w.deleteErr
+	}
 	if w.cookieScopeURI != "" && uri != w.cookieScopeURI {
 		return nil
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GameBanana login error reporting with clearer diagnostic details.
  - Login timeouts and validation failures now provide more informative, cause-preserving errors.
  - Unsupported cookie-based login failures are classified and reported consistently.
  - Repeated polling failures are throttled to reduce duplicate diagnostics, while sensitive cookie values remain protected.
  - Normal login cancellation continues without generating unnecessary diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->