### PR TITLE
perf(tools): decode WWMI dump hints from small DDS mips

### DIFF
--- a/internal/tools/model_viewer_material.go
+++ b/internal/tools/model_viewer_material.go
@@ -369,11 +369,7 @@ func decodeModelViewerTextureSource(ctx context.Context, path string) (*modelVie
 		var raw []byte
 		raw, err = os.ReadFile(path)
 		if err == nil {
-			var width, height int
-			width, height, err = modelViewerTextureDimensions(raw, extension)
-			if err == nil && int64(width)*int64(height) > maxModelViewerTextureInputPixels {
-				err = fmt.Errorf("viewer texture dimensions exceed the input safety limit: %dx%d", width, height)
-			}
+			_, _, err = modelViewerTextureDimensions(raw, extension)
 		}
 		if err == nil {
 			rgba, err = decodeModelViewerImage(raw, extension)
@@ -529,27 +525,14 @@ func decodeModelViewerDDS(raw []byte) (*image.NRGBA, error) {
 }
 
 func decodeModelViewerDDSFile(path string, size int64) (*image.NRGBA, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = file.Close() }()
-	reader, err := ddsutil.NewDdsReader(file, size)
-	if err != nil {
-		return nil, err
-	}
-	metadata := reader.Metadata()
-	if int64(metadata.Width)*int64(metadata.Height) > maxModelViewerTextureInputPixels {
-		return nil, fmt.Errorf("viewer texture dimensions exceed the input safety limit: %dx%d", metadata.Width, metadata.Height)
-	}
-	if metadata.Depth != 1 {
-		return nil, fmt.Errorf("viewer texture must be two-dimensional: depth=%d", metadata.Depth)
-	}
-	mipmap, targetWidth, targetHeight := modelViewerPreviewMipmap(metadata.Width, metadata.Height, metadata.Mipmaps)
-	return decodeModelViewerDDSMip(reader, mipmap, uint32(targetWidth), uint32(targetHeight))
+	return decodeModelViewerDDSWithMip(path, size, modelViewerPreviewMipmap)
 }
 
 func decodeModelViewerDDSHint(path string, size int64) (*image.NRGBA, error) {
+	return decodeModelViewerDDSWithMip(path, size, wwmiHintMipmap)
+}
+
+func decodeModelViewerDDSWithMip(path string, size int64, selectMip func(width, height, mipmaps uint32) (uint32, uint32, uint32)) (*image.NRGBA, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -560,28 +543,14 @@ func decodeModelViewerDDSHint(path string, size int64) (*image.NRGBA, error) {
 		return nil, err
 	}
 	metadata := reader.Metadata()
-	if int64(metadata.Width)*int64(metadata.Height) > maxModelViewerTextureInputPixels {
+	if texturePixelCount(metadata.Width, metadata.Height) > uint64(maxModelViewerTextureInputPixels) {
 		return nil, fmt.Errorf("viewer texture dimensions exceed the input safety limit: %dx%d", metadata.Width, metadata.Height)
 	}
 	if metadata.Depth != 1 {
 		return nil, fmt.Errorf("viewer texture must be two-dimensional: depth=%d", metadata.Depth)
 	}
-	mipmap, targetWidth, targetHeight := wwmiHintMipmap(metadata.Width, metadata.Height, metadata.Mipmaps)
-	return decodeModelViewerDDSMip(reader, mipmap, uint32(targetWidth), uint32(targetHeight))
-}
-
-func modelViewerPreviewMipmap(width, height, mipmaps uint32) (uint32, int, int) {
-	targetWidth, targetHeight := viewerPreviewTextureSize(int(width), int(height))
-	mipmap := uint32(0)
-	for mipmap+1 < max(uint32(1), mipmaps) {
-		mipWidth := ddsutil.MipDimension(width, mipmap)
-		mipHeight := ddsutil.MipDimension(height, mipmap)
-		if int64(mipWidth)*int64(mipHeight) <= maxModelViewerTextureOutputPixels {
-			break
-		}
-		mipmap++
-	}
-	return mipmap, targetWidth, targetHeight
+	mipmap, targetWidth, targetHeight := selectMip(metadata.Width, metadata.Height, metadata.Mipmaps)
+	return decodeModelViewerDDSMip(reader, mipmap, targetWidth, targetHeight)
 }
 
 func decodeModelViewerDDSMip(reader *ddsutil.DdsReader, mipmap, targetWidth, targetHeight uint32) (*image.NRGBA, error) {
@@ -618,77 +587,105 @@ func imageToNRGBA(src image.Image) *image.NRGBA {
 	return dst
 }
 
+func texturePixelCount(width, height uint32) uint64 {
+	return uint64(width) * uint64(height)
+}
+
+func textureArea(width, height uint32) int {
+	count := texturePixelCount(width, height)
+	if count > uint64(math.MaxInt) {
+		return math.MaxInt
+	}
+	return int(count)
+}
+
+func fitTextureSize(width, height uint32, maxPixels uint64) (uint32, uint32) {
+	for texturePixelCount(width, height) > maxPixels && (width > 1 || height > 1) {
+		width = max(uint32(1), width/2)
+		height = max(uint32(1), height/2)
+	}
+	return width, height
+}
+
+func selectMipForPixelBudget(width, height, mipmaps uint32, maxPixels uint64) (mipmap, mipWidth, mipHeight uint32) {
+	mipWidth, mipHeight = width, height
+	for mipmap+1 < max(uint32(1), mipmaps) {
+		if texturePixelCount(mipWidth, mipHeight) <= maxPixels {
+			break
+		}
+		mipmap++
+		mipWidth = ddsutil.MipDimension(width, mipmap)
+		mipHeight = ddsutil.MipDimension(height, mipmap)
+	}
+	return mipmap, mipWidth, mipHeight
+}
+
+func modelViewerPreviewMipmap(width, height, mipmaps uint32) (uint32, uint32, uint32) {
+	mipmap, _, _ := selectMipForPixelBudget(width, height, mipmaps, uint64(maxModelViewerTextureOutputPixels))
+	targetWidth, targetHeight := fitTextureSize(width, height, uint64(maxModelViewerTextureOutputPixels))
+	return mipmap, targetWidth, targetHeight
+}
+
+func wwmiHintMipmap(width, height, mipmaps uint32) (uint32, uint32, uint32) {
+	mipmap, mipWidth, mipHeight := selectMipForPixelBudget(width, height, mipmaps, uint64(maxHintAnalyzePixels))
+	targetWidth, targetHeight := fitTextureSize(mipWidth, mipHeight, uint64(maxHintAnalyzePixels))
+	return mipmap, targetWidth, targetHeight
+}
+
 func modelViewerTextureDimensions(raw []byte, extension string) (int, int, error) {
 	switch strings.ToLower(extension) {
 	case ".dds":
 		if len(raw) < 20 || string(raw[:4]) != "DDS " {
 			return 0, 0, fmt.Errorf("invalid DDS texture header")
 		}
-		width := int(binary.LittleEndian.Uint32(raw[16:20]))
-		height := int(binary.LittleEndian.Uint32(raw[12:16]))
-		if width <= 0 || height <= 0 {
+		width := binary.LittleEndian.Uint32(raw[16:20])
+		height := binary.LittleEndian.Uint32(raw[12:16])
+		if width == 0 || height == 0 {
 			return 0, 0, fmt.Errorf("invalid DDS texture dimensions")
 		}
-		return width, height, nil
+		if texturePixelCount(width, height) > uint64(maxModelViewerTextureInputPixels) {
+			return 0, 0, fmt.Errorf("viewer texture dimensions exceed the input safety limit: %dx%d", width, height)
+		}
+		return int(width), int(height), nil
 	case ".png":
 		if len(raw) < 24 || !bytes.Equal(raw[:8], []byte{137, 80, 78, 71, 13, 10, 26, 10}) {
 			return 0, 0, fmt.Errorf("invalid PNG texture header")
 		}
-		width := int(binary.BigEndian.Uint32(raw[16:20]))
-		height := int(binary.BigEndian.Uint32(raw[20:24]))
-		if width <= 0 || height <= 0 {
+		width := binary.BigEndian.Uint32(raw[16:20])
+		height := binary.BigEndian.Uint32(raw[20:24])
+		if width == 0 || height == 0 {
 			return 0, 0, fmt.Errorf("invalid PNG texture dimensions")
 		}
-		return width, height, nil
+		if texturePixelCount(width, height) > uint64(maxModelViewerTextureInputPixels) {
+			return 0, 0, fmt.Errorf("viewer texture dimensions exceed the input safety limit: %dx%d", width, height)
+		}
+		return int(width), int(height), nil
 	default:
 		configuration, _, err := image.DecodeConfig(bytes.NewReader(raw))
 		if err != nil {
 			return 0, 0, err
 		}
+		if configuration.Width <= 0 || configuration.Height <= 0 {
+			return 0, 0, fmt.Errorf("invalid texture dimensions")
+		}
+		if uint64(configuration.Width)*uint64(configuration.Height) > uint64(maxModelViewerTextureInputPixels) {
+			return 0, 0, fmt.Errorf("viewer texture dimensions exceed the input safety limit: %dx%d", configuration.Width, configuration.Height)
+		}
 		return configuration.Width, configuration.Height, nil
 	}
-}
-
-func viewerPreviewTextureSize(width, height int) (int, int) {
-	for int64(width)*int64(height) > maxModelViewerTextureOutputPixels && (width > 1 || height > 1) {
-		width = max(1, width/2)
-		height = max(1, height/2)
-	}
-	return width, height
-}
-
-func wwmiHintAnalyzeSize(width, height int) (int, int) {
-	for int64(width)*int64(height) > maxHintAnalyzePixels && (width > 1 || height > 1) {
-		width = max(1, width/2)
-		height = max(1, height/2)
-	}
-	return width, height
-}
-
-func wwmiHintMipmap(width, height, mipmaps uint32) (uint32, int, int) {
-	mipmap := uint32(0)
-	mipWidth, mipHeight := int(width), int(height)
-	for mipmap+1 < max(uint32(1), mipmaps) {
-		if int64(mipWidth)*int64(mipHeight) <= maxHintAnalyzePixels {
-			break
-		}
-		mipmap++
-		mipWidth = int(ddsutil.MipDimension(width, mipmap))
-		mipHeight = int(ddsutil.MipDimension(height, mipmap))
-	}
-	targetWidth, targetHeight := wwmiHintAnalyzeSize(mipWidth, mipHeight)
-	return mipmap, targetWidth, targetHeight
 }
 
 func downscaleModelViewerTexture(source *image.NRGBA, maxPixels int64) *image.NRGBA {
 	if source == nil || maxPixels <= 0 {
 		return source
 	}
-	for int64(source.Bounds().Dx())*int64(source.Bounds().Dy()) > maxPixels {
-		width, height := max(1, source.Bounds().Dx()/2), max(1, source.Bounds().Dy()/2)
-		source = downsampleModelViewerTextureHalf(source, width, height)
+	for {
+		width, height := source.Bounds().Dx(), source.Bounds().Dy()
+		if width <= 0 || height <= 0 || uint64(width)*uint64(height) <= uint64(maxPixels) {
+			return source
+		}
+		source = downsampleModelViewerTextureHalf(source, max(1, width/2), max(1, height/2))
 	}
-	return source
 }
 
 func downsampleModelViewerTextureHalf(source *image.NRGBA, width, height int) *image.NRGBA {

--- a/internal/tools/model_viewer_material.go
+++ b/internal/tools/model_viewer_material.go
@@ -517,6 +517,9 @@ func decodeModelViewerImage(raw []byte, extension string) (*image.NRGBA, error) 
 }
 
 func decodeModelViewerDDS(raw []byte) (*image.NRGBA, error) {
+	if _, _, err := modelViewerTextureDimensions(raw, ".dds"); err != nil {
+		return nil, err
+	}
 	reader, err := ddsutil.NewDdsReader(bytes.NewReader(raw), int64(len(raw)))
 	if err != nil {
 		return nil, err
@@ -538,14 +541,18 @@ func decodeModelViewerDDSWithMip(path string, size int64, selectMip func(width, 
 		return nil, err
 	}
 	defer func() { _ = file.Close() }()
+	// NewDdsReader can fail first with an unrelated format error for huge headers.
+	header := make([]byte, 20)
+	if n, headerErr := file.ReadAt(header, 0); headerErr == nil && n == 20 {
+		if _, _, err := modelViewerTextureDimensions(header, ".dds"); err != nil {
+			return nil, err
+		}
+	}
 	reader, err := ddsutil.NewDdsReader(file, size)
 	if err != nil {
 		return nil, err
 	}
 	metadata := reader.Metadata()
-	if texturePixelCount(metadata.Width, metadata.Height) > uint64(maxModelViewerTextureInputPixels) {
-		return nil, fmt.Errorf("viewer texture dimensions exceed the input safety limit: %dx%d", metadata.Width, metadata.Height)
-	}
 	if metadata.Depth != 1 {
 		return nil, fmt.Errorf("viewer texture must be two-dimensional: depth=%d", metadata.Depth)
 	}

--- a/internal/tools/model_viewer_material.go
+++ b/internal/tools/model_viewer_material.go
@@ -549,6 +549,27 @@ func decodeModelViewerDDSFile(path string, size int64) (*image.NRGBA, error) {
 	return decodeModelViewerDDSMip(reader, mipmap, uint32(targetWidth), uint32(targetHeight))
 }
 
+func decodeModelViewerDDSHint(path string, size int64) (*image.NRGBA, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	reader, err := ddsutil.NewDdsReader(file, size)
+	if err != nil {
+		return nil, err
+	}
+	metadata := reader.Metadata()
+	if int64(metadata.Width)*int64(metadata.Height) > maxModelViewerTextureInputPixels {
+		return nil, fmt.Errorf("viewer texture dimensions exceed the input safety limit: %dx%d", metadata.Width, metadata.Height)
+	}
+	if metadata.Depth != 1 {
+		return nil, fmt.Errorf("viewer texture must be two-dimensional: depth=%d", metadata.Depth)
+	}
+	mipmap, targetWidth, targetHeight := wwmiHintMipmap(metadata.Width, metadata.Height, metadata.Mipmaps)
+	return decodeModelViewerDDSMip(reader, mipmap, uint32(targetWidth), uint32(targetHeight))
+}
+
 func modelViewerPreviewMipmap(width, height, mipmaps uint32) (uint32, int, int) {
 	targetWidth, targetHeight := viewerPreviewTextureSize(int(width), int(height))
 	mipmap := uint32(0)
@@ -634,6 +655,29 @@ func viewerPreviewTextureSize(width, height int) (int, int) {
 		height = max(1, height/2)
 	}
 	return width, height
+}
+
+func wwmiHintAnalyzeSize(width, height int) (int, int) {
+	for int64(width)*int64(height) > maxHintAnalyzePixels && (width > 1 || height > 1) {
+		width = max(1, width/2)
+		height = max(1, height/2)
+	}
+	return width, height
+}
+
+func wwmiHintMipmap(width, height, mipmaps uint32) (uint32, int, int) {
+	mipmap := uint32(0)
+	mipWidth, mipHeight := int(width), int(height)
+	for mipmap+1 < max(uint32(1), mipmaps) {
+		if int64(mipWidth)*int64(mipHeight) <= maxHintAnalyzePixels {
+			break
+		}
+		mipmap++
+		mipWidth = int(ddsutil.MipDimension(width, mipmap))
+		mipHeight = int(ddsutil.MipDimension(height, mipmap))
+	}
+	targetWidth, targetHeight := wwmiHintAnalyzeSize(mipWidth, mipHeight)
+	return mipmap, targetWidth, targetHeight
 }
 
 func downscaleModelViewerTexture(source *image.NRGBA, maxPixels int64) *image.NRGBA {

--- a/internal/tools/model_viewer_material_test.go
+++ b/internal/tools/model_viewer_material_test.go
@@ -215,14 +215,17 @@ func TestModelViewerTextureRejectsMaxUint32Dimensions(t *testing.T) {
 	if err := os.WriteFile(ddsPath, ddsHeader, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := decodeModelViewerDDSFile(ddsPath, int64(len(ddsHeader))); err == nil {
-		t.Fatal("oversized DDS decoded")
+	if _, err := decodeModelViewerDDS(ddsHeader); err == nil || !strings.Contains(err.Error(), "input safety limit") {
+		t.Fatalf("oversized DDS in-memory decode err = %v", err)
 	}
-	if _, err := decodeModelViewerDDSHint(ddsPath, int64(len(ddsHeader))); err == nil {
-		t.Fatal("oversized DDS hint decoded")
+	if _, err := decodeModelViewerDDSFile(ddsPath, int64(len(ddsHeader))); err == nil || !strings.Contains(err.Error(), "input safety limit") {
+		t.Fatalf("oversized DDS decode err = %v", err)
 	}
-	if _, err := prepareModelViewerTexture(context.Background(), ddsPath, "Diffuse", "png", 85); err == nil {
-		t.Fatal("oversized DDS prepared")
+	if _, err := decodeModelViewerDDSHint(ddsPath, int64(len(ddsHeader))); err == nil || !strings.Contains(err.Error(), "input safety limit") {
+		t.Fatalf("oversized DDS hint decode err = %v", err)
+	}
+	if _, err := prepareModelViewerTexture(context.Background(), ddsPath, "Diffuse", "png", 85); err == nil || !strings.Contains(err.Error(), "input safety limit") {
+		t.Fatalf("oversized DDS prepare err = %v", err)
 	}
 }
 

--- a/internal/tools/model_viewer_material_test.go
+++ b/internal/tools/model_viewer_material_test.go
@@ -7,6 +7,7 @@ import (
 	"image"
 	"image/color"
 	"image/png"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -148,12 +149,16 @@ func TestPrepareModelViewerTextureDecodesUncompressedDDS(t *testing.T) {
 }
 
 func encodeUncompressedDDS(pixel color.NRGBA) []byte {
+	return append(encodeUncompressedDDSHeader(1, 1), pixel.B, pixel.G, pixel.R, pixel.A)
+}
+
+func encodeUncompressedDDSHeader(width, height uint32) []byte {
 	header := make([]byte, 128)
 	copy(header[:4], "DDS ")
 	binary.LittleEndian.PutUint32(header[4:8], 124)
 	binary.LittleEndian.PutUint32(header[8:12], 0x100f)
-	binary.LittleEndian.PutUint32(header[12:16], 1)
-	binary.LittleEndian.PutUint32(header[16:20], 1)
+	binary.LittleEndian.PutUint32(header[12:16], height)
+	binary.LittleEndian.PutUint32(header[16:20], width)
 	binary.LittleEndian.PutUint32(header[20:24], 4)
 	binary.LittleEndian.PutUint32(header[76:80], 32)
 	binary.LittleEndian.PutUint32(header[80:84], 0x41)
@@ -163,7 +168,7 @@ func encodeUncompressedDDS(pixel color.NRGBA) []byte {
 	binary.LittleEndian.PutUint32(header[100:104], 0x000000ff)
 	binary.LittleEndian.PutUint32(header[104:108], 0xff000000)
 	binary.LittleEndian.PutUint32(header[108:112], 0x1000)
-	return append(header, pixel.B, pixel.G, pixel.R, pixel.A)
+	return header
 }
 
 func TestModelViewerTextureRejectsDeclaredOversizedPNG(t *testing.T) {
@@ -182,21 +187,66 @@ func TestModelViewerTextureRejectsDeclaredOversizedPNG(t *testing.T) {
 	}
 }
 
-func TestViewerPreviewTextureSize(t *testing.T) {
+func TestModelViewerTextureRejectsMaxUint32Dimensions(t *testing.T) {
+	t.Parallel()
+	pngHeader := make([]byte, 24)
+	copy(pngHeader, []byte{137, 80, 78, 71, 13, 10, 26, 10})
+	copy(pngHeader[12:16], "IHDR")
+	binary.BigEndian.PutUint32(pngHeader[16:20], math.MaxUint32)
+	binary.BigEndian.PutUint32(pngHeader[20:24], math.MaxUint32)
+	if _, _, err := modelViewerTextureDimensions(pngHeader, ".png"); err == nil || !strings.Contains(err.Error(), "input safety limit") {
+		t.Fatalf("png dimensions err = %v", err)
+	}
+
+	pngPath := filepath.Join(t.TempDir(), "maxuint32.png")
+	if err := os.WriteFile(pngPath, pngHeader, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareModelViewerTexture(context.Background(), pngPath, "Diffuse", "png", 85); err == nil || !strings.Contains(err.Error(), "input safety limit") {
+		t.Fatalf("prepare png err = %v", err)
+	}
+
+	ddsHeader := encodeUncompressedDDSHeader(math.MaxUint32, math.MaxUint32)
+	if _, _, err := modelViewerTextureDimensions(ddsHeader, ".dds"); err == nil || !strings.Contains(err.Error(), "input safety limit") {
+		t.Fatalf("dds dimensions err = %v", err)
+	}
+
+	ddsPath := filepath.Join(t.TempDir(), "maxuint32.dds")
+	if err := os.WriteFile(ddsPath, ddsHeader, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodeModelViewerDDSFile(ddsPath, int64(len(ddsHeader))); err == nil {
+		t.Fatal("oversized DDS decoded")
+	}
+	if _, err := decodeModelViewerDDSHint(ddsPath, int64(len(ddsHeader))); err == nil {
+		t.Fatal("oversized DDS hint decoded")
+	}
+	if _, err := prepareModelViewerTexture(context.Background(), ddsPath, "Diffuse", "png", 85); err == nil {
+		t.Fatal("oversized DDS prepared")
+	}
+}
+
+func TestFitTextureSize(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		width, height, wantW, wantH int
+		width, height, wantW, wantH uint32
+		maxPixels                   uint64
 	}{
-		{8192, 8192, 2048, 2048},
-		{2048, 8192, 1024, 4096},
-		{4096, 4096, 2048, 2048},
-		{2048, 2048, 2048, 2048},
+		{8192, 8192, 2048, 2048, uint64(maxModelViewerTextureOutputPixels)},
+		{2048, 8192, 1024, 4096, uint64(maxModelViewerTextureOutputPixels)},
+		{4096, 4096, 2048, 2048, uint64(maxModelViewerTextureOutputPixels)},
+		{2048, 2048, 2048, 2048, uint64(maxModelViewerTextureOutputPixels)},
+		{math.MaxUint32, math.MaxUint32, 2047, 2047, uint64(maxModelViewerTextureOutputPixels)},
+		{4096, 4096, 256, 256, uint64(maxHintAnalyzePixels)},
+		{256, 256, 256, 256, uint64(maxHintAnalyzePixels)},
+		{128, 128, 128, 128, uint64(maxHintAnalyzePixels)},
+		{math.MaxUint32, math.MaxUint32, 255, 255, uint64(maxHintAnalyzePixels)},
 	}
 	for _, test := range cases {
-		gotW, gotH := viewerPreviewTextureSize(test.width, test.height)
+		gotW, gotH := fitTextureSize(test.width, test.height, test.maxPixels)
 		if gotW != test.wantW || gotH != test.wantH {
-			t.Fatalf("viewerPreviewTextureSize(%d, %d) = %d×%d, want %d×%d",
-				test.width, test.height, gotW, gotH, test.wantW, test.wantH)
+			t.Fatalf("fitTextureSize(%d, %d, %d) = %d×%d, want %d×%d",
+				test.width, test.height, test.maxPixels, gotW, gotH, test.wantW, test.wantH)
 		}
 	}
 }
@@ -207,7 +257,7 @@ func TestModelViewerPreviewMipmap(t *testing.T) {
 		width, height uint32
 		mipmaps       uint32
 		wantMip       uint32
-		wantW, wantH  int
+		wantW, wantH  uint32
 	}{
 		{8192, 8192, 14, 2, 2048, 2048},
 		{2048, 8192, 14, 1, 1024, 4096},
@@ -215,6 +265,8 @@ func TestModelViewerPreviewMipmap(t *testing.T) {
 		{8192, 8192, 2, 1, 2048, 2048},
 		{4096, 4096, 2, 1, 2048, 2048},
 		{2048, 2048, 1, 0, 2048, 2048},
+		{math.MaxUint32, math.MaxUint32, 1, 0, 2047, 2047},
+		{math.MaxUint32, math.MaxUint32, 32, 21, 2047, 2047},
 	}
 	for _, test := range cases {
 		mip, width, height := modelViewerPreviewMipmap(test.width, test.height, test.mipmaps)

--- a/internal/tools/wwmi_dump.go
+++ b/internal/tools/wwmi_dump.go
@@ -282,7 +282,9 @@ func inspectWwmiTextureHint(filePath string) *wwmiTextureHint {
 	if len(header) < 128 {
 		return &wwmiTextureHint{ColorSpace: "unknown", Bytes: size}
 	}
-	area := int(binary.LittleEndian.Uint32(header[16:20]) * binary.LittleEndian.Uint32(header[12:16]))
+	width := binary.LittleEndian.Uint32(header[16:20])
+	height := binary.LittleEndian.Uint32(header[12:16])
+	area := textureArea(width, height)
 	fourcc := string(header[84:88])
 	dxgi := uint32(0xFFFFFFFF)
 	if fourcc == "DX10" && len(header) >= 132 {
@@ -298,7 +300,7 @@ func inspectWwmiTextureHint(filePath string) *wwmiTextureHint {
 		}
 	}
 	packedFormat := ddsPackedFourCC[fourcc] || ddsPackedDXGI[dxgi]
-	if colorSpace == "linear" || packedFormat || area > maxHintDecodeArea || size > maxHintDecodeBytes {
+	if colorSpace == "linear" || packedFormat || texturePixelCount(width, height) > uint64(maxHintDecodeArea) || size > maxHintDecodeBytes {
 		return &wwmiTextureHint{SRGB: colorSpace == "srgb", ColorSpace: colorSpace, Area: area, Bytes: size, IsLikelyNormal: packedFormat, IsLikelyPacked: packedFormat}
 	}
 	decoded, decodeErr := decodeModelViewerDDSHint(filePath, size)
@@ -337,7 +339,7 @@ func pngIhdrArea(header []byte) int {
 	if width == 0 || height == 0 {
 		return 0
 	}
-	return int(width * height)
+	return textureArea(width, height)
 }
 
 func hintFromAnalysis(analysis wwmiRGBAAnalysis, colorSpace string, area int, size int64) *wwmiTextureHint {

--- a/internal/tools/wwmi_dump.go
+++ b/internal/tools/wwmi_dump.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	maxHintDecodeBytes = 32 * 1024 * 1024
-	maxHintDecodeArea  = 4096 * 4096
+	maxHintDecodeBytes   = 32 * 1024 * 1024
+	maxHintDecodeArea    = 4096 * 4096
+	maxHintAnalyzePixels = int64(256 * 256)
 )
 
 var (
@@ -265,8 +266,10 @@ func inspectWwmiTextureHint(filePath string) *wwmiTextureHint {
 		if decodeErr != nil {
 			return nil
 		}
-		analysis := analyzeRGBAImage(decoded)
-		return hintFromAnalysis(analysis, "srgb", decoded.Bounds().Dx()*decoded.Bounds().Dy(), size)
+		if area == 0 {
+			area = decoded.Bounds().Dx() * decoded.Bounds().Dy()
+		}
+		return hintFromAnalysis(analyzeRGBAImage(decoded), "srgb", area, size)
 	}
 	if ext == ".jpg" || ext == ".jpeg" {
 		return &wwmiTextureHint{SRGB: true, ColorSpace: "srgb", Area: 0, Bytes: size}
@@ -298,15 +301,11 @@ func inspectWwmiTextureHint(filePath string) *wwmiTextureHint {
 	if colorSpace == "linear" || packedFormat || area > maxHintDecodeArea || size > maxHintDecodeBytes {
 		return &wwmiTextureHint{SRGB: colorSpace == "srgb", ColorSpace: colorSpace, Area: area, Bytes: size, IsLikelyNormal: packedFormat, IsLikelyPacked: packedFormat}
 	}
-	raw, readErr := os.ReadFile(filePath)
-	if readErr != nil {
-		return nil
-	}
-	decoded, decodeErr := decodeModelViewerDDS(raw)
+	decoded, decodeErr := decodeModelViewerDDSHint(filePath, size)
 	if decodeErr != nil {
 		return nil
 	}
-	return hintFromAnalysis(analyzeRGBAImage(decoded), colorSpace, area, size)
+	return hintFromAnalysis(analyzeNRGBA(decoded), colorSpace, area, size)
 }
 
 func parseDdsSrgbState(header []byte) *bool {
@@ -371,6 +370,17 @@ func hintFromAnalysis(analysis wwmiRGBAAnalysis, colorSpace string, area int, si
 			analysis.luminanceStdDev <= 0.12,
 		IsLikelyPacked: packed,
 	}
+}
+
+func analyzeNRGBA(img *image.NRGBA) wwmiRGBAAnalysis {
+	if img == nil {
+		return wwmiRGBAAnalysis{}
+	}
+	width, height := img.Bounds().Dx(), img.Bounds().Dy()
+	if img.Rect.Min == image.Pt(0, 0) && img.Stride == width*4 {
+		return analyzeRGBA(img.Pix, width, height)
+	}
+	return analyzeRGBAImage(img)
 }
 
 func analyzeRGBAImage(img image.Image) wwmiRGBAAnalysis {

--- a/internal/tools/wwmi_dump_test.go
+++ b/internal/tools/wwmi_dump_test.go
@@ -5,6 +5,7 @@ import (
 	"image"
 	"image/color"
 	"image/draw"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -90,12 +91,14 @@ func TestWwmiHintMipmap(t *testing.T) {
 		width, height uint32
 		mipmaps       uint32
 		wantMip       uint32
-		wantW, wantH  int
+		wantW, wantH  uint32
 	}{
 		{4096, 4096, 14, 4, 256, 256},
 		{4096, 4096, 1, 0, 256, 256},
 		{4096, 4096, 2, 1, 256, 256},
 		{128, 128, 8, 0, 128, 128},
+		{math.MaxUint32, math.MaxUint32, 1, 0, 255, 255},
+		{math.MaxUint32, math.MaxUint32, 32, 24, 255, 255},
 	}
 	for _, test := range cases {
 		mip, width, height := wwmiHintMipmap(test.width, test.height, test.mipmaps)
@@ -103,6 +106,46 @@ func TestWwmiHintMipmap(t *testing.T) {
 			t.Fatalf("wwmiHintMipmap(%d, %d, %d) = (%d, %d, %d), want (%d, %d, %d)",
 				test.width, test.height, test.mipmaps, mip, width, height, test.wantMip, test.wantW, test.wantH)
 		}
+	}
+}
+
+func TestTextureAreaClampsUint32Overflow(t *testing.T) {
+	t.Parallel()
+	if got := textureArea(math.MaxUint32, math.MaxUint32); got != math.MaxInt {
+		t.Fatalf("textureArea(MaxUint32, MaxUint32) = %d, want MaxInt", got)
+	}
+	header := make([]byte, 24)
+	copy(header, pngSignature)
+	copy(header[12:16], "IHDR")
+	binary.BigEndian.PutUint32(header[16:20], math.MaxUint32)
+	binary.BigEndian.PutUint32(header[20:24], math.MaxUint32)
+	if got := pngIhdrArea(header); got != math.MaxInt {
+		t.Fatalf("pngIhdrArea = %d, want MaxInt", got)
+	}
+}
+
+func TestInspectWwmiTextureHintKeepsOversizedHeaderWithoutDecode(t *testing.T) {
+	ddsPath := filepath.Join(t.TempDir(), "huge.dds")
+	if err := os.WriteFile(ddsPath, encodeUncompressedDDSHeader(math.MaxUint32, math.MaxUint32), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ddsHint := inspectWwmiTextureHint(ddsPath)
+	if ddsHint == nil || ddsHint.Area != math.MaxInt || ddsHint.ColorSpace != "unknown" {
+		t.Fatalf("dds hint = %#v", ddsHint)
+	}
+
+	pngHeader := make([]byte, 24)
+	copy(pngHeader, pngSignature)
+	copy(pngHeader[12:16], "IHDR")
+	binary.BigEndian.PutUint32(pngHeader[16:20], math.MaxUint32)
+	binary.BigEndian.PutUint32(pngHeader[20:24], math.MaxUint32)
+	pngPath := filepath.Join(t.TempDir(), "huge.png")
+	if err := os.WriteFile(pngPath, pngHeader, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pngHint := inspectWwmiTextureHint(pngPath)
+	if pngHint == nil || pngHint.Area != math.MaxInt || !pngHint.SRGB {
+		t.Fatalf("png hint = %#v", pngHint)
 	}
 }
 

--- a/internal/tools/wwmi_dump_test.go
+++ b/internal/tools/wwmi_dump_test.go
@@ -2,10 +2,14 @@ package tools
 
 import (
 	"encoding/binary"
+	"image"
 	"image/color"
+	"image/draw"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/myparsleycat/ddsutil"
 )
 
 func TestPickWwmiDumpDiffusePrefersSRGBThenLarger(t *testing.T) {
@@ -80,6 +84,127 @@ func TestInspectWwmiTextureHintDecodesInBudgetDDS(t *testing.T) {
 	}
 }
 
+func TestWwmiHintMipmap(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		width, height uint32
+		mipmaps       uint32
+		wantMip       uint32
+		wantW, wantH  int
+	}{
+		{4096, 4096, 14, 4, 256, 256},
+		{4096, 4096, 1, 0, 256, 256},
+		{4096, 4096, 2, 1, 256, 256},
+		{128, 128, 8, 0, 128, 128},
+	}
+	for _, test := range cases {
+		mip, width, height := wwmiHintMipmap(test.width, test.height, test.mipmaps)
+		if mip != test.wantMip || width != test.wantW || height != test.wantH {
+			t.Fatalf("wwmiHintMipmap(%d, %d, %d) = (%d, %d, %d), want (%d, %d, %d)",
+				test.width, test.height, test.mipmaps, mip, width, height, test.wantMip, test.wantW, test.wantH)
+		}
+	}
+}
+
+func TestInspectWwmiTextureHintKeepsHeaderAreaAfterDownsample(t *testing.T) {
+	root := t.TempDir()
+	const dim = 512
+	flatPixels := make([]color.NRGBA, dim*dim)
+	for index := range flatPixels {
+		flatPixels[index] = color.NRGBA{R: 128, G: 64, B: 32, A: 255}
+	}
+	flatPath := filepath.Join(root, "flat.dds")
+	if err := os.WriteFile(flatPath, encodeWwmiUncompressedDDS(dim, dim, flatPixels), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	flatInfo, err := os.Stat(flatPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	flatDecoded, err := decodeModelViewerDDSHint(flatPath, flatInfo.Size())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if flatDecoded.Bounds().Dx() != 256 || flatDecoded.Bounds().Dy() != 256 {
+		t.Fatalf("flat decode size = %dx%d, want 256x256", flatDecoded.Bounds().Dx(), flatDecoded.Bounds().Dy())
+	}
+	flat := inspectWwmiTextureHint(flatPath)
+	if flat == nil || flat.Area != dim*dim || !flat.IsLikelyFlat || isLikelyWwmiDiffuse(*flat) {
+		t.Fatalf("flat DDS hint = %#v", flat)
+	}
+
+	diffusePixels := make([]color.NRGBA, dim*dim)
+	for y := range dim {
+		for x := range dim {
+			diffusePixels[y*dim+x] = color.NRGBA{R: uint8(x * 255 / (dim - 1)), G: uint8(y * 255 / (dim - 1)), B: 90, A: 255}
+		}
+	}
+	diffusePath := filepath.Join(root, "diffuse.dds")
+	if err := os.WriteFile(diffusePath, encodeWwmiUncompressedDDS(dim, dim, diffusePixels), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	diffuse := inspectWwmiTextureHint(diffusePath)
+	if diffuse == nil || diffuse.Area != dim*dim || diffuse.IsLikelyFlat || !isLikelyWwmiDiffuse(*diffuse) {
+		t.Fatalf("diffuse DDS hint = %#v", diffuse)
+	}
+}
+
+func TestAnalyzeRGBAImagePremultipliesNRGBA(t *testing.T) {
+	t.Parallel()
+	src := image.NewNRGBA(image.Rect(0, 0, 1, 1))
+	src.SetNRGBA(0, 0, color.NRGBA{R: 100, G: 0, B: 0, A: 128})
+	premul := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	draw.Draw(premul, premul.Bounds(), src, image.Point{}, draw.Src)
+	got := analyzeRGBAImage(src)
+	want := analyzeRGBA(premul.Pix, 1, 1)
+	if got != want {
+		t.Fatalf("analyzeRGBAImage = %#v, want premultiplied %#v", got, want)
+	}
+}
+
+func TestInspectWwmiTextureHintDecodesCompressedMipChain(t *testing.T) {
+	root := t.TempDir()
+	const dim = 512
+	flatPixels := make([]color.NRGBA, dim*dim)
+	for index := range flatPixels {
+		flatPixels[index] = color.NRGBA{R: 128, G: 64, B: 32, A: 255}
+	}
+	flatPath := filepath.Join(root, "flat.dds")
+	if err := os.WriteFile(flatPath, encodeWwmiBC1MipDDS(t, dim, dim, flatPixels), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	flatInfo, err := os.Stat(flatPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	flatDecoded, err := decodeModelViewerDDSHint(flatPath, flatInfo.Size())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if flatDecoded.Bounds().Dx() != 256 || flatDecoded.Bounds().Dy() != 256 {
+		t.Fatalf("flat compressed decode size = %dx%d, want 256x256", flatDecoded.Bounds().Dx(), flatDecoded.Bounds().Dy())
+	}
+	flat := inspectWwmiTextureHint(flatPath)
+	if flat == nil || flat.Area != dim*dim || !flat.IsLikelyFlat || isLikelyWwmiDiffuse(*flat) {
+		t.Fatalf("flat compressed DDS hint = %#v", flat)
+	}
+
+	diffusePixels := make([]color.NRGBA, dim*dim)
+	for y := range dim {
+		for x := range dim {
+			diffusePixels[y*dim+x] = color.NRGBA{R: uint8(x * 255 / (dim - 1)), G: uint8(y * 255 / (dim - 1)), B: 90, A: 255}
+		}
+	}
+	diffusePath := filepath.Join(root, "diffuse.dds")
+	if err := os.WriteFile(diffusePath, encodeWwmiBC1MipDDS(t, dim, dim, diffusePixels), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	diffuse := inspectWwmiTextureHint(diffusePath)
+	if diffuse == nil || diffuse.Area != dim*dim || diffuse.IsLikelyFlat || !isLikelyWwmiDiffuse(*diffuse) {
+		t.Fatalf("diffuse compressed DDS hint = %#v", diffuse)
+	}
+}
+
 func TestKeepLikelyDiffuseAssignmentsPreservesRelativeOrder(t *testing.T) {
 	assignments := []modelViewerDirectTextureAssignment{
 		{role: "diffuse", file: "first"},
@@ -140,6 +265,31 @@ func encodeWwmiUncompressedDDS(width, height uint32, pixels []color.NRGBA) []byt
 	raw = append(raw, header...)
 	for _, pixel := range pixels {
 		raw = append(raw, pixel.B, pixel.G, pixel.R, pixel.A)
+	}
+	return raw
+}
+
+func encodeWwmiBC1MipDDS(t *testing.T, width, height int, pixels []color.NRGBA) []byte {
+	t.Helper()
+	if len(pixels) != width*height {
+		t.Fatalf("pixel count = %d, want %d", len(pixels), width*height)
+	}
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := range height {
+		for x := range width {
+			img.Set(x, y, pixels[y*width+x])
+		}
+	}
+	encoded, err := ddsutil.DdsFromImage(img, ddsutil.BC1RgbaUnormSrgb, ddsutil.QualityFast, ddsutil.MipmapsGeneratedAutomatic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if encoded.GetNumMipmapLevels() < 2 {
+		t.Fatalf("mipmaps = %d, want at least 2", encoded.GetNumMipmapLevels())
+	}
+	raw, err := encoded.Bytes()
+	if err != nil {
+		t.Fatal(err)
 	}
 	return raw
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved texture hint analysis for DDS textures, including compressed formats and mipmapped images.
  * Added safer handling for oversized dimensions, preventing overflow-related processing issues.
  * Improved analysis of images with premultiplied transparency and incomplete size metadata.
  * Reduced analysis dimensions when needed to stay within processing limits while preserving original texture sizing information.

* **Tests**
  * Expanded coverage for mipmap selection, downsampling, compressed textures, transparency analysis, and oversized dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->