### PR TITLE
fix(gamebanana): harden session races and login error classification

### DIFF
--- a/frontend/src/components/download-confirmation-overlay.test.tsx
+++ b/frontend/src/components/download-confirmation-overlay.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+
+const calls = vi.hoisted(() => ({
+  select: vi.fn().mockResolvedValue(undefined),
+  logout: vi.fn(),
+  navigate: vi.fn(),
+  setDownloadMode: vi.fn(),
+  reset: vi.fn(),
+}));
+vi.mock("@bindings/mod", () => ({ Mod: { SelectModManagerPath: calls.select } }));
+vi.mock("@bindings/gamebanana", () => ({ GameBanana: { Logout: calls.logout } }));
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => calls.navigate }));
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock("@renderer/hooks/use-settings", () => ({ useSetting: () => ({ data: true }) }));
+vi.mock("@renderer/lib/logger", () => ({ Logger: { error: vi.fn() } }));
+vi.mock("@renderer/lib/settings", () => ({ setSetting: vi.fn() }));
+vi.mock("@renderer/store/mod", () => {
+  const state = {
+    downloadMode: {
+      downloadId: "download",
+      downloadSource: "gamebanana",
+      suggestedName: "Example",
+    },
+    selectedGroup: { path: "C:\\Mods", name: "Mods" },
+    setDownloadMode: calls.setDownloadMode,
+    resetUserSelectedDuringDownload: calls.reset,
+  };
+  return { useModStore: (select: (value: typeof state) => unknown) => select(state) };
+});
+
+import { DownloadConfirmationOverlay } from "./download-confirmation-overlay";
+
+afterEach(cleanup);
+
+it("returns to GameBanana after accepting the download without logging out", async () => {
+  render(<DownloadConfirmationOverlay />);
+  fireEvent.click(screen.getByRole("button", { name: "g.select" }));
+  await waitFor(() => expect(calls.navigate).toHaveBeenCalledWith({ to: "/gamebanana" }));
+  expect(calls.select).toHaveBeenCalledWith("download", "C:\\Mods", "Example");
+  expect(calls.setDownloadMode).toHaveBeenCalledWith(null);
+  expect(calls.logout).not.toHaveBeenCalled();
+});

--- a/frontend/src/lib/gamebanana-auth.test.ts
+++ b/frontend/src/lib/gamebanana-auth.test.ts
@@ -6,8 +6,32 @@ import {
     isManualRmcPrimaryAction,
     runGameBananaEnsureSession,
 } from "./gamebanana-auth";
+import en from "./i18n/locales/en.json";
+import ja from "./i18n/locales/ja.json";
+import ko from "./i18n/locales/ko.json";
+import zh from "./i18n/locales/zh.json";
 
 describe("getGameBananaAuthErrorCode", () => {
+    it.each(["GAMEBANANA_LOGIN_INIT_FAILED", "GAMEBANANA_AUTH_CHECK_FAILED"])(
+        "preserves %s and provides localized retry guidance",
+        async (code) => {
+            expect(getGameBananaAuthErrorCode(new Error(code))).toBe(code);
+            expect(isManualRmcPrimaryAction(code)).toBe(false);
+            expect(await runGameBananaEnsureSession(() => Promise.reject(new Error(code)))).toEqual(
+                { ok: false, code },
+            );
+            const copy = gameBananaAuthCopyKey(code);
+            for (const locale of [en, ja, ko, zh]) {
+                const title = copy.title.split(".").at(-1);
+                const description = copy.description.split(".").at(-1);
+                expect(title && Object.hasOwn(locale.page.gamebanana.auth, title)).toBe(true);
+                expect(description && Object.hasOwn(locale.page.gamebanana.auth, description)).toBe(
+                    true,
+                );
+                expect(Object.hasOwn(locale.page.gamebanana.auth.manual_rmc, code)).toBe(true);
+            }
+        },
+    );
     it("classifies cancelled, unsupported, unreachable, and generic failures", () => {
         expect(getGameBananaAuthErrorCode(new Error("GAMEBANANA_LOGIN_CANCELLED"))).toBe(
             "GAMEBANANA_LOGIN_CANCELLED",

--- a/frontend/src/lib/gamebanana-auth.ts
+++ b/frontend/src/lib/gamebanana-auth.ts
@@ -1,4 +1,6 @@
 export type GameBananaAuthErrorCode =
+    | "GAMEBANANA_LOGIN_INIT_FAILED"
+    | "GAMEBANANA_AUTH_CHECK_FAILED"
     | "GAMEBANANA_AUTH_FAILED"
     | "GAMEBANANA_LOGIN_CANCELLED"
     | "GAMEBANANA_AUTO_LOGIN_UNSUPPORTED"
@@ -10,6 +12,8 @@ export function getGameBananaAuthErrorCode(error: unknown): GameBananaAuthErrorC
     }
 
     switch (error.message) {
+        case "GAMEBANANA_LOGIN_INIT_FAILED":
+        case "GAMEBANANA_AUTH_CHECK_FAILED":
         case "GAMEBANANA_LOGIN_CANCELLED":
         case "GAMEBANANA_AUTO_LOGIN_UNSUPPORTED":
         case "GAMEBANANA_SERVER_UNREACHABLE":
@@ -19,7 +23,7 @@ export function getGameBananaAuthErrorCode(error: unknown): GameBananaAuthErrorC
     }
 }
 
-export function isManualRmcPrimaryAction(code: GameBananaAuthErrorCode | string | null): boolean {
+export function isManualRmcPrimaryAction(code: string | null): boolean {
     return code === "GAMEBANANA_AUTO_LOGIN_UNSUPPORTED";
 }
 

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -790,6 +790,10 @@
         "cancelled_description": "Complete login to load GameBanana data.",
         "unsupported_title": "Automatic GameBanana login is unavailable",
         "unsupported_description": "This platform cannot open the GameBanana login window. Enter an rmc cookie to continue.",
+        "init_failed_title": "Could not prepare GameBanana login",
+        "init_failed_description": "The login window could not be prepared. Please try again shortly.",
+        "check_failed_title": "Could not verify GameBanana authentication",
+        "check_failed_description": "The server response could not confirm your login status. Please try again shortly.",
         "unreachable_title": "GameBanana is unreachable",
         "unreachable_description": "Could not reach GameBanana. Check your connection and try again.",
         "retry": "Sign In Again",
@@ -800,6 +804,8 @@
           "empty": "Enter an rmc value.",
           "GAMEBANANA_INVALID_RMC": "The rmc token is invalid.",
           "GAMEBANANA_SERVER_UNREACHABLE": "The server is not responding.",
+          "GAMEBANANA_AUTH_CHECK_FAILED": "The server response could not confirm your login status. Please try again shortly.",
+          "GAMEBANANA_LOGIN_INIT_FAILED": "The login window could not be prepared. Please try again shortly.",
           "GAMEBANANA_MANUAL_RMC_SAVE_FAILED": "Failed to save the rmc token."
         }
       },

--- a/frontend/src/lib/i18n/locales/ja.json
+++ b/frontend/src/lib/i18n/locales/ja.json
@@ -769,6 +769,10 @@
         "cancelled_description": "GameBanana のデータを読み込むにはログインを完了してください。",
         "unsupported_title": "GameBanana の自動ログインは利用できません",
         "unsupported_description": "この環境では GameBanana のログインウィンドウを開けません。rmc Cookie を入力してください。",
+        "init_failed_title": "GameBanana ログインの準備に失敗しました",
+        "init_failed_description": "ログイン画面を準備できませんでした。しばらくしてから再試行してください。",
+        "check_failed_title": "GameBanana の認証を確認できませんでした",
+        "check_failed_description": "サーバーの応答からログイン状態を確認できませんでした。しばらくしてから再試行してください。",
         "unreachable_title": "GameBanana に接続できません",
         "unreachable_description": "GameBanana に到達できませんでした。接続を確認してから再試行してください。",
         "retry": "再ログイン",
@@ -779,6 +783,8 @@
           "empty": "rmc 値を入力してください。",
           "GAMEBANANA_INVALID_RMC": "無効な rmc トークンです。",
           "GAMEBANANA_SERVER_UNREACHABLE": "サーバーが応答していません。",
+          "GAMEBANANA_AUTH_CHECK_FAILED": "サーバーの応答からログイン状態を確認できませんでした。しばらくしてから再試行してください。",
+          "GAMEBANANA_LOGIN_INIT_FAILED": "ログイン画面を準備できませんでした。しばらくしてから再試行してください。",
           "GAMEBANANA_MANUAL_RMC_SAVE_FAILED": "rmc トークンの保存に失敗しました。"
         }
       },

--- a/frontend/src/lib/i18n/locales/ko.json
+++ b/frontend/src/lib/i18n/locales/ko.json
@@ -774,6 +774,10 @@
         "cancelled_description": "로그인을 완료해야 GameBanana 데이터를 불러올 수 있습니다.",
         "unsupported_title": "GameBanana 자동 로그인을 사용할 수 없습니다",
         "unsupported_description": "이 환경에서는 GameBanana 로그인 창을 열 수 없습니다. rmc 쿠키를 직접 입력해 주세요.",
+        "init_failed_title": "GameBanana 로그인 준비에 실패했습니다",
+        "init_failed_description": "로그인 창을 준비하지 못했습니다. 잠시 후 다시 시도해 주세요.",
+        "check_failed_title": "GameBanana 인증을 확인하지 못했습니다",
+        "check_failed_description": "서버 응답으로 로그인 상태를 확인할 수 없습니다. 잠시 후 다시 시도해 주세요.",
         "unreachable_title": "GameBanana 서버에 연결할 수 없습니다",
         "unreachable_description": "GameBanana에 연결하지 못했습니다. 네트워크 상태를 확인한 뒤 다시 시도해 주세요.",
         "retry": "다시 로그인",
@@ -784,6 +788,8 @@
           "empty": "rmc 값을 입력해 주세요.",
           "GAMEBANANA_INVALID_RMC": "잘못된 rmc 토큰입니다.",
           "GAMEBANANA_SERVER_UNREACHABLE": "서버가 응답하지 않습니다.",
+          "GAMEBANANA_AUTH_CHECK_FAILED": "서버 응답으로 로그인 상태를 확인할 수 없습니다. 잠시 후 다시 시도해 주세요.",
+          "GAMEBANANA_LOGIN_INIT_FAILED": "로그인 창을 준비하지 못했습니다. 잠시 후 다시 시도해 주세요.",
           "GAMEBANANA_MANUAL_RMC_SAVE_FAILED": "rmc 토큰 저장에 실패했습니다."
         }
       },

--- a/frontend/src/lib/i18n/locales/zh.json
+++ b/frontend/src/lib/i18n/locales/zh.json
@@ -768,6 +768,10 @@
         "cancelled_description": "需要完成登录后才能加载 GameBanana 数据。",
         "unsupported_title": "无法使用 GameBanana 自动登录",
         "unsupported_description": "当前环境无法打开 GameBanana 登录窗口。请手动输入 rmc Cookie 后继续。",
+        "init_failed_title": "无法准备 GameBanana 登录",
+        "init_failed_description": "无法准备登录窗口。请稍后重试。",
+        "check_failed_title": "无法验证 GameBanana 身份验证",
+        "check_failed_description": "无法根据服务器响应确认登录状态。请稍后重试。",
         "unreachable_title": "无法连接 GameBanana",
         "unreachable_description": "无法访问 GameBanana。请检查网络后重试。",
         "retry": "重新登录",
@@ -778,6 +782,8 @@
           "empty": "请输入 rmc 值。",
           "GAMEBANANA_INVALID_RMC": "rmc token 无效。",
           "GAMEBANANA_SERVER_UNREACHABLE": "服务器没有响应。",
+          "GAMEBANANA_AUTH_CHECK_FAILED": "无法根据服务器响应确认登录状态。请稍后重试。",
+          "GAMEBANANA_LOGIN_INIT_FAILED": "无法准备登录窗口。请稍后重试。",
           "GAMEBANANA_MANUAL_RMC_SAVE_FAILED": "保存 rmc token 失败。"
         }
       },

--- a/frontend/src/routes/gamebanana/-auth-session.test.tsx
+++ b/frontend/src/routes/gamebanana/-auth-session.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { act, Suspense, type ComponentType } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const backend = vi.hoisted(() => ({
+  EnsureSession: vi.fn<() => Promise<void>>(),
+  Logout: vi.fn<() => Promise<void>>(),
+  SetManualRMCToken: vi.fn(),
+}));
+const navigate = vi.hoisted(() => vi.fn());
+vi.mock("@bindings/gamebanana", () => ({ GameBanana: backend }));
+vi.mock("@bindings/platform", () => ({ Shell: { OpenExternal: vi.fn() } }));
+vi.mock("@tanstack/react-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-router")>()),
+  createFileRoute: () => (options: { component: ComponentType }) => ({
+    options,
+    useSearch: () => ({}),
+    useNavigate: () => navigate,
+  }),
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: "en" } }),
+}));
+vi.mock("@renderer/store/mod", () => ({ modStore: { getState: () => ({ selectedGame: "" }) } }));
+vi.mock("@renderer/hooks/use-mod-data", () => ({ useGames: () => ({ data: [] }) }));
+vi.mock("@renderer/hooks/use-gamebanana-data", () => ({
+  useGameBananaGames: () => ({ data: {} }),
+  useGameBananaGameOverview: () => ({}),
+  useGameBananaGameSubfeed: () => ({}),
+  useGameBananaModCategoryOverview: () => ({}),
+  useGameBananaModOverview: () => ({}),
+}));
+vi.mock("./-components/gamebanana-toolbar", () => ({ GameBananaToolbar: () => null }));
+vi.mock("./-panels/game-home-panel", () => ({
+  GameHomePanel: () => <div>authenticated-content</div>,
+}));
+vi.mock("./-panels/category-panel", () => ({ CategoryPanel: () => null }));
+vi.mock("./-panels/mod-detail-panel", () => ({ ModDetailPanel: () => null }));
+vi.mock("./-sidebars/category-sidebar", () => ({ CategorySidebar: () => null }));
+vi.mock("./-sidebars/mod-files-sidebar", () => ({ ModFilesSidebar: () => null }));
+
+import { Route } from "./index";
+
+async function renderRoute() {
+  const Component = Route.options.component;
+  if (!Component) throw new Error("GameBanana route has no component");
+  let view: ReturnType<typeof render> | undefined;
+  await act(async () => {
+    view = render(
+      <Suspense fallback={null}>
+        <Component />
+      </Suspense>,
+    );
+  });
+  if (!view) throw new Error("Route failed to mount");
+  return view;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  backend.EnsureSession.mockResolvedValue();
+});
+afterEach(cleanup);
+
+describe("GameBanana route authentication lifecycle", () => {
+  it("revalidates when returning without logging out on unmount", async () => {
+    const first = await renderRoute();
+    await screen.findByText("authenticated-content");
+    first.unmount();
+    expect(backend.Logout).not.toHaveBeenCalled();
+    await renderRoute();
+    await screen.findByText("authenticated-content");
+    expect(backend.EnsureSession).toHaveBeenCalledTimes(2);
+    expect(backend.Logout).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["GAMEBANANA_LOGIN_INIT_FAILED", "init_failed_title"],
+    ["GAMEBANANA_AUTH_CHECK_FAILED", "check_failed_title"],
+  ])("shows retry guidance for %s", async (code, title) => {
+    backend.EnsureSession.mockRejectedValue(new Error(code));
+    await renderRoute();
+    await screen.findByText(`page.gamebanana.auth.${title}`);
+    expect(screen.queryByText("authenticated-content")).toBeNull();
+    expect(backend.Logout).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/routes/gamebanana/-shared/auth-error.ts
+++ b/frontend/src/routes/gamebanana/-shared/auth-error.ts
@@ -9,6 +9,16 @@ export function gameBananaAuthCopyKey(code: string | null): {
     description: string;
 } {
     switch (code) {
+        case "GAMEBANANA_LOGIN_INIT_FAILED":
+            return {
+                title: "page.gamebanana.auth.init_failed_title",
+                description: "page.gamebanana.auth.init_failed_description",
+            };
+        case "GAMEBANANA_AUTH_CHECK_FAILED":
+            return {
+                title: "page.gamebanana.auth.check_failed_title",
+                description: "page.gamebanana.auth.check_failed_description",
+            };
         case "GAMEBANANA_LOGIN_CANCELLED":
             return {
                 title: "page.gamebanana.auth.cancelled_title",

--- a/frontend/src/routes/gamebanana/index.tsx
+++ b/frontend/src/routes/gamebanana/index.tsx
@@ -374,6 +374,8 @@ function RouteComponent() {
                 "GAMEBANANA_INVALID_RMC",
                 "GAMEBANANA_SERVER_UNREACHABLE",
                 "GAMEBANANA_MANUAL_RMC_SAVE_FAILED",
+                "GAMEBANANA_AUTH_CHECK_FAILED",
+                "GAMEBANANA_LOGIN_INIT_FAILED",
               ].includes(error.message)
               ? `page.gamebanana.auth.manual_rmc.${error.message}`
               : "page.gamebanana.auth.manual_rmc.GAMEBANANA_MANUAL_RMC_SAVE_FAILED",

--- a/internal/app/gamebanana_login.go
+++ b/internal/app/gamebanana_login.go
@@ -22,11 +22,15 @@ const (
 	gameBananaCookiePollWait = 350 * time.Millisecond
 	gameBananaReadyWait      = 100 * time.Millisecond
 	gameBananaLogoutWait     = 15 * time.Second
+	gameBananaCleanupWait    = 5 * time.Second
 )
 
 var gameBananaAuthCookieNames = []string{"rmc", "sess"}
 
 type loginWindow interface {
+	Run()
+	ID() uint
+	WaitClosed(context.Context) error
 	Show() application.Window
 	Focus()
 	Close()
@@ -36,6 +40,11 @@ type loginWindow interface {
 }
 
 type loginWindowFactory func() (loginWindow, error)
+
+type loginWindowResult struct {
+	cookie string
+	err    error
+}
 
 type gameBananaLogin struct {
 	mu sync.Mutex
@@ -47,6 +56,8 @@ type gameBananaLogin struct {
 	factory        loginWindowFactory
 	logoutFactory  loginWindowFactory
 	pollWait       time.Duration
+	logoutWait     time.Duration
+	cleanupWait    time.Duration
 	pollDiagnostic infra.DiagnosticThrottle
 	profile        loginWindow
 	window         loginWindow
@@ -62,6 +73,7 @@ type gameBananaLogin struct {
 	result         string
 	err            error
 	done           chan struct{}
+	call           *loginWindowResult
 	unsub          func()
 	readyUnsub     func()
 }
@@ -105,6 +117,7 @@ func (l *gameBananaLogin) Open(ctx context.Context, validate gamebanana.CookieVa
 			window := l.window
 			ready := l.ready
 			done := l.done
+			call := l.call
 			l.mu.Unlock()
 			if ready {
 				window.Show()
@@ -118,10 +131,7 @@ func (l *gameBananaLogin) Open(ctx context.Context, validate gamebanana.CookieVa
 			case <-ctx.Done():
 				return "", ctx.Err()
 			}
-			l.mu.Lock()
-			cookie, err := l.result, l.err
-			l.mu.Unlock()
-			return cookie, err
+			return call.cookie, call.err
 		}
 		if l.opening {
 			l.mu.Unlock()
@@ -141,14 +151,13 @@ func (l *gameBananaLogin) Open(ctx context.Context, validate gamebanana.CookieVa
 		l.opening = true
 		l.mu.Unlock()
 
-		// GameBanana's logout response must be processed by WebView2 itself. A Go
-		// HTTP request can invalidate the backend token, but it cannot apply the
-		// browser session transition to the shared WebView profile.
+		// Prefer the browser's server logout transition; a bounded local cookie
+		// cleanup can recover when that transition stalls.
 		if err := l.resetWebSession(ctx); err != nil {
 			l.mu.Lock()
 			l.opening = false
 			l.mu.Unlock()
-			return "", infra.ReportError(l.log, classifyLoginWindowError(err), "GameBananaLogin.Open", infra.Diagnostic{
+			return "", infra.ReportError(l.log, infra.WithCause(gamebanana.ErrLoginInitFailed, err), "GameBananaLogin.Open", infra.Diagnostic{
 				Severity: infra.DiagnosticWarn, Operation: "login", Stage: "logout-shared-webview-profile",
 			})
 		}
@@ -168,13 +177,21 @@ func (l *gameBananaLogin) Open(ctx context.Context, validate gamebanana.CookieVa
 			l.mu.Unlock()
 			return "", gamebanana.ErrAutoLoginUnsupported
 		}
+		if err := ctx.Err(); err != nil {
+			l.mu.Lock()
+			l.opening = false
+			l.mu.Unlock()
+			return "", err
+		}
 
-		sessionCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+		sessionCtx, cancel := context.WithCancel(ctx)
 		done := make(chan struct{})
+		call := &loginWindowResult{}
 		l.mu.Lock()
 		l.window = window
 		l.cancel = cancel
 		l.done = done
+		l.call = call
 		l.settled = false
 		l.programmatic = false
 		l.closed = false
@@ -186,20 +203,19 @@ func (l *gameBananaLogin) Open(ctx context.Context, validate gamebanana.CookieVa
 		l.err = nil
 		l.opening = false
 		l.unsub = window.OnWindowEvent(events.Common.WindowClosing, func(*application.WindowEvent) {
-			l.handleWindowClosing()
+			l.handleWindowClosing(window)
 		})
 		l.readyUnsub = window.OnWindowEvent(events.Windows.WebViewNavigationCompleted, func(*application.WindowEvent) {
 			l.handleNavigationCompleted(sessionCtx, validate)
 		})
 		l.mu.Unlock()
+		window.Run()
 
 		select {
 		case <-done:
-			l.mu.Lock()
-			cookie, loginErr := l.result, l.err
-			l.mu.Unlock()
-			return cookie, loginErr
+			return call.cookie, call.err
 		case <-ctx.Done():
+			l.settle(window, "", ctx.Err())
 			return "", ctx.Err()
 		}
 	}
@@ -217,7 +233,7 @@ func (l *gameBananaLogin) handleNavigationCompleted(
 	case <-timer.C:
 	}
 	l.mu.Lock()
-	if l.settled || l.closed || l.ready {
+	if l.settled || l.closed || l.ready || ctx.Err() != nil {
 		l.mu.Unlock()
 		return
 	}
@@ -241,65 +257,131 @@ func (l *gameBananaLogin) ClearCookies(ctx context.Context) error {
 		ctx = context.Background()
 	}
 	l.Close()
-	return l.resetWebSession(ctx)
+	if err := l.resetWebSession(ctx); err != nil {
+		return infra.WithCause(gamebanana.ErrLoginInitFailed, err)
+	}
+	return nil
 }
 
 func (l *gameBananaLogin) resetWebSession(ctx context.Context) error {
 	l.mu.Lock()
-	factory := l.logoutFactory
-	profile := l.profile
-	parent := l.parent
+	factory, profile, parent := l.logoutFactory, l.profile, l.parent
+	navigationWait, cleanupWait := l.logoutWait, l.cleanupWait
 	l.mu.Unlock()
-	if factory == nil {
-		if profile != nil {
-			return clearGameBananaCookies(ctx, profile)
-		}
-		if parent != nil {
-			if host := parent.native(); host != nil {
-				return clearGameBananaCookies(ctx, &nativeLoginWindow{window: host})
-			}
-		}
-		return nil
+	if navigationWait <= 0 {
+		navigationWait = gameBananaLogoutWait
 	}
-
+	if cleanupWait <= 0 {
+		cleanupWait = gameBananaCleanupWait
+	}
+	if profile == nil && parent != nil {
+		if host := parent.native(); host != nil {
+			profile = &nativeLoginWindow{window: host}
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if factory == nil {
+		if profile == nil {
+			return nil
+		}
+		return clearGameBananaCookies(ctx, profile)
+	}
+	started := time.Now()
+	stage := "create-logout-window"
 	window, err := factory()
 	if err != nil {
-		return err
+		return infra.AnnotateError(err, infra.Diagnostic{Operation: "login", Stage: stage})
 	}
 	if window == nil {
 		return gamebanana.ErrAutoLoginUnsupported
 	}
 	defer window.Close()
-
 	completed := make(chan struct{})
 	var once sync.Once
 	unsub := window.OnWindowEvent(events.Windows.WebViewNavigationCompleted, func(*application.WindowEvent) {
 		once.Do(func() { close(completed) })
 	})
 	defer unsub()
-
-	waitCtx, cancel := context.WithTimeout(ctx, gameBananaLogoutWait)
-	defer cancel()
+	waitCtx, cancel := context.WithTimeout(ctx, navigationWait)
+	window.Run()
+	stage = "wait-logout-navigation"
+	navigated := false
 	select {
 	case <-waitCtx.Done():
-		return waitCtx.Err()
+		err = waitCtx.Err()
 	case <-completed:
+		navigated = true
 	}
-
-	timer := time.NewTimer(gameBananaReadyWait)
-	defer timer.Stop()
-	select {
-	case <-waitCtx.Done():
-		return waitCtx.Err()
-	case <-timer.C:
+	cancel()
+	if err == nil {
+		stage = "clear-webview-cookies"
+		cleanCtx, cleanCancel := context.WithTimeout(ctx, cleanupWait)
+		timer := time.NewTimer(gameBananaReadyWait)
+		select {
+		case <-cleanCtx.Done():
+			err = cleanCtx.Err()
+		case <-timer.C:
+			err = clearGameBananaCookies(cleanCtx, window)
+		}
+		timer.Stop()
+		cleanCancel()
 	}
-	return clearGameBananaCookies(waitCtx, window)
+	if err == nil {
+		closeCtx, closeCancel := context.WithTimeout(ctx, cleanupWait)
+		defer closeCancel()
+		window.Close()
+		return infra.AnnotateError(window.WaitClosed(closeCtx), infra.Diagnostic{
+			Operation: "login", Stage: "close-logout-window",
+			Fields: map[string]any{"windowID": window.ID(), "elapsedMs": time.Since(started).Milliseconds(), "cleanupTimeoutMs": cleanupWait.Milliseconds()},
+		})
+	}
+	original := infra.AnnotateError(err, infra.Diagnostic{Operation: "login", Stage: stage})
+	fields := map[string]any{
+		"windowID": window.ID(), "navigationCompleted": navigated,
+		"navigationTimeoutMs": navigationWait.Milliseconds(), "cleanupTimeoutMs": cleanupWait.Milliseconds(),
+		"fallbackAttempted": false,
+	}
+	if ctx.Err() != nil {
+		fields["contextError"] = ctx.Err().Error()
+		fields["elapsedMs"] = time.Since(started).Milliseconds()
+		return infra.AnnotateError(original, infra.Diagnostic{Operation: "login", Stage: stage, Fields: fields})
+	}
+	fields["fallbackAttempted"] = true
+	fallbackCtx, fallbackCancel := context.WithTimeout(ctx, cleanupWait)
+	defer fallbackCancel()
+	stage = "close-logout-window"
+	window.Close()
+	err = window.WaitClosed(fallbackCtx)
+	if err == nil {
+		stage = "fallback-clear-profile"
+		if profile == nil {
+			err = errors.New("shared WebView profile is unavailable")
+		} else {
+			err = clearGameBananaCookies(fallbackCtx, profile)
+		}
+	}
+	fields["elapsedMs"] = time.Since(started).Milliseconds()
+	fields["fallbackSucceeded"] = err == nil
+	if fallbackCtx.Err() != nil {
+		fields["contextError"] = fallbackCtx.Err().Error()
+	}
+	diagnostic := infra.Diagnostic{Severity: infra.DiagnosticWarn, Operation: "login", Stage: stage, Fields: fields, Causes: []error{original}}
+	if err != nil {
+		return infra.AnnotateError(err, diagnostic)
+	}
+	_ = infra.ReportError(l.log, original, "GameBananaLogin.recover", diagnostic)
+	return nil
 }
 
 func clearGameBananaCookies(ctx context.Context, window loginWindow) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	cookies, err := window.GetCookies(ctx, gameBananaCookieURI)
 	if err != nil {
-		return ignoreUnsupportedCookies(err)
+		return err
 	}
 	// WebView2 rejects the documented empty-name wildcard with E_INVALIDARG,
 	// so always delete GameBanana's known auth cookies by name and include any
@@ -319,14 +401,7 @@ func clearGameBananaCookies(ctx context.Context, window loginWindow) error {
 		seen[cookie.Name] = struct{}{}
 		names = append(names, cookie.Name)
 	}
-	return ignoreUnsupportedCookies(window.DeleteCookies(ctx, gameBananaCookieURI, names...))
-}
-
-func ignoreUnsupportedCookies(err error) error {
-	if errors.Is(err, application.ErrWebviewCookiesUnsupported) {
-		return nil
-	}
-	return err
+	return window.DeleteCookies(ctx, gameBananaCookieURI, names...)
 }
 
 func (l *gameBananaLogin) Close() {
@@ -345,10 +420,10 @@ func (l *gameBananaLogin) Close() {
 	}
 }
 
-func (l *gameBananaLogin) handleWindowClosing() {
+func (l *gameBananaLogin) handleWindowClosing(window loginWindow) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.closed {
+	if l.closed || l.window != window {
 		return
 	}
 	l.closed = true
@@ -382,13 +457,16 @@ func (l *gameBananaLogin) finishLocked() {
 	select {
 	case <-l.done:
 	default:
+		if l.call != nil {
+			l.call.cookie, l.call.err = l.result, l.err
+		}
 		close(l.done)
 	}
 }
 
-func (l *gameBananaLogin) settle(cookie string, err error) {
+func (l *gameBananaLogin) settle(window loginWindow, cookie string, err error) {
 	l.mu.Lock()
-	if l.settled {
+	if l.settled || l.window != window {
 		l.mu.Unlock()
 		return
 	}
@@ -396,7 +474,6 @@ func (l *gameBananaLogin) settle(cookie string, err error) {
 	l.result = cookie
 	l.err = err
 	l.programmatic = true
-	window := l.window
 	l.window = nil
 	l.closed = true
 	if l.unsub != nil {
@@ -426,12 +503,6 @@ func (l *gameBananaLogin) poll(ctx context.Context, validate gamebanana.CookieVa
 	for {
 		select {
 		case <-ctx.Done():
-			l.mu.Lock()
-			already := l.settled || l.closed
-			l.mu.Unlock()
-			if !already && ctx.Err() != nil && !errors.Is(ctx.Err(), context.Canceled) {
-				l.settle("", gamebanana.ErrAuthFailed)
-			}
 			return
 		case <-ticker.C:
 			if !l.pollOnce(ctx, validate) {
@@ -443,7 +514,7 @@ func (l *gameBananaLogin) poll(ctx context.Context, validate gamebanana.CookieVa
 
 func (l *gameBananaLogin) pollOnce(ctx context.Context, validate gamebanana.CookieValidator) bool {
 	l.mu.Lock()
-	if l.settled || l.closed {
+	if l.settled || l.closed || ctx.Err() != nil {
 		l.mu.Unlock()
 		return false
 	}
@@ -463,8 +534,10 @@ func (l *gameBananaLogin) pollOnce(ctx context.Context, validate gamebanana.Cook
 
 	cookies, err := window.GetCookies(ctx, gameBananaCookieURI)
 	l.mu.Lock()
-	l.pollInFlight = false
-	if l.settled || l.closed {
+	if l.window == window && ctx.Err() == nil {
+		l.pollInFlight = false
+	}
+	if l.settled || l.closed || ctx.Err() != nil {
 		l.mu.Unlock()
 		return false
 	}
@@ -474,7 +547,7 @@ func (l *gameBananaLogin) pollOnce(ctx context.Context, validate gamebanana.Cook
 			return false
 		}
 		if errors.Is(err, application.ErrWebviewCookiesUnsupported) {
-			l.settle("", infra.AnnotateError(classifyLoginWindowError(err), l.cookieDiagnostic(ctx, "poll-cookies")))
+			l.settle(window, "", infra.AnnotateError(classifyLoginWindowError(err), l.cookieDiagnostic(ctx, "poll-cookies")))
 			return false
 		}
 		l.pollDiagnostic.Report(l.log, err, "GameBananaLogin", l.cookieDiagnostic(ctx, "poll-cookies"))
@@ -499,6 +572,10 @@ func (l *gameBananaLogin) pollOnce(ctx context.Context, validate gamebanana.Cook
 	}
 
 	l.mu.Lock()
+	if ctx.Err() != nil || l.window != window {
+		l.mu.Unlock()
+		return false
+	}
 	if l.lastCandidates == nil {
 		l.lastCandidates = make(map[string]struct{})
 	}
@@ -516,13 +593,13 @@ func (l *gameBananaLogin) pollOnce(ctx context.Context, validate gamebanana.Cook
 	}
 
 	if validate == nil {
-		l.settle("", gamebanana.ErrAuthFailed)
+		l.settle(window, "", gamebanana.ErrAuthFailed)
 		return false
 	}
 	for _, candidate := range untried {
 		valid, verr := validate(ctx, candidate)
 		l.mu.Lock()
-		alreadyDone := l.settled || l.closed
+		alreadyDone := l.settled || l.closed || ctx.Err() != nil
 		l.mu.Unlock()
 		if alreadyDone {
 			return false
@@ -531,20 +608,22 @@ func (l *gameBananaLogin) pollOnce(ctx context.Context, validate gamebanana.Cook
 			if errors.Is(verr, context.Canceled) {
 				return false
 			}
-			l.settle("", infra.AnnotateError(
+			l.settle(window, "", infra.AnnotateError(
 				infra.WithCause(gamebanana.ClassifyLoginError(verr), verr),
 				l.cookieDiagnostic(ctx, "validate-cookie"),
 			))
 			return false
 		}
 		if valid {
-			l.settle(candidate, nil)
+			l.settle(window, candidate, nil)
 			return false
 		}
 	}
 	if err := window.DeleteCookies(ctx, gameBananaCookieURI, "rmc"); err == nil {
 		l.mu.Lock()
-		l.lastCandidates = nil
+		if ctx.Err() == nil && l.window == window {
+			l.lastCandidates = nil
+		}
 		l.mu.Unlock()
 	} else if !errors.Is(err, context.Canceled) {
 		diagnostic := l.cookieDiagnostic(ctx, "delete-invalid-cookie")
@@ -585,7 +664,7 @@ func (l *gameBananaLogin) createNativeWindow() (loginWindow, error) {
 	if app == nil || app.Window == nil {
 		return nil, gamebanana.ErrAutoLoginUnsupported
 	}
-	created := app.Window.NewWithOptions(application.WebviewWindowOptions{
+	created := application.NewWindow(application.WebviewWindowOptions{
 		Name:                       gameBananaLoginName,
 		Title:                      "GameBanana 로그인",
 		Width:                      540,
@@ -607,12 +686,7 @@ func (l *gameBananaLogin) createNativeWindow() (loginWindow, error) {
 	if created == nil {
 		return nil, gamebanana.ErrAutoLoginUnsupported
 	}
-	if parent != nil {
-		if host := parent.native(); host != nil {
-			host.AttachModal(created)
-		}
-	}
-	return &nativeLoginWindow{window: created}, nil
+	return &nativeLoginWindow{window: created, app: app, parent: parent}, nil
 }
 
 func (l *gameBananaLogin) createNativeLogoutWindow() (loginWindow, error) {
@@ -622,7 +696,7 @@ func (l *gameBananaLogin) createNativeLogoutWindow() (loginWindow, error) {
 	if app == nil || app.Window == nil {
 		return nil, gamebanana.ErrAutoLoginUnsupported
 	}
-	created := app.Window.NewWithOptions(application.WebviewWindowOptions{
+	created := application.NewWindow(application.WebviewWindowOptions{
 		Name:                       gameBananaLogoutName,
 		Title:                      "GameBanana 로그아웃",
 		Width:                      1,
@@ -639,11 +713,38 @@ func (l *gameBananaLogin) createNativeLogoutWindow() (loginWindow, error) {
 	if created == nil {
 		return nil, gamebanana.ErrAutoLoginUnsupported
 	}
-	return &nativeLoginWindow{window: created}, nil
+	return &nativeLoginWindow{window: created, app: app}, nil
 }
 
 type nativeLoginWindow struct {
 	window *application.WebviewWindow
+	app    *application.App
+	parent *Window
+}
+
+func (w *nativeLoginWindow) Run() {
+	w.app.Window.Add(w.window)
+	w.window.Run()
+	if w.parent != nil {
+		if host := w.parent.native(); host != nil {
+			host.AttachModal(w.window)
+		}
+	}
+}
+func (w *nativeLoginWindow) ID() uint { return w.window.ID() }
+func (w *nativeLoginWindow) WaitClosed(ctx context.Context) error {
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if _, exists := w.app.Window.GetByID(w.window.ID()); !exists {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 func (w *nativeLoginWindow) Show() application.Window { return w.window.Show() }

--- a/internal/app/gamebanana_login_diagnostic_test.go
+++ b/internal/app/gamebanana_login_diagnostic_test.go
@@ -121,8 +121,8 @@ func TestGameBananaCookiePollDeadlineDiagnostic(t *testing.T) {
 	if login.pollOnce(ctx, nil) {
 		t.Fatal("deadline did not stop polling")
 	}
-	if !strings.Contains(output.String(), `"contextError":"context deadline exceeded"`) {
-		t.Fatalf("deadline context missing: %s", output.String())
+	if win.gets.Load() != 0 {
+		t.Fatal("expired polling context reached WebView")
 	}
 }
 
@@ -150,6 +150,7 @@ func TestGameBananaLoginDiagnosticPreservesClassifiedCause(t *testing.T) {
 				login.factory = func() (loginWindow, error) { return nil, cause }
 				_, err = login.Open(context.Background(), nil)
 			case "logout-shared-webview-profile":
+				wantCode = gamebanana.ErrLoginInitFailed
 				login.factory = func() (loginWindow, error) { return newFakeLoginWindow(), nil }
 				login.logoutFactory = func() (loginWindow, error) { return nil, cause }
 				_, err = login.Open(context.Background(), nil)

--- a/internal/app/gamebanana_login_recovery_test.go
+++ b/internal/app/gamebanana_login_recovery_test.go
@@ -1,0 +1,163 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+	"github.com/wailsapp/wails/v3/pkg/events"
+
+	"nahida.live/desktop/internal/gamebanana"
+	"nahida.live/desktop/internal/infra"
+)
+
+func TestGameBananaLoginRecoversBeforeOpening(t *testing.T) {
+	for _, navigation := range []bool{false, true} {
+		t.Run(map[bool]string{false: "navigation-timeout", true: "cookie-error"}[navigation], func(t *testing.T) {
+			var output bytes.Buffer
+			logout := newFakeLoginWindow()
+			logout.autoReady = navigation
+			if navigation {
+				logout.getErr = errors.New("cookie read failed")
+			}
+			profile := newFakeLoginWindow(application.WebviewCookie{Name: "rmc", Value: "private-token"})
+			win := newFakeLoginWindow(application.WebviewCookie{Name: "rmc", Value: "candidate"})
+			login := newGameBananaLogin()
+			login.log = infra.NewLogWithOptions(infra.LogOptions{Writer: &output, DisableFile: true})
+			login.logoutWait = 5 * time.Millisecond
+			login.cleanupWait = time.Second
+			login.profile = profile
+			login.logoutFactory = func() (loginWindow, error) { return logout, nil }
+			var created atomic.Int32
+			login.factory = func() (loginWindow, error) {
+				created.Add(1)
+				if !logout.closed.Load() || profile.gets.Load() != 1 {
+					t.Error("login opened before fallback cleanup")
+				}
+				profile.mu.Lock()
+				defer profile.mu.Unlock()
+				if len(profile.cookies) != 0 {
+					t.Error("profile cookies remain")
+				}
+				return win, nil
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			cookie, err := login.Open(ctx, func(context.Context, string) (bool, error) { return true, nil })
+			if err != nil || cookie != "rmc=candidate" || created.Load() != 1 {
+				t.Fatalf("login failed: %v; windows=%d", err, created.Load())
+			}
+			for _, want := range []string{`"fallbackSucceeded":true`, `"fallbackAttempted":true`, `"windowID":1`, `"elapsedMs":`, "fallback-clear-profile"} {
+				if !strings.Contains(output.String(), want) {
+					t.Errorf("missing %s in %s", want, output.String())
+				}
+			}
+			if strings.Contains(output.String(), "private-token") {
+				t.Fatal("secret leaked")
+			}
+		})
+	}
+}
+
+func TestGameBananaLoginRejectsUnsafeFallback(t *testing.T) {
+	for _, kind := range []string{"close", "missing-profile", "unsupported", "delete", "cleanup-timeout", "cancel"} {
+		t.Run(kind, func(t *testing.T) {
+			logout := newFakeLoginWindow()
+			logout.autoReady = false
+			profile := newFakeLoginWindow()
+			login := newGameBananaLogin()
+			login.profile = profile
+			login.logoutWait = 5 * time.Millisecond
+			login.cleanupWait = 20 * time.Millisecond
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			switch kind {
+			case "close":
+				logout.waitCloseErr = errors.New("native window still exists")
+			case "missing-profile":
+				login.profile = nil
+			case "unsupported":
+				profile.getErr = application.ErrWebviewCookiesUnsupported
+			case "delete":
+				profile.deleteErr = errors.New("delete failed")
+			case "cleanup-timeout":
+				profile.holdGet = make(chan struct{})
+			case "cancel":
+				logout.runHook = cancel
+			}
+			login.logoutFactory = func() (loginWindow, error) { return logout, nil }
+			var created atomic.Int32
+			login.factory = func() (loginWindow, error) { created.Add(1); return newFakeLoginWindow(), nil }
+			_, err := login.Open(ctx, nil)
+			if err == nil || created.Load() != 0 {
+				t.Fatalf("unsafe fallback opened login: %v", err)
+			}
+			if kind == "close" || kind == "cancel" {
+				if profile.gets.Load() != 0 {
+					t.Fatal("cleanup started before safe close or after cancellation")
+				}
+			}
+		})
+	}
+}
+
+func TestGameBananaLoginDeadlineClosesWindow(t *testing.T) {
+	win := newFakeLoginWindow()
+	win.autoReady = false
+	login := newGameBananaLogin()
+	login.factory = func() (loginWindow, error) { return win, nil }
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err := login.Open(ctx, nil)
+	if !errors.Is(err, context.DeadlineExceeded) || !win.closed.Load() {
+		t.Fatalf("deadline left window alive: %v", err)
+	}
+	win.emit(events.Windows.WebViewNavigationCompleted)
+	if win.gets.Load() != 0 {
+		t.Fatal("late navigation started polling")
+	}
+}
+
+func TestGameBananaOldWindowCannotCloseNewLogin(t *testing.T) {
+	first := newFakeLoginWindow(application.WebviewCookie{Name: "rmc", Value: "first"})
+	second := newFakeLoginWindow()
+	second.autoReady = false
+	login := newGameBananaLogin()
+	login.factory = func() (loginWindow, error) { return first, nil }
+	if _, err := login.Open(context.Background(), func(context.Context, string) (bool, error) { return true, nil }); err != nil {
+		t.Fatal(err)
+	}
+	started := make(chan struct{})
+	second.runHook = func() { close(started) }
+	login.factory = func() (loginWindow, error) { return second, nil }
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { _, err := login.Open(ctx, nil); done <- err }()
+	<-started
+	first.emit(events.Common.WindowClosing)
+	first.emit(events.Windows.WebViewNavigationCompleted)
+	login.mu.Lock()
+	closed := login.closed
+	login.mu.Unlock()
+	if closed || second.closed.Load() {
+		t.Fatal("old event closed new login")
+	}
+	cancel()
+	<-done
+}
+
+func TestGameBananaInitializationErrorCode(t *testing.T) {
+	login := newGameBananaLogin()
+	login.factory = func() (loginWindow, error) { return newFakeLoginWindow(), nil }
+	login.logoutFactory = func() (loginWindow, error) { return nil, errors.New("native failure") }
+	_, err := login.Open(context.Background(), nil)
+	if !errors.Is(err, gamebanana.ErrLoginInitFailed) {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/internal/app/gamebanana_login_test.go
+++ b/internal/app/gamebanana_login_test.go
@@ -35,6 +35,8 @@ type fakeLoginWindow struct {
 	cookieScopeURI     string
 	suppressCloseEvent bool
 	autoReady          bool
+	waitCloseErr       error
+	runHook            func()
 }
 
 func newFakeLoginWindow(cookies ...application.WebviewCookie) *fakeLoginWindow {
@@ -45,6 +47,25 @@ func newFakeLoginWindow(cookies ...application.WebviewCookie) *fakeLoginWindow {
 	}
 }
 
+func (w *fakeLoginWindow) Run() {
+	if w.runHook != nil {
+		w.runHook()
+	}
+	if w.autoReady {
+		w.emit(events.Windows.WebViewNavigationCompleted)
+	}
+}
+func (w *fakeLoginWindow) ID() uint { return 1 }
+func (w *fakeLoginWindow) WaitClosed(ctx context.Context) error {
+	if w.waitCloseErr != nil {
+		return w.waitCloseErr
+	}
+	if w.closed.Load() {
+		return nil
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
 func (w *fakeLoginWindow) Show() application.Window {
 	w.shows.Add(1)
 	return nil
@@ -126,14 +147,7 @@ func (w *fakeLoginWindow) DeleteCookies(_ context.Context, uri string, names ...
 func (w *fakeLoginWindow) OnWindowEvent(eventType events.WindowEventType, callback func(*application.WindowEvent)) func() {
 	w.mu.Lock()
 	w.listeners[eventType] = append(w.listeners[eventType], callback)
-	autoReady := w.autoReady && eventType == events.Windows.WebViewNavigationCompleted
 	w.mu.Unlock()
-	if autoReady {
-		go func() {
-			time.Sleep(time.Millisecond)
-			w.emit(events.Windows.WebViewNavigationCompleted)
-		}()
-	}
 	return func() {}
 }
 func (w *fakeLoginWindow) emit(eventType events.WindowEventType) {
@@ -547,7 +561,7 @@ func TestGameBananaLoginDoesNotCreateWindowWhenSharedSessionLogoutFails(t *testi
 	_, err := login.Open(context.Background(), func(context.Context, string) (bool, error) {
 		return true, nil
 	})
-	if !errors.Is(err, gamebanana.ErrAuthFailed) {
+	if !errors.Is(err, gamebanana.ErrLoginInitFailed) {
 		t.Fatalf("err = %v", err)
 	}
 	if created.Load() != 0 {

--- a/internal/gamebanana/errors.go
+++ b/internal/gamebanana/errors.go
@@ -9,6 +9,8 @@ const (
 	errCodeAutoLoginUnsupported = "GAMEBANANA_AUTO_LOGIN_UNSUPPORTED"
 	errCodeServerUnreachable    = "GAMEBANANA_SERVER_UNREACHABLE"
 	errCodeInvalidRMC           = "GAMEBANANA_INVALID_RMC"
+	errCodeLoginInitFailed      = "GAMEBANANA_LOGIN_INIT_FAILED"
+	errCodeAuthCheckFailed      = "GAMEBANANA_AUTH_CHECK_FAILED"
 )
 
 var (
@@ -18,4 +20,6 @@ var (
 	ErrAutoLoginUnsupported = errors.New(errCodeAutoLoginUnsupported)
 	ErrServerUnreachable    = errors.New(errCodeServerUnreachable)
 	ErrInvalidRMC           = errors.New(errCodeInvalidRMC)
+	ErrLoginInitFailed      = errors.New(errCodeLoginInitFailed)
+	ErrAuthCheckFailed      = errors.New(errCodeAuthCheckFailed)
 )

--- a/internal/gamebanana/gamebanana.go
+++ b/internal/gamebanana/gamebanana.go
@@ -96,6 +96,9 @@ type ToggleLikeResult struct {
 }
 
 type GameBanana struct {
+	cookieMu       sync.Mutex
+	cookieRevision uint64
+	cookieLoaded   bool
 	mu             sync.Mutex
 	http           *infra.Client
 	log            *infra.Log
@@ -110,6 +113,8 @@ type GameBanana struct {
 
 	loginMu           sync.Mutex
 	login             *loginCall
+	loggingOut        bool
+	shuttingDown      bool
 	openLogin         OpenLoginFunc
 	clearLoginCookies ClearLoginCookiesFunc
 }
@@ -154,25 +159,7 @@ func (g *GameBanana) GetGames() map[string]int {
 }
 
 func (g *GameBanana) EnsureSession(ctx context.Context) error {
-	cookie, err := g.getCookie(ctx)
-	if err != nil {
-		return err
-	}
-
-	if cookie != "" {
-		valid, _, err := g.validateStoredRMCCookie(ctx, cookie)
-		if err != nil {
-			return classifyLoginError(err)
-		}
-		if valid {
-			return nil
-		}
-		if err := g.removeCookie(ctx); err != nil {
-			return err
-		}
-	}
-
-	_, err = g.openAuthenticatedSession(ctx)
+	_, err := g.openAuthenticatedSession(ctx)
 	return err
 }
 
@@ -181,9 +168,24 @@ func (g *GameBanana) SetManualRMCToken(ctx context.Context, input string) (Manua
 	if !normalized {
 		return ManualRMCSaveResult{ErrorCode: "GAMEBANANA_INVALID_RMC"}, nil
 	}
+	g.loginMu.Lock()
+	if g.loggingOut || g.shuttingDown {
+		g.loginMu.Unlock()
+		return ManualRMCSaveResult{ErrorCode: "GAMEBANANA_MANUAL_RMC_SAVE_FAILED"}, nil
+	}
+	_, revision, err := g.cookieSnapshot(ctx)
+	g.loginMu.Unlock()
+	if err != nil {
+		g.reportRecovery(err, "load-manual-cookie")
+		return ManualRMCSaveResult{ErrorCode: "GAMEBANANA_MANUAL_RMC_SAVE_FAILED"}, nil
+	}
 	valid, merged, err := g.validateCandidateRMCCookie(ctx, cookie)
 	if err != nil {
+		g.reportRecovery(err, "validate-manual-cookie")
 		code := "GAMEBANANA_MANUAL_RMC_SAVE_FAILED"
+		if errors.Is(err, ErrAuthCheckFailed) {
+			code = errCodeAuthCheckFailed
+		}
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(classifyLoginError(err), ErrServerUnreachable) {
 			code = errCodeServerUnreachable
 		}
@@ -195,35 +197,40 @@ func (g *GameBanana) SetManualRMCToken(ctx context.Context, input string) (Manua
 	if merged == "" {
 		merged = cookie
 	}
-	if !g.persistManualCookie(ctx, merged) {
+	if !g.persistManualCookie(ctx, revision, merged) {
 		return ManualRMCSaveResult{ErrorCode: "GAMEBANANA_MANUAL_RMC_SAVE_FAILED"}, nil
 	}
 	return ManualRMCSaveResult{OK: true}, nil
 }
 
 func (g *GameBanana) Logout(ctx context.Context) error {
-	g.cancelLogin()
-	cookie, err := g.getCookie(ctx)
+	g.loginMu.Lock()
+	if g.loggingOut {
+		g.loginMu.Unlock()
+		return ErrLoginCancelled
+	}
+	g.loggingOut = true
+	if g.login != nil {
+		g.login.cancel()
+		g.login = nil
+	}
+	g.loginMu.Unlock()
+	defer func() {
+		g.loginMu.Lock()
+		g.loggingOut = false
+		g.loginMu.Unlock()
+	}()
+	cookie, err := g.takeCookie(ctx)
 	if err != nil {
-		return err
+		return infra.ReportError(g.log, err, "GameBananaService.logout", infra.Diagnostic{Severity: infra.DiagnosticWarn, Operation: "logout", Stage: "invalidate-cookie"})
 	}
 	var clearErr error
 	if g.clearLoginCookies != nil {
 		clearErr = g.clearLoginCookies(ctx)
-		if clearErr != nil && g.log != nil {
-			g.log.Warn(map[string]any{
-				"stage": "webview-logout",
-				"error": sanitizeLogMessage(clearErr.Error()),
-			}, "GameBananaService.logout")
-		}
+		clearErr = infra.ReportError(g.log, clearErr, "GameBananaService.logout", infra.Diagnostic{Severity: infra.DiagnosticWarn, Operation: "logout", Stage: "webview-logout"})
 	}
 	if cookie != "" {
-		if logoutErr := g.logoutWebSession(ctx, cookie); logoutErr != nil && g.log != nil {
-			g.log.Warn(sanitizeLogMessage(logoutErr.Error()), "GameBananaService.logout")
-		}
-	}
-	if err := g.removeCookie(ctx); err != nil {
-		return err
+		_ = infra.ReportError(g.log, g.logoutWebSession(ctx, cookie), "GameBananaService.logout", infra.Diagnostic{Severity: infra.DiagnosticWarn, Operation: "logout", Stage: "backend-logout"})
 	}
 	return clearErr
 }
@@ -540,13 +547,13 @@ func (g *GameBanana) request(ctx context.Context, method, rawURL string, header 
 	} else {
 		header = header.Clone()
 	}
+	stored, revision, err := g.cookieSnapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
 	cookie := policy.Cookie
 	if cookie == "" {
-		var err error
-		cookie, err = g.getCookie(ctx)
-		if err != nil {
-			return nil, err
-		}
+		cookie = stored
 	}
 	if cookie != "" {
 		header.Set("Cookie", cookie)
@@ -557,47 +564,50 @@ func (g *GameBanana) request(ctx context.Context, method, rawURL string, header 
 		return nil, err
 	}
 	diagnostic = infra.HTTPDiagnostic(method, rawURL, "response", response)
-	mergedCookie := cookie
-	if policy.PersistResponseCookies {
-		if merged := mergeSetCookies(cookie, response.Header.Values("Set-Cookie")); merged != "" && merged != cookie {
-			if saveErr := g.saveCookie(ctx, merged); saveErr != nil {
-				_ = response.Body.Close()
-				return nil, saveErr
-			}
-			mergedCookie = merged
-		}
+	if diagnostic.Fields == nil {
+		diagnostic.Fields = make(map[string]any)
 	}
-	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		_, _ = io.Copy(io.Discard, response.Body)
-		_ = response.Body.Close()
-		if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden {
-			if !policy.SkipAuthRetry {
-				return g.retryAuthenticatedRequest(ctx, method, rawURL, header, policy, cookie, mergedCookie)
-			}
-			if policy.ClearStoredCookieOnAuth {
-				g.reportRecovery(g.removeCookie(ctx), "remove-cookie")
-			}
-			return nil, ErrAuthFailed
-		}
+	diagnostic.Fields["contentType"] = response.Header.Get("Content-Type")
+	body, readErr := io.ReadAll(response.Body)
+	_ = response.Body.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= 500 {
+		diagnostic.Fields["reason"] = "server-unavailable"
 		return nil, &gameBananaHTTPError{Status: response.StatusCode}
 	}
-	if body, readErr := io.ReadAll(response.Body); readErr != nil {
-		_ = response.Body.Close()
-		return nil, readErr
-	} else {
-		_ = response.Body.Close()
-		response.Body = io.NopCloser(bytes.NewReader(body))
-		if isLoginRequiredBody(body) {
-			_ = response.Body.Close()
-			if !policy.SkipAuthRetry {
-				return g.retryAuthenticatedRequest(ctx, method, rawURL, header, policy, cookie, mergedCookie)
+	if response.StatusCode == http.StatusUnauthorized || isLoginRequiredBody(body) {
+		diagnostic.Fields["reason"] = "authentication-required"
+		if !policy.SkipAuthRetry {
+			return g.retryAuthenticatedRequest(ctx, method, rawURL, header, policy, revision)
+		}
+		if policy.ClearStoredCookieOnAuth {
+			_, clearErr := g.updateCookie(ctx, revision, "")
+			g.reportRecovery(clearErr, "remove-cookie")
+		}
+		return nil, ErrAuthFailed
+	}
+	if response.StatusCode == http.StatusForbidden {
+		diagnostic.Fields["reason"] = "access-denied"
+		return nil, ErrAuthCheckFailed
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, &gameBananaHTTPError{Status: response.StatusCode}
+	}
+	// API responses must be JSON before response cookies can mutate a session.
+	if strings.HasPrefix(rawURL, g.baseURL+"/") && response.StatusCode != http.StatusNoContent && !json.Valid(body) {
+		diagnostic.Fields["reason"] = "invalid-json-response"
+		return nil, ErrAuthCheckFailed
+	}
+	if policy.PersistResponseCookies {
+		if merged := mergeSetCookies(cookie, response.Header.Values("Set-Cookie")); merged != "" && merged != cookie {
+			if _, saveErr := g.updateCookie(ctx, revision, merged); saveErr != nil {
+				return nil, saveErr
 			}
-			if policy.ClearStoredCookieOnAuth {
-				g.reportRecovery(g.removeCookie(ctx), "remove-cookie")
-			}
-			return nil, ErrAuthFailed
 		}
 	}
+	response.Body = io.NopCloser(bytes.NewReader(body))
 	return response, nil
 }
 
@@ -606,16 +616,23 @@ func (g *GameBanana) retryAuthenticatedRequest(
 	method, rawURL string,
 	header http.Header,
 	policy requestPolicy,
-	originalCookie, mergedCookie string,
+	revision uint64,
 ) (*http.Response, error) {
 	policy.SkipAuthRetry = true
 	policy.Cookie = ""
 	header = header.Clone()
 	header.Del("Cookie")
-	if mergedCookie == "" || mergedCookie == originalCookie {
+	current, latest, err := g.cookieSnapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if latest == revision {
 		if err := g.EnsureSession(ctx); err != nil {
 			return nil, err
 		}
+	} else if current == "" {
+		// Logout won the race; an old request must not reopen login.
+		return nil, ErrAuthRequired
 	}
 	return g.request(ctx, method, rawURL, header, policy)
 }
@@ -650,10 +667,12 @@ func (g *GameBanana) validateRMCCookie(ctx context.Context, cookie string, polic
 		return false, "", err
 	}
 	defer func() { _ = response.Body.Close() }()
+	diagnostic := infra.HTTPDiagnostic(http.MethodGet, g.baseURL+"/Member/Navigator/Personal", "validate-cookie-response", response)
+	diagnostic.Fields["contentType"] = response.Header.Get("Content-Type")
 	var value map[string]any
 	if err := json.NewDecoder(response.Body).Decode(&value); err != nil {
-		g.reportRecovery(err, "validate-cookie-response")
-		return false, "", nil
+		diagnostic.Fields["reason"] = "invalid-profile-json"
+		return false, "", infra.AnnotateError(infra.WithCause(ErrAuthCheckFailed, err), diagnostic)
 	}
 	if value["_sErrorCode"] == "LOGIN_REQUIRED" {
 		return false, "", nil
@@ -661,15 +680,21 @@ func (g *GameBanana) validateRMCCookie(ctx context.Context, cookie string, polic
 	_, usernameOK := value["_sUsername"].(string)
 	_, profileOK := value["_sProfileUrl"].(string)
 	if !usernameOK || !profileOK {
-		g.reportRecovery(errors.New("invalid cookie validation response: expected username and profile URL strings"), "validate-cookie-schema")
-		return false, "", nil
+		diagnostic.Stage = "validate-cookie-schema"
+		diagnostic.Fields["reason"] = "missing-profile-fields"
+		return false, "", infra.AnnotateError(ErrAuthCheckFailed, diagnostic)
 	}
 	return true, mergeSetCookies(cookie, response.Header.Values("Set-Cookie")), nil
 }
 
 func (g *GameBanana) getCookie(ctx context.Context) (string, error) {
+	cookie, _, err := g.cookieSnapshot(ctx)
+	return cookie, err
+}
+
+func (g *GameBanana) loadCookieLocked(ctx context.Context) (string, error) {
 	g.mu.Lock()
-	if g.sessionCookie != "" {
+	if g.cookieLoaded {
 		cookie := g.sessionCookie
 		g.mu.Unlock()
 		return cookie, nil
@@ -682,15 +707,17 @@ func (g *GameBanana) getCookie(ctx context.Context) (string, error) {
 	}
 	value, err := client.Settings.GetValue(ctx, cookieSettingKey)
 	if err != nil || value == nil || *value == "" {
+		g.cookieLoaded = err == nil
 		return "", err
 	}
 	decrypted, decryptErr := crypto.DecryptString(*value)
 	if decryptErr != nil {
-		g.reportRecovery(infra.WithCause(decryptErr, g.removeCookie(ctx)), "restore-cookie")
+		g.reportRecovery(infra.WithCause(decryptErr, g.removeCookieLocked(ctx)), "restore-cookie")
 		return "", nil
 	}
 	g.mu.Lock()
 	g.sessionCookie = decrypted
+	g.cookieLoaded = true
 	g.mu.Unlock()
 	return decrypted, nil
 }
@@ -700,17 +727,17 @@ func normalizedRMCCookie(input string) (string, bool) {
 	return cookie, err == nil
 }
 
-func (g *GameBanana) persistManualCookie(ctx context.Context, cookie string) bool {
-	err := g.saveCookie(ctx, cookie)
-	g.reportRecovery(err, "save-manual-cookie")
-	return err == nil
-}
-
 func (g *GameBanana) reportRecovery(err error, stage string) {
 	_ = infra.ReportError(g.log, err, "GameBanana", infra.Diagnostic{Severity: infra.DiagnosticWarn, Operation: "authentication", Stage: stage})
 }
 
 func (g *GameBanana) saveCookie(ctx context.Context, cookie string) error {
+	g.cookieMu.Lock()
+	defer g.cookieMu.Unlock()
+	return g.saveCookieLocked(ctx, cookie)
+}
+
+func (g *GameBanana) saveCookieLocked(ctx context.Context, cookie string) error {
 	rmc := cookieValue(cookie, "rmc")
 	if rmc == "" {
 		return ErrInvalidRMC
@@ -732,15 +759,19 @@ func (g *GameBanana) saveCookie(ctx context.Context, cookie string) error {
 	}
 	g.mu.Lock()
 	g.sessionCookie = cookie
+	g.cookieLoaded = true
 	g.mu.Unlock()
+	g.cookieRevision++
 	return nil
 }
 
-func (g *GameBanana) removeCookie(ctx context.Context) error {
+func (g *GameBanana) removeCookieLocked(ctx context.Context) error {
 	g.mu.Lock()
 	g.sessionCookie = ""
+	g.cookieLoaded = true
 	client := g.client
 	g.mu.Unlock()
+	g.cookieRevision++
 	if client == nil {
 		return nil
 	}

--- a/internal/gamebanana/gamebanana_test.go
+++ b/internal/gamebanana/gamebanana_test.go
@@ -395,14 +395,14 @@ func TestToggleModLikeReauthenticatesLoginRequiredBody(t *testing.T) {
 	}
 }
 
-func TestRequestReauthenticatesAndRetriesForbidden(t *testing.T) {
+func TestRequestReauthenticatesAndRetriesUnauthorized(t *testing.T) {
 	var subfeedCalls int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		switch request.URL.Path {
 		case "/apiv13/Game/8552/Subfeed":
 			subfeedCalls++
 			if request.Header.Get("Cookie") != "rmc=fresh" {
-				w.WriteHeader(http.StatusForbidden)
+				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}
 			_, _ = io.WriteString(w, `{"_aMetadata":{"_nRecordCount":0,"_nPerpage":15,"_bIsComplete":true},"_aRecords":[]}`)
@@ -411,7 +411,7 @@ func TestRequestReauthenticatesAndRetriesForbidden(t *testing.T) {
 				_, _ = io.WriteString(w, validMemberJSON)
 				return
 			}
-			w.WriteHeader(http.StatusForbidden)
+			w.WriteHeader(http.StatusUnauthorized)
 		default:
 			http.NotFound(w, request)
 		}

--- a/internal/gamebanana/login.go
+++ b/internal/gamebanana/login.go
@@ -35,9 +35,9 @@ func (g *GameBanana) openAuthenticatedSession(ctx context.Context) (string, erro
 	}
 
 	g.loginMu.Lock()
-	if g.openLogin == nil {
+	if g.loggingOut || g.shuttingDown {
 		g.loginMu.Unlock()
-		return "", ErrAutoLoginUnsupported
+		return "", ErrLoginCancelled
 	}
 	if call := g.login; call != nil {
 		g.loginMu.Unlock()
@@ -65,6 +65,56 @@ func (g *GameBanana) runLogin(ctx context.Context, call *loginCall, openLogin Op
 		g.loginMu.Unlock()
 		close(call.done)
 	}()
+	var revision uint64
+	for {
+		if err := ctx.Err(); err != nil {
+			call.err = err
+			return
+		}
+		stored, current, err := g.cookieSnapshot(ctx)
+		if err != nil {
+			call.err = err
+			return
+		}
+		revision = current
+		if stored == "" {
+			break
+		}
+		valid, merged, err := g.validateStoredRMCCookie(ctx, stored)
+		_, latest, snapshotErr := g.cookieSnapshot(ctx)
+		if snapshotErr != nil {
+			call.err = snapshotErr
+			return
+		}
+		if latest != revision {
+			continue
+		}
+		if err != nil {
+			call.err = infra.ReportError(g.log, infra.WithCause(classifyLoginError(err), err), "GameBananaService.login", infra.Diagnostic{Severity: infra.DiagnosticWarn, Operation: "login", Stage: "validate-stored-cookie"})
+			return
+		}
+		if !valid {
+			merged = ""
+		}
+		applied, err := g.updateCookie(ctx, revision, merged)
+		if err != nil {
+			g.reportRecovery(err, "persist-validated-cookie")
+			call.err = err
+			return
+		}
+		if !applied {
+			continue
+		}
+		if valid {
+			call.cookie = merged
+			return
+		}
+		// Read the new revision before opening; another accepted session wins.
+	}
+	if openLogin == nil {
+		call.err = ErrAutoLoginUnsupported
+		return
+	}
 
 	var validatedMu sync.Mutex
 	validatedCookies := make(map[string]string)
@@ -95,8 +145,19 @@ func (g *GameBanana) runLogin(ctx context.Context, call *loginCall, openLogin Op
 		call.err = ErrAuthFailed
 		return
 	}
-	if err := g.saveCookie(ctx, merged); err != nil {
+	applied, err := g.updateCookie(ctx, revision, merged)
+	if err != nil {
 		call.err = infra.ReportError(g.log, infra.WithCause(classifyLoginError(err), err), "GameBananaService.login", infra.Diagnostic{Severity: infra.DiagnosticWarn, Operation: "login", Stage: "persist-cookie"})
+		return
+	}
+	if !applied {
+		// A concurrently accepted manual session satisfies the waiting callers.
+		// An empty session means logout won, and must never reopen login.
+		current, _, snapshotErr := g.cookieSnapshot(ctx)
+		call.cookie, call.err = current, snapshotErr
+		if snapshotErr == nil && current == "" {
+			call.err = ErrLoginCancelled
+		}
 		return
 	}
 	call.cookie = merged
@@ -128,6 +189,7 @@ func (g *GameBanana) cancelLogin() {
 	}
 	g.loginMu.Lock()
 	call := g.login
+	g.login = nil
 	g.loginMu.Unlock()
 	if call != nil && call.cancel != nil {
 		call.cancel()
@@ -136,6 +198,9 @@ func (g *GameBanana) cancelLogin() {
 
 // ServiceShutdown cancels any in-flight login session.
 func (g *GameBanana) ServiceShutdown() error {
+	g.loginMu.Lock()
+	g.shuttingDown = true
+	g.loginMu.Unlock()
 	g.cancelLogin()
 	return nil
 }
@@ -159,11 +224,16 @@ func classifyLoginError(err error) error {
 	if errors.Is(err, ErrServerUnreachable) || errorCode(err) == errCodeServerUnreachable {
 		return ErrServerUnreachable
 	}
+	for _, classified := range []error{ErrLoginInitFailed, ErrAuthCheckFailed} {
+		if errors.Is(err, classified) || errorCode(err) == classified.Error() {
+			return classified
+		}
+	}
 	if errors.Is(err, context.DeadlineExceeded) {
-		return ErrAuthFailed
+		return ErrServerUnreachable
 	}
 	var httpErr *gameBananaHTTPError
-	if errors.As(err, &httpErr) && httpErr.Status >= 500 {
+	if errors.As(err, &httpErr) && (httpErr.Status >= 500 || httpErr.Status == 429) {
 		return ErrServerUnreachable
 	}
 	if isUnreachable(err) {

--- a/internal/gamebanana/login_test.go
+++ b/internal/gamebanana/login_test.go
@@ -150,14 +150,16 @@ func TestEnsureSessionPersistsRotatedRMCWithoutRevalidatingOldCookie(t *testing.
 	}
 }
 
-func TestEnsureSessionDoesNotPersistRotatedStoredCookie(t *testing.T) {
+func TestEnsureSessionPersistsRotatedStoredCookie(t *testing.T) {
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
-		if request.Header.Get("Cookie") != "rmc=initial" {
-			t.Fatalf("cookie = %q, want stored cookie", request.Header.Get("Cookie"))
+		if requests.Add(1) == 1 {
+			w.Header().Add("Set-Cookie", "rmc=rotated; Path=/; HttpOnly")
+			w.Header().Add("Set-Cookie", "sess=live; Path=/; HttpOnly")
+		} else if cookieValue(request.Header.Get("Cookie"), "rmc") != "rotated" {
+			_, _ = io.WriteString(w, `{"_sErrorCode":"LOGIN_REQUIRED"}`)
+			return
 		}
-		requests.Add(1)
-		w.Header().Add("Set-Cookie", "rmc=rotated; Path=/; HttpOnly")
 		_, _ = io.WriteString(w, validMemberJSON)
 	}))
 	t.Cleanup(server.Close)
@@ -165,19 +167,23 @@ func TestEnsureSessionDoesNotPersistRotatedStoredCookie(t *testing.T) {
 	if err := service.saveCookie(context.Background(), "rmc=initial"); err != nil {
 		t.Fatal(err)
 	}
-
-	if err := service.EnsureSession(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	if err := service.EnsureSession(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	if requests.Load() != 2 {
-		t.Fatalf("requests = %d, want 2", requests.Load())
+	for range 2 {
+		if err := service.EnsureSession(context.Background()); err != nil {
+			t.Fatal(err)
+		}
 	}
 	stored, err := client.Settings.GetValue(context.Background(), cookieSettingKey)
-	if err != nil || stored == nil || *stored != "rmc=initial" {
-		t.Fatalf("stored = %v, error = %v", stored, err)
+	if err != nil || stored == nil || *stored != "rmc=rotated" {
+		t.Fatalf("stored cookie was not rotated: %v", err)
+	}
+	cookie, err := service.getCookie(context.Background())
+	if err != nil || cookieValue(cookie, "sess") != "live" {
+		t.Fatal("session cookie missing from memory")
+	}
+	restored := NewWithOptions(Options{HTTP: service.http, Crypto: service.crypto, BaseURL: service.baseURL})
+	restored.UseClient(client)
+	if err := restored.EnsureSession(context.Background()); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -278,7 +284,7 @@ func TestEnsureSessionTreatsUnauthorizedStoredCookieAsInvalidThenLogsIn(t *testi
 	}
 }
 
-func TestEnsureSessionTreatsBadProfileAsInvalidThenLogsIn(t *testing.T) {
+func TestEnsureSessionPreservesCookieOnBadProfile(t *testing.T) {
 	var opens atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		if request.Header.Get("Cookie") == "rmc=stale" {
@@ -303,14 +309,14 @@ func TestEnsureSessionTreatsBadProfileAsInvalidThenLogsIn(t *testing.T) {
 		}
 		return "rmc=fresh", nil
 	}
-	if err := service.EnsureSession(context.Background()); err != nil {
+	if err := service.EnsureSession(context.Background()); !errors.Is(err, ErrAuthCheckFailed) {
 		t.Fatal(err)
 	}
-	if opens.Load() != 1 {
+	if opens.Load() != 0 {
 		t.Fatalf("opens = %d", opens.Load())
 	}
 	stored, err := client.Settings.GetValue(context.Background(), cookieSettingKey)
-	if err != nil || stored == nil || *stored != "rmc=fresh" {
+	if err != nil || stored == nil || *stored != "rmc=stale" {
 		t.Fatalf("stored = %v, error = %v", stored, err)
 	}
 }

--- a/internal/gamebanana/session.go
+++ b/internal/gamebanana/session.go
@@ -1,0 +1,47 @@
+package gamebanana
+
+import "context"
+
+func (g *GameBanana) persistManualCookie(ctx context.Context, revision uint64, cookie string) bool {
+	applied, err := g.updateCookie(ctx, revision, cookie)
+	g.reportRecovery(err, "save-manual-cookie")
+	return applied && err == nil
+}
+
+// cookieMu serializes persistent and in-memory state; network calls never hold it.
+func (g *GameBanana) cookieSnapshot(ctx context.Context) (string, uint64, error) {
+	g.cookieMu.Lock()
+	defer g.cookieMu.Unlock()
+	cookie, err := g.loadCookieLocked(ctx)
+	return cookie, g.cookieRevision, err
+}
+
+func (g *GameBanana) updateCookie(ctx context.Context, revision uint64, cookie string) (bool, error) {
+	g.cookieMu.Lock()
+	defer g.cookieMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	if revision != g.cookieRevision {
+		return false, nil
+	}
+	if cookie == "" {
+		return true, g.removeCookieLocked(ctx)
+	}
+	if g.cookieLoaded && cookie == g.sessionCookie {
+		return true, nil
+	}
+	return true, g.saveCookieLocked(ctx, cookie)
+}
+
+// Invalidate pending responses before starting remote logout.
+func (g *GameBanana) takeCookie(ctx context.Context) (string, error) {
+	g.cookieMu.Lock()
+	defer g.cookieMu.Unlock()
+	cookie, err := g.loadCookieLocked(ctx)
+	if err != nil {
+		g.cookieRevision++
+		return "", err
+	}
+	return cookie, g.removeCookieLocked(ctx)
+}

--- a/internal/gamebanana/session_test.go
+++ b/internal/gamebanana/session_test.go
@@ -1,0 +1,369 @@
+package gamebanana
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"nahida.live/desktop/internal/infra"
+)
+
+func TestAuthenticationResponseClassification(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		status     int
+		body, code string
+		invalid    bool
+	}{
+		{"unauthorized", 401, "", "GAMEBANANA_INVALID_RMC", true},
+		{"login-required", 200, `{"_sErrorCode":"LOGIN_REQUIRED"}`, "GAMEBANANA_INVALID_RMC", true},
+		{"forbidden-login-required", 403, `{"_sErrorCode":"LOGIN_REQUIRED"}`, "GAMEBANANA_INVALID_RMC", true},
+		{"forbidden", 403, "<html>Access denied</html>", errCodeAuthCheckFailed, false},
+		{"html", 200, "<html>Challenge</html>", errCodeAuthCheckFailed, false},
+		{"malformed", 200, "{", errCodeAuthCheckFailed, false},
+		{"schema", 200, `{"_sUsername":12}`, errCodeAuthCheckFailed, false},
+		{"empty", 200, "", errCodeAuthCheckFailed, false},
+		{"limited", 429, "", errCodeServerUnreachable, false},
+		{"server", 503, "", errCodeServerUnreachable, false},
+		{"server-login-body", 503, `{"_sErrorCode":"LOGIN_REQUIRED"}`, errCodeServerUnreachable, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/html")
+				w.Header().Add("Set-Cookie", "rmc=untrusted-response; Path=/")
+				w.WriteHeader(tc.status)
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			t.Cleanup(server.Close)
+			service, _ := gameBananaTestService(t, server)
+			var logs bytes.Buffer
+			service.log = infra.NewLogWithOptions(infra.LogOptions{Writer: &logs, DisableFile: true})
+			ctx := context.Background()
+			if err := service.saveCookie(ctx, "rmc=private-saved"); err != nil {
+				t.Fatal(err)
+			}
+			result, err := service.SetManualRMCToken(ctx, "private-candidate")
+			if err != nil || result.OK || result.ErrorCode != tc.code {
+				t.Fatalf("result=%+v, err=%v", result, err)
+			}
+			cookie, err := service.getCookie(ctx)
+			if err != nil || cookie != "rmc=private-saved" {
+				t.Fatal("manual validation modified saved session")
+			}
+			var opens atomic.Int32
+			service.openLogin = func(context.Context, CookieValidator) (string, error) { opens.Add(1); return "", ErrLoginCancelled }
+			err = service.EnsureSession(ctx)
+			if tc.invalid {
+				if !errors.Is(err, ErrLoginCancelled) || opens.Load() != 1 {
+					t.Fatalf("expected fresh login: %v", err)
+				}
+			} else {
+				if err == nil || err.Error() != tc.code || opens.Load() != 0 {
+					t.Fatalf("unexpected auth handling: %v; opens=%d", err, opens.Load())
+				}
+				cookie, _ = service.getCookie(ctx)
+				if cookie != "rmc=private-saved" {
+					t.Fatal("uncertain response cleared cookie")
+				}
+			}
+			if strings.Contains(logs.String(), "private-") || strings.Contains(logs.String(), "untrusted-response") {
+				t.Fatal("auth diagnostic leaked secret")
+			}
+		})
+	}
+}
+
+func TestManualSaveWinsPendingAutomaticLogin(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, validMemberJSON)
+	}))
+	defer server.Close()
+	service, _ := gameBananaTestService(t, server)
+	validated, release := make(chan struct{}), make(chan struct{})
+	service.openLogin = func(ctx context.Context, validate CookieValidator) (string, error) {
+		ok, err := validate(ctx, "rmc=automatic")
+		if err != nil || !ok {
+			return "", ErrAuthFailed
+		}
+		close(validated)
+		<-release
+		return "rmc=automatic", nil
+	}
+	done := make(chan error, 1)
+	go func() { done <- service.EnsureSession(context.Background()) }()
+	<-validated
+	result, err := service.SetManualRMCToken(context.Background(), "manual")
+	close(release)
+	if err != nil || !result.OK {
+		t.Fatalf("manual=%+v err=%v", result, err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("accepted manual session was reported as failure: %v", err)
+	}
+	cookie, _ := service.getCookie(context.Background())
+	if cookie != "rmc=manual" {
+		t.Fatal("automatic response overwrote manual session")
+	}
+}
+
+func TestLogoutBlocksNewAuthenticationUntilCleanupCompletes(t *testing.T) {
+	server := validProfileServer(t, "rmc=candidate")
+	service, _ := gameBananaTestService(t, server)
+	started, release := make(chan struct{}), make(chan struct{})
+	service.clearLoginCookies = func(context.Context) error { close(started); <-release; return nil }
+	done := make(chan error, 1)
+	go func() { done <- service.Logout(context.Background()) }()
+	<-started
+	err := service.EnsureSession(context.Background())
+	result, manualErr := service.SetManualRMCToken(context.Background(), "candidate")
+	close(release)
+	if !errors.Is(err, ErrLoginCancelled) || manualErr != nil || result.OK {
+		t.Fatalf("authentication ran during logout: %v, %+v", err, result)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+type failingSaveCrypto struct{ Crypto }
+
+func (f failingSaveCrypto) EncryptString(string) (string, error) {
+	return "", errors.New("encryption unavailable")
+}
+
+func TestRotatedCookiePersistenceFailureIsNotSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Add("Set-Cookie", "rmc=rotated; Path=/")
+		_, _ = io.WriteString(w, validMemberJSON)
+	}))
+	defer server.Close()
+	service, client := gameBananaTestService(t, server)
+	ctx := context.Background()
+	if err := service.saveCookie(ctx, "rmc=original"); err != nil {
+		t.Fatal(err)
+	}
+	service.crypto = failingSaveCrypto{service.crypto}
+	if err := service.EnsureSession(ctx); err == nil {
+		t.Fatal("persistence failure returned success")
+	}
+	cookie, _ := service.getCookie(ctx)
+	stored, err := client.Settings.GetValue(ctx, cookieSettingKey)
+	if cookie != "rmc=original" || err != nil || stored == nil || *stored != "rmc=original" {
+		t.Fatal("failed save partially changed session")
+	}
+}
+
+func TestUnchangedValidationDoesNotInvalidatePendingUpdates(t *testing.T) {
+	server := validProfileServer(t, "rmc=saved")
+	service, _ := gameBananaTestService(t, server)
+	ctx := context.Background()
+	if err := service.saveCookie(ctx, "rmc=saved"); err != nil {
+		t.Fatal(err)
+	}
+	_, revision, err := service.cookieSnapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := service.EnsureSession(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if applied, err := service.updateCookie(ctx, revision, "rmc=next"); err != nil || !applied {
+		t.Fatalf("unchanged validation invalidated update: %v", err)
+	}
+}
+
+func TestConcurrentStoredValidationSharesCallAndAllowsWaiterCancel(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	unblock := func() { once.Do(func() { close(release) }) }
+	defer unblock()
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) == 1 {
+			close(started)
+		}
+		select {
+		case <-release:
+		case <-r.Context().Done():
+			return
+		}
+		_, _ = io.WriteString(w, validMemberJSON)
+	}))
+	defer server.Close()
+	service, _ := gameBananaTestService(t, server)
+	if err := service.saveCookie(context.Background(), "rmc=saved"); err != nil {
+		t.Fatal(err)
+	}
+	owner := make(chan error, 1)
+	go func() { owner <- service.EnsureSession(context.Background()) }()
+	<-started
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := service.EnsureSession(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("waiter=%v", err)
+	}
+	unblock()
+	if err := <-owner; err != nil {
+		t.Fatal(err)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("requests=%d", requests.Load())
+	}
+}
+
+func TestStoredValidationDiscardsStaleResult(t *testing.T) {
+	for _, valid := range []bool{false, true} {
+		t.Run(map[bool]string{false: "invalid", true: "valid"}[valid], func(t *testing.T) {
+			started := make(chan struct{})
+			release := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if cookieValue(r.Header.Get("Cookie"), "rmc") == "old" {
+					close(started)
+					<-release
+					if !valid {
+						_, _ = io.WriteString(w, `{"_sErrorCode":"LOGIN_REQUIRED"}`)
+						return
+					}
+					w.Header().Add("Set-Cookie", "rmc=stale-rotation; Path=/")
+				}
+				_, _ = io.WriteString(w, validMemberJSON)
+			}))
+			defer server.Close()
+			service, _ := gameBananaTestService(t, server)
+			ctx := context.Background()
+			if err := service.saveCookie(ctx, "rmc=old"); err != nil {
+				t.Fatal(err)
+			}
+			done := make(chan error, 1)
+			go func() { done <- service.EnsureSession(ctx) }()
+			<-started
+			result, err := service.SetManualRMCToken(ctx, "new")
+			if err != nil || !result.OK {
+				close(release)
+				t.Fatalf("manual=%+v %v", result, err)
+			}
+			close(release)
+			if err := <-done; err != nil {
+				t.Fatal(err)
+			}
+			cookie, _ := service.getCookie(ctx)
+			if cookie != "rmc=new" {
+				t.Fatal("stale validation overwrote new session")
+			}
+		})
+	}
+}
+
+func TestLogoutInvalidatesPendingManualSave(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/Personal") {
+			close(started)
+			<-release
+			_, _ = io.WriteString(w, validMemberJSON)
+		}
+	}))
+	defer server.Close()
+	service, _ := gameBananaTestService(t, server)
+	ctx := context.Background()
+	if err := service.saveCookie(ctx, "rmc=saved"); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan ManualRMCSaveResult, 1)
+	go func() { result, _ := service.SetManualRMCToken(ctx, "pending"); done <- result }()
+	<-started
+	err := service.Logout(ctx)
+	close(release)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result := <-done; result.OK {
+		t.Fatal("late manual save resurrected logout")
+	}
+	cookie, _ := service.getCookie(ctx)
+	if cookie != "" {
+		t.Fatal("logout did not persist")
+	}
+}
+
+func TestLogoutInvalidatesPendingAutomaticLogin(t *testing.T) {
+	server := validProfileServer(t, "rmc=candidate")
+	service, _ := gameBananaTestService(t, server)
+	validated := make(chan struct{})
+	release := make(chan struct{})
+	service.openLogin = func(ctx context.Context, validate CookieValidator) (string, error) {
+		ok, err := validate(ctx, "rmc=candidate")
+		if err != nil || !ok {
+			return "", ErrAuthFailed
+		}
+		close(validated)
+		<-release
+		return "rmc=candidate", nil
+	}
+	done := make(chan error, 1)
+	go func() { done <- service.EnsureSession(context.Background()) }()
+	<-validated
+	err := service.Logout(context.Background())
+	close(release)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := <-done; err == nil {
+		t.Fatal("cancelled login succeeded")
+	}
+	cookie, _ := service.getCookie(context.Background())
+	if cookie != "" {
+		t.Fatal("automatic login resurrected logout")
+	}
+}
+
+func TestRequestCannotMutateReplacedSession(t *testing.T) {
+	for _, status := range []int{200, 401, 403} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			started := make(chan struct{})
+			release := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				close(started)
+				<-release
+				w.Header().Add("Set-Cookie", "rmc=stale; Path=/")
+				w.WriteHeader(status)
+				_, _ = io.WriteString(w, `{}`)
+			}))
+			defer server.Close()
+			service, _ := gameBananaTestService(t, server)
+			ctx := context.Background()
+			if err := service.saveCookie(ctx, "rmc=old"); err != nil {
+				t.Fatal(err)
+			}
+			done := make(chan error, 1)
+			go func() {
+				r, err := service.request(ctx, http.MethodGet, server.URL+"/apiv13/test", nil, requestPolicy{PersistResponseCookies: true, ClearStoredCookieOnAuth: true, SkipAuthRetry: true})
+				if r != nil {
+					_ = r.Body.Close()
+				}
+				done <- err
+			}()
+			<-started
+			if err := service.saveCookie(ctx, "rmc=new"); err != nil {
+				close(release)
+				t.Fatal(err)
+			}
+			close(release)
+			<-done
+			cookie, _ := service.getCookie(ctx)
+			if cookie != "rmc=new" {
+				t.Fatal("old response changed new cookie")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #235.

Hardens GameBanana session persistence so switching away, completing a download, or retrying login no longer drops a valid cookie. Distinguishes login-init and auth-check failures from a generic auth error.