### PR TITLE
fix(protocol): assemble chunked body-shape memory uploads

### DIFF
--- a/frontend/src/wails/binary-memory.test.ts
+++ b/frontend/src/wails/binary-memory.test.ts
@@ -66,4 +66,35 @@ describe("binary memory transport", () => {
         await uploadTypedArray("/upload", payload);
         expect(bodies).toEqual([binaryUploadChunkBytes, 16]);
     });
+
+    it("rejects a failed chunk and does not start later chunks", async () => {
+        const fetchMock = vi.fn(async () => {
+            if (fetchMock.mock.calls.length === 1) {
+                return new Response(null, { status: 204 });
+            }
+            return new Response(null, { status: 400 });
+        });
+        vi.stubGlobal("fetch", fetchMock);
+        const payload = new Uint8Array(binaryUploadChunkBytes * 2 + 16);
+
+        await expect(uploadTypedArray("/upload", payload)).rejects.toMatchObject({
+            status: 400,
+        } satisfies Partial<BinaryTransportError>);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("rejects an aborted chunk and does not start later chunks", async () => {
+        const abortError = new DOMException("Aborted", "AbortError");
+        const fetchMock = vi.fn(async () => {
+            if (fetchMock.mock.calls.length === 1) {
+                return new Response(null, { status: 204 });
+            }
+            throw abortError;
+        });
+        vi.stubGlobal("fetch", fetchMock);
+        const payload = new Uint8Array(binaryUploadChunkBytes * 2 + 16);
+
+        await expect(uploadTypedArray("/upload", payload)).rejects.toBe(abortError);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
 });

--- a/frontend/src/wails/binary-memory.test.ts
+++ b/frontend/src/wails/binary-memory.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { BinaryTransportError, fetchFloat32, fetchUint32, uploadTypedArray } from "./binary-memory";
+import {
+    BinaryTransportError,
+    binaryUploadChunkBytes,
+    fetchFloat32,
+    fetchUint32,
+    uploadTypedArray,
+} from "./binary-memory";
 
 afterEach(() => vi.unstubAllGlobals());
 
@@ -46,5 +52,18 @@ describe("binary memory transport", () => {
 
         await uploadTypedArray("/upload", bytes.subarray(1, 3));
         expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it("splits large uploads into WebView-safe chunks", async () => {
+        const bodies: number[] = [];
+        const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+            bodies.push((init?.body as Uint8Array).byteLength);
+            return new Response(null, { status: 204 });
+        });
+        vi.stubGlobal("fetch", fetchMock);
+        const payload = new Uint8Array(binaryUploadChunkBytes + 16);
+
+        await uploadTypedArray("/upload", payload);
+        expect(bodies).toEqual([binaryUploadChunkBytes, 16]);
     });
 });

--- a/frontend/src/wails/binary-memory.ts
+++ b/frontend/src/wails/binary-memory.ts
@@ -69,24 +69,33 @@ export async function fetchUint32(
     return new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 4);
 }
 
+// WebView2 delivers at most ~2MB per intercepted request body. Stay well under
+// that cap and copy each slice so fetch cannot send the backing ArrayBuffer.
+export const binaryUploadChunkBytes = 512 * 1024;
+
 export async function uploadTypedArray(
     url: string,
     value: ArrayBufferView<ArrayBufferLike>,
     signal?: AbortSignal,
 ): Promise<void> {
     const bytes = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
-    const response = await fetch(url, {
-        method: "PUT",
-        headers: { "Content-Type": "application/octet-stream" },
-        body: bytes as unknown as BodyInit,
-        signal,
-    });
-    if (!response.ok) {
-        throw new BinaryTransportError(
-            `Failed to upload binary buffer: ${url} (${response.status})`,
-            response.status,
-        );
-    }
+    let offset = 0;
+    do {
+        const chunk = bytes.slice(offset, offset + binaryUploadChunkBytes);
+        const response = await fetch(url, {
+            method: "PUT",
+            headers: { "Content-Type": "application/octet-stream" },
+            body: chunk as unknown as BodyInit,
+            signal,
+        });
+        if (!response.ok) {
+            throw new BinaryTransportError(
+                `Failed to upload binary buffer: ${url} (${response.status})`,
+                response.status,
+            );
+        }
+        offset += chunk.byteLength;
+    } while (offset < bytes.byteLength);
 }
 
 export function isAbortError(error: unknown): boolean {

--- a/internal/infra/protocol.go
+++ b/internal/infra/protocol.go
@@ -289,9 +289,17 @@ func (p *Protocol) serveMemoryUpload(w http.ResponseWriter, request *http.Reques
 		http.Error(w, "memory upload already used", http.StatusConflict)
 		return
 	}
-	if request.ContentLength != upload.expected {
+	received := int64(len(upload.data))
+	remaining := upload.expected - received
+	// WebView2 often omits Content-Length on intercepted PUT bodies, and the
+	// frontend splits large buffers into chunks under the ~2MB delivery cap.
+	// Reject only a declared length that cannot fit in the remaining slot.
+	if request.ContentLength > remaining {
 		delete(session.uploads, uploadID)
+		expected := upload.expected
+		contentLength := request.ContentLength
 		p.mu.Unlock()
+		p.reportProtocolFailure(errors.New("memory upload content length exceeds remaining slot"), request, "validate-memory-upload-length", map[string]any{"expectedBytes": expected, "receivedBytes": received, "contentLength": contentLength})
 		http.Error(w, "content length does not match upload slot", http.StatusBadRequest)
 		return
 	}
@@ -299,13 +307,13 @@ func (p *Protocol) serveMemoryUpload(w http.ResponseWriter, request *http.Reques
 	expected := upload.expected
 	p.mu.Unlock()
 
-	data, err := io.ReadAll(io.LimitReader(request.Body, expected+1))
-	if err != nil || int64(len(data)) != expected {
+	data, err := io.ReadAll(io.LimitReader(request.Body, remaining+1))
+	if err != nil || int64(len(data)) > remaining {
 		failure := err
 		if failure == nil {
 			failure = errors.New("memory upload length mismatch")
 		}
-		p.reportProtocolFailure(failure, request, "read-memory-upload", map[string]any{"expectedBytes": expected, "receivedBytes": len(data)})
+		p.reportProtocolFailure(failure, request, "read-memory-upload", map[string]any{"expectedBytes": expected, "receivedBytes": received, "chunkBytes": len(data)})
 		p.mu.Lock()
 		if current := p.sessions[sessionID]; current != nil && current.uploads[uploadID] == upload {
 			delete(current.uploads, uploadID)
@@ -321,7 +329,11 @@ func (p *Protocol) serveMemoryUpload(w http.ResponseWriter, request *http.Reques
 		http.NotFound(w, request)
 		return
 	}
-	upload.data, upload.uploading, upload.ready = data, false, true
+	if upload.data == nil && expected > 0 {
+		upload.data = make([]byte, 0, expected)
+	}
+	upload.data = append(upload.data, data...)
+	upload.uploading, upload.ready = false, int64(len(upload.data)) == expected
 	p.mu.Unlock()
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/infra/protocol_test.go
+++ b/internal/infra/protocol_test.go
@@ -228,6 +228,23 @@ func TestProtocolMemoryUploadAcceptsMissingContentLengthAndChunks(t *testing.T) 
 	if err != nil || string(got) != "meshdata" {
 		t.Fatalf("TakeMemoryUpload = %q, %v", got, err)
 	}
+
+	overflowURL, err := service.CreateMemoryUpload(session, "overflow", 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	overflow := httptest.NewRequest(http.MethodPut, overflowURL, strings.NewReader("meshdata!"))
+	overflow.Header.Set("Content-Type", "application/octet-stream")
+	overflow.ContentLength = -1
+	overflow.Header.Del("Content-Length")
+	overflowRecorder := httptest.NewRecorder()
+	service.ServeHTTP(overflowRecorder, overflow)
+	if overflowRecorder.Code != http.StatusBadRequest {
+		t.Fatalf("overflow chunk = %d %s", overflowRecorder.Code, overflowRecorder.Body.String())
+	}
+	if _, err := service.TakeMemoryUpload(session, "overflow"); err == nil {
+		t.Fatal("overflow upload remained consumable")
+	}
 }
 
 func TestProtocolRejectsOversizedMemoryUploadSlot(t *testing.T) {

--- a/internal/infra/protocol_test.go
+++ b/internal/infra/protocol_test.go
@@ -137,11 +137,26 @@ func TestProtocolRejectsInvalidMemoryUploads(t *testing.T) {
 	shortRequest.Header.Set("Content-Type", "application/octet-stream")
 	short := httptest.NewRecorder()
 	service.ServeHTTP(short, shortRequest)
-	if short.Code != http.StatusBadRequest {
+	if short.Code != http.StatusNoContent {
 		t.Fatalf("short upload = %d", short.Code)
 	}
 	if _, err = service.TakeMemoryUpload(session, "short"); err == nil {
 		t.Fatal("short upload remained consumable")
+	}
+
+	oversizeURL, err := service.CreateMemoryUpload(session, "oversize", 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oversizeRequest := httptest.NewRequest(http.MethodPut, oversizeURL, strings.NewReader("toolong"))
+	oversizeRequest.Header.Set("Content-Type", "application/octet-stream")
+	oversize := httptest.NewRecorder()
+	service.ServeHTTP(oversize, oversizeRequest)
+	if oversize.Code != http.StatusBadRequest {
+		t.Fatalf("oversize upload = %d", oversize.Code)
+	}
+	if _, err = service.TakeMemoryUpload(session, "oversize"); err == nil {
+		t.Fatal("oversize upload remained consumable")
 	}
 
 	duplicateURL, err := service.CreateMemoryUpload(session, "duplicate", 4)
@@ -175,6 +190,43 @@ func TestProtocolRejectsInvalidMemoryUploads(t *testing.T) {
 	service.ServeHTTP(afterCleanup, request)
 	if afterCleanup.Code != http.StatusNotFound {
 		t.Fatalf("after cleanup = %d", afterCleanup.Code)
+	}
+}
+
+func TestProtocolMemoryUploadAcceptsMissingContentLengthAndChunks(t *testing.T) {
+	t.Parallel()
+	service := NewProtocol()
+	session := service.CreateMemorySession()
+	uploadURL, err := service.CreateMemoryUpload(session, "positions", 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first := httptest.NewRequest(http.MethodPut, uploadURL, strings.NewReader("mesh"))
+	first.Header.Set("Content-Type", "application/octet-stream")
+	first.ContentLength = -1
+	first.Header.Del("Content-Length")
+	firstRecorder := httptest.NewRecorder()
+	service.ServeHTTP(firstRecorder, first)
+	if firstRecorder.Code != http.StatusNoContent {
+		t.Fatalf("first chunk = %d %s", firstRecorder.Code, firstRecorder.Body.String())
+	}
+	if _, err := service.TakeMemoryUpload(session, "positions"); err == nil {
+		t.Fatal("partial upload was consumable")
+	}
+
+	second := httptest.NewRequest(http.MethodPut, uploadURL, strings.NewReader("data"))
+	second.Header.Set("Content-Type", "application/octet-stream")
+	second.ContentLength = -1
+	second.Header.Del("Content-Length")
+	secondRecorder := httptest.NewRecorder()
+	service.ServeHTTP(secondRecorder, second)
+	if secondRecorder.Code != http.StatusNoContent {
+		t.Fatalf("second chunk = %d %s", secondRecorder.Code, secondRecorder.Body.String())
+	}
+	got, err := service.TakeMemoryUpload(session, "positions")
+	if err != nil || string(got) != "meshdata" {
+		t.Fatalf("TakeMemoryUpload = %q, %v", got, err)
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/myparsleycat/nahida-desktop/issues/268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Large memory uploads now transfer in smaller chunks, improving reliability for substantial payloads.
  * Chunked uploads can proceed without a declared content length and are assembled automatically until complete.

* **Bug Fixes**
  * Uploads exceeding the expected size are rejected.
  * Incomplete uploads remain unavailable until all expected data has been received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->