### PR TITLE
sync registry DisplayVersion after in-place update

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -72,6 +72,9 @@ func Run(assets embed.FS, icon []byte) (runErr error) {
 	} else if err := platform.RegisterNahidaURLProtocol(executable); err != nil && rt.log != nil {
 		_ = infra.ReportError(rt.log, err, "App:registerURLProtocol", infra.Diagnostic{Severity: infra.DiagnosticError, Operation: "App:registerURLProtocol", Stage: "background"})
 	}
+	if err := platform.SyncInstalledVersion(); err != nil && rt.log != nil {
+		_ = infra.ReportError(rt.log, err, "App:syncInstalledVersion", infra.Diagnostic{Severity: infra.DiagnosticError, Operation: "App:syncInstalledVersion", Stage: "background"})
+	}
 	autostartSync := func(enabled bool) error {
 		return syncAutostart(app.Autostart, enabled)
 	}

--- a/internal/platform/installed_version_windows.go
+++ b/internal/platform/installed_version_windows.go
@@ -1,0 +1,51 @@
+//go:build windows
+
+package platform
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// The NSIS installer owns this key and writes DisplayVersion once, from the
+// version baked into the installer. The in-app updater swaps the binary in
+// place without re-running the installer, so the value drifts behind the
+// running version until this sync repairs it. Keep the path in sync with
+// UNINST_KEY_NAME in build/windows/nsis/wails_tools.nsh
+// (INFO_COMPANYNAME + INFO_PRODUCTNAME).
+const uninstallDisplayVersionKeyPath = `Software\Microsoft\Windows\CurrentVersion\Uninstall\nahida.liveNahida Desktop`
+
+// SyncInstalledVersion repairs the Add/Remove Programs DisplayVersion after
+// an in-place updater swap. It is a no-op for portable and dev runs and never
+// creates the key: uninstalled copies must not grow an uninstall entry.
+// Best effort and safe to call on every startup.
+func SyncInstalledVersion() error {
+	if !Packaged() || !nsisInstalled() {
+		return nil
+	}
+	return syncInstalledVersion(registry.CURRENT_USER, uninstallDisplayVersionKeyPath, AppVersion)
+}
+
+func syncInstalledVersion(hive registry.Key, path, version string) error {
+	key, err := registry.OpenKey(hive, path, registry.QUERY_VALUE|registry.SET_VALUE)
+	if errors.Is(err, registry.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("open uninstall display version key: %w", err)
+	}
+	defer func() { _ = key.Close() }()
+	current, _, err := key.GetStringValue("DisplayVersion")
+	if err != nil && !errors.Is(err, registry.ErrNotExist) {
+		return fmt.Errorf("read installed display version: %w", err)
+	}
+	if current == version {
+		return nil
+	}
+	if err := key.SetStringValue("DisplayVersion", version); err != nil {
+		return fmt.Errorf("set installed display version: %w", err)
+	}
+	return nil
+}

--- a/internal/platform/installed_version_windows_test.go
+++ b/internal/platform/installed_version_windows_test.go
@@ -1,0 +1,98 @@
+//go:build windows
+
+package platform
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+func newInstalledVersionTestKey(t *testing.T) string {
+	t.Helper()
+	path := fmt.Sprintf(`Software\Classes\nahida-installed-version-test-%d`, time.Now().UnixNano())
+	t.Cleanup(func() {
+		_ = registry.DeleteKey(registry.CURRENT_USER, path)
+	})
+	return path
+}
+
+func setInstalledVersionTestValue(t *testing.T, path, value string) {
+	t.Helper()
+	key, _, err := registry.CreateKey(registry.CURRENT_USER, path, registry.SET_VALUE|registry.CREATE_SUB_KEY)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value != "" {
+		if err := key.SetStringValue("DisplayVersion", value); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := key.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readInstalledVersionTestValue(t *testing.T, path string) (string, error) {
+	t.Helper()
+	key, err := registry.OpenKey(registry.CURRENT_USER, path, registry.QUERY_VALUE)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = key.Close() }()
+	value, _, err := key.GetStringValue("DisplayVersion")
+	return value, err
+}
+
+func TestSyncInstalledVersionSkipsWhenKeyAbsent(t *testing.T) {
+	path := newInstalledVersionTestKey(t)
+
+	if err := syncInstalledVersion(registry.CURRENT_USER, path, "3.8.0"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.OpenKey(registry.CURRENT_USER, path, registry.QUERY_VALUE); !errors.Is(err, registry.ErrNotExist) {
+		t.Fatalf("missing key must stay absent, error = %v", err)
+	}
+}
+
+func TestSyncInstalledVersionRewritesStaleVersion(t *testing.T) {
+	path := newInstalledVersionTestKey(t)
+	setInstalledVersionTestValue(t, path, "3.7.0")
+
+	if err := syncInstalledVersion(registry.CURRENT_USER, path, "3.8.0"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readInstalledVersionTestValue(t, path)
+	if err != nil || got != "3.8.0" {
+		t.Fatalf("display version = %q, want %q, error = %v", got, "3.8.0", err)
+	}
+}
+
+func TestSyncInstalledVersionKeepsCurrentVersion(t *testing.T) {
+	path := newInstalledVersionTestKey(t)
+	setInstalledVersionTestValue(t, path, "3.8.0")
+
+	if err := syncInstalledVersion(registry.CURRENT_USER, path, "3.8.0"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readInstalledVersionTestValue(t, path)
+	if err != nil || got != "3.8.0" {
+		t.Fatalf("display version = %q, want %q, error = %v", got, "3.8.0", err)
+	}
+}
+
+func TestSyncInstalledVersionFillsMissingValue(t *testing.T) {
+	path := newInstalledVersionTestKey(t)
+	setInstalledVersionTestValue(t, path, "")
+
+	if err := syncInstalledVersion(registry.CURRENT_USER, path, "3.8.0"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readInstalledVersionTestValue(t, path)
+	if err != nil || got != "3.8.0" {
+		t.Fatalf("display version = %q, want %q, error = %v", got, "3.8.0", err)
+	}
+}

--- a/internal/platform/installed_version_windows_test.go
+++ b/internal/platform/installed_version_windows_test.go
@@ -26,13 +26,15 @@ func setInstalledVersionTestValue(t *testing.T, path, value string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		if err := key.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
 	if value != "" {
 		if err := key.SetStringValue("DisplayVersion", value); err != nil {
 			t.Fatal(err)
 		}
-	}
-	if err := key.Close(); err != nil {
-		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows installations now keep the displayed application version in Add/Remove Programs synchronized after in-place updates.
  * Startup continues normally if version synchronization encounters an error.
  * Portable and development installations remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->