### PR TITLE
fix(model-viewer): restore context menu after updates

### DIFF
--- a/internal/platform/model_viewer_menu_windows.go
+++ b/internal/platform/model_viewer_menu_windows.go
@@ -5,15 +5,15 @@ package platform
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 )
 
-// The NSIS installer registers this Explorer verb for directories and owns
-// its Icon and command values. The app only refreshes the display label so
-// it follows the selected app language. The key is never created here:
-// portable runs must not grow an installer-provided context menu.
+// The NSIS installer registers this Explorer verb for directories. The app
+// also repairs the registration for installations upgraded in place from a
+// version that predates the verb. Portable runs must not grow this menu.
 const modelViewerMenuKeyPath = `Software\Classes\Directory\shell\nahida.live.ModelViewer`
 
 const shcneAssocChanged = 0x08000000
@@ -34,29 +34,61 @@ func modelViewerMenuLabel(language string) string {
 	return modelViewerMenuLabels["en"]
 }
 
-// UpdateModelViewerContextMenu rewrites the installer-registered Explorer
-// verb label to the app language. It is a no-op when the key is absent
-// (portable run). The NSIS entry point enforces per-user installation;
-// legacy HKLM values are left untouched and never require elevation.
+// UpdateModelViewerContextMenu keeps the installer-registered Explorer verb
+// in sync with the app language and repairs it after an in-place update. The
+// NSIS entry point enforces per-user installation; legacy HKLM values are left
+// untouched and never require elevation.
 func UpdateModelViewerContextMenu(language string) error {
-	updated, err := updateModelViewerMenu(registry.CURRENT_USER, modelViewerMenuKeyPath, language)
+	executable := ""
+	if Packaged() && nsisInstalled() {
+		var err error
+		executable, err = executablePath()
+		if err != nil {
+			return fmt.Errorf("resolve executable for model viewer context menu: %w", err)
+		}
+	}
+	updated, err := updateModelViewerMenu(registry.CURRENT_USER, modelViewerMenuKeyPath, language, executable)
 	if err == nil && updated {
 		_, _, _ = shellChangeNotify.Call(shcneAssocChanged, 0, 0, 0)
 	}
 	return err
 }
 
-func updateModelViewerMenu(hive registry.Key, path, language string) (bool, error) {
-	key, err := registry.OpenKey(hive, path, registry.QUERY_VALUE|registry.SET_VALUE)
+func updateModelViewerMenu(hive registry.Key, path, language, executable string) (bool, error) {
+	key, err := registry.OpenKey(hive, path, registry.QUERY_VALUE|registry.SET_VALUE|registry.CREATE_SUB_KEY)
 	if errors.Is(err, registry.ErrNotExist) {
-		return false, nil
+		if executable == "" {
+			return false, nil
+		}
+		key, _, err = registry.CreateKey(hive, path, registry.SET_VALUE|registry.CREATE_SUB_KEY)
 	}
 	if err != nil {
-		return false, fmt.Errorf("open model viewer context menu key: %w", err)
+		return false, fmt.Errorf("open or create model viewer context menu key: %w", err)
 	}
 	defer func() { _ = key.Close() }()
 	if err := key.SetStringValue("", modelViewerMenuLabel(language)); err != nil {
 		return false, fmt.Errorf("set model viewer context menu label: %w", err)
+	}
+	if executable == "" {
+		return true, nil
+	}
+	executable = filepath.Clean(executable)
+	if err := key.SetStringValue("Icon", fmt.Sprintf(`"%s",0`, executable)); err != nil {
+		return false, fmt.Errorf("set model viewer context menu icon: %w", err)
+	}
+	if err := key.SetStringValue("MultiSelectModel", "Single"); err != nil {
+		return false, fmt.Errorf("set model viewer context menu selection mode: %w", err)
+	}
+	command, _, err := registry.CreateKey(key, "command", registry.SET_VALUE)
+	if err != nil {
+		return false, fmt.Errorf("create model viewer context menu command key: %w", err)
+	}
+	if err := command.SetStringValue("", fmt.Sprintf(`"%s" --model-viewer "%%1"`, executable)); err != nil {
+		_ = command.Close()
+		return false, fmt.Errorf("set model viewer context menu command: %w", err)
+	}
+	if err := command.Close(); err != nil {
+		return false, fmt.Errorf("close model viewer context menu command key: %w", err)
 	}
 	return true, nil
 }

--- a/internal/platform/model_viewer_menu_windows_test.go
+++ b/internal/platform/model_viewer_menu_windows_test.go
@@ -5,6 +5,7 @@ package platform
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -39,7 +40,7 @@ func TestUpdateModelViewerMenuSkipsWhenKeyAbsent(t *testing.T) {
 		}
 	})
 
-	updated, err := updateModelViewerMenu(registry.CURRENT_USER, path, "ko")
+	updated, err := updateModelViewerMenu(registry.CURRENT_USER, path, "ko", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +75,7 @@ func TestUpdateModelViewerMenuRewritesLabel(t *testing.T) {
 	}
 	r = 0
 
-	updated, err := updateModelViewerMenu(registry.CURRENT_USER, path, "ja")
+	updated, err := updateModelViewerMenu(registry.CURRENT_USER, path, "ja", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,5 +90,89 @@ func TestUpdateModelViewerMenuRewritesLabel(t *testing.T) {
 	got, _, err := key.GetStringValue("")
 	if err != nil || got != modelViewerMenuLabel("ja") {
 		t.Fatalf("label = %q, want %q, error = %v", got, modelViewerMenuLabel("ja"), err)
+	}
+}
+
+func TestUpdateModelViewerMenuCreatesInstalledRegistration(t *testing.T) {
+	root := fmt.Sprintf(`Software\Classes\nahida-mv-test-%d`, time.Now().UnixNano())
+	path := root + `\shell\verb`
+	t.Cleanup(func() {
+		for _, suffix := range []string{`\shell\verb\command`, `\shell\verb`, `\shell`, ``} {
+			_ = registry.DeleteKey(registry.CURRENT_USER, root+suffix)
+		}
+	})
+	executable := filepath.Join(t.TempDir(), "Nahida Desktop.exe")
+
+	updated, err := updateModelViewerMenu(registry.CURRENT_USER, path, "ko", executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated {
+		t.Fatal("installed registration must be created")
+	}
+	key, err := registry.OpenKey(registry.CURRENT_USER, path, registry.QUERY_VALUE)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = key.Close() }()
+	for name, want := range map[string]string{
+		"":                 modelViewerMenuLabel("ko"),
+		"Icon":             fmt.Sprintf(`"%s",0`, filepath.Clean(executable)),
+		"MultiSelectModel": "Single",
+	} {
+		got, _, err := key.GetStringValue(name)
+		if err != nil || got != want {
+			t.Fatalf("%s = %q, want %q, error = %v", name, got, want, err)
+		}
+	}
+	commandKey, err := registry.OpenKey(registry.CURRENT_USER, path+`\command`, registry.QUERY_VALUE)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = commandKey.Close() }()
+	command, _, err := commandKey.GetStringValue("")
+	wantCommand := fmt.Sprintf(`"%s" --model-viewer "%%1"`, filepath.Clean(executable))
+	if err != nil || command != wantCommand {
+		t.Fatalf("command = %q, want %q, error = %v", command, wantCommand, err)
+	}
+}
+
+func TestUpdateModelViewerMenuRepairsInstalledRegistration(t *testing.T) {
+	root := fmt.Sprintf(`Software\Classes\nahida-mv-test-%d`, time.Now().UnixNano())
+	path := root + `\shell\verb`
+	t.Cleanup(func() {
+		for _, suffix := range []string{`\shell\verb\command`, `\shell\verb`, `\shell`, ``} {
+			_ = registry.DeleteKey(registry.CURRENT_USER, root+suffix)
+		}
+	})
+	key, _, err := registry.CreateKey(registry.CURRENT_USER, path, registry.SET_VALUE|registry.CREATE_SUB_KEY)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := key.SetStringValue("", "stale label"); err != nil {
+		_ = key.Close()
+		t.Fatal(err)
+	}
+	if err := key.Close(); err != nil {
+		t.Fatal(err)
+	}
+	executable := filepath.Join(t.TempDir(), "Nahida Desktop.exe")
+
+	updated, err := updateModelViewerMenu(registry.CURRENT_USER, path, "en", executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated {
+		t.Fatal("installed registration must be repaired")
+	}
+	commandKey, err := registry.OpenKey(registry.CURRENT_USER, path+`\command`, registry.QUERY_VALUE)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = commandKey.Close() }()
+	command, _, err := commandKey.GetStringValue("")
+	wantCommand := fmt.Sprintf(`"%s" --model-viewer "%%1"`, filepath.Clean(executable))
+	if err != nil || command != wantCommand {
+		t.Fatalf("command = %q, want %q, error = %v", command, wantCommand, err)
 	}
 }

--- a/internal/platform/model_viewer_menu_windows_test.go
+++ b/internal/platform/model_viewer_menu_windows_test.go
@@ -149,9 +149,15 @@ func TestUpdateModelViewerMenuRepairsInstalledRegistration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := key.SetStringValue("", "stale label"); err != nil {
-		_ = key.Close()
-		t.Fatal(err)
+	for name, value := range map[string]string{
+		"":                 "stale label",
+		"Icon":             "stale icon",
+		"MultiSelectModel": "stale selection mode",
+	} {
+		if err := key.SetStringValue(name, value); err != nil {
+			_ = key.Close()
+			t.Fatal(err)
+		}
 	}
 	if err := key.Close(); err != nil {
 		t.Fatal(err)
@@ -164,6 +170,21 @@ func TestUpdateModelViewerMenuRepairsInstalledRegistration(t *testing.T) {
 	}
 	if !updated {
 		t.Fatal("installed registration must be repaired")
+	}
+	key, err = registry.OpenKey(registry.CURRENT_USER, path, registry.QUERY_VALUE)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = key.Close() }()
+	for name, want := range map[string]string{
+		"":                 modelViewerMenuLabel("en"),
+		"Icon":             fmt.Sprintf(`"%s",0`, filepath.Clean(executable)),
+		"MultiSelectModel": "Single",
+	} {
+		got, _, err := key.GetStringValue(name)
+		if err != nil || got != want {
+			t.Fatalf("%s = %q, want %q, error = %v", name, got, want, err)
+		}
 	}
 	commandKey, err := registry.OpenKey(registry.CURRENT_USER, path+`\command`, registry.QUERY_VALUE)
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows model viewer context-menu registration during application upgrades.
  * Restored missing or incomplete registration details, including the application icon and model-viewer command.
  * Ensured model files open with the model viewer when launched from the context menu.
  * Portable runs continue to update the menu label without installing system registration entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->