### PR TITLE
feat(model-viewer): support packed dual-quaternion animation

### DIFF
--- a/frontend/src/components/tools/model-viewer/model-viewer-compute-controller.test.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-compute-controller.test.ts
@@ -104,30 +104,33 @@ describe("ModelViewerComputeController", () => {
         controller.dispose();
     });
 
-    it("restores the static baseline after a worker error and reports it once", () => {
-        const root = fixtureRoot();
-        const worker = new FakeWorker();
-        const onError = vi.fn();
-        const controller = new ModelViewerComputeController(
-            root,
-            deformer,
-            [],
-            vi.fn(),
-            onError,
-            worker,
-        );
-        const init = worker.messages[0] as { generation: number };
-        const mesh = root.children[0] as Mesh;
-        (mesh.geometry.getAttribute("position").array as Float32Array).set([9, 9, 9]);
-        const error = { type: "error", generation: init.generation, message: "broken" };
-        worker.onmessage?.(new MessageEvent("message", { data: error }));
-        worker.onmessage?.(new MessageEvent("message", { data: error }));
-        expect([...(mesh.geometry.getAttribute("position").array as Float32Array)]).toEqual([
-            1, 2, 3,
-        ]);
-        expect(onError).toHaveBeenCalledOnce();
-        controller.dispose();
-    });
+    it.each(["gimi_shape_pose_v1", "gimi_packed_dual_quaternion_v1"] as const)(
+        "restores the static baseline for %s after a worker error and reports it once",
+        (kind) => {
+            const root = fixtureRoot();
+            const worker = new FakeWorker();
+            const onError = vi.fn();
+            const controller = new ModelViewerComputeController(
+                root,
+                { ...deformer, kind },
+                [],
+                vi.fn(),
+                onError,
+                worker,
+            );
+            const init = worker.messages[0] as { generation: number };
+            const mesh = root.children[0] as Mesh;
+            (mesh.geometry.getAttribute("position").array as Float32Array).set([9, 9, 9]);
+            const error = { type: "error", generation: init.generation, message: "broken" };
+            worker.onmessage?.(new MessageEvent("message", { data: error }));
+            worker.onmessage?.(new MessageEvent("message", { data: error }));
+            expect([...(mesh.geometry.getAttribute("position").array as Float32Array)]).toEqual([
+                1, 2, 3,
+            ]);
+            expect(onError).toHaveBeenCalledOnce();
+            controller.dispose();
+        },
+    );
 
     it("removes controller-created attributes that were absent from the baseline", () => {
         const root = new Object3D();
@@ -220,44 +223,49 @@ describe("ModelViewerComputeController", () => {
         controller.dispose();
     });
 
-    it("removes an existing tangent attribute when the kernel omits tangents", () => {
-        const root = fixtureRoot();
-        const mesh = root.children[0] as Mesh;
-        const worker = new FakeWorker();
-        const controller = new ModelViewerComputeController(
-            root,
-            { ...deformer, kind: "gimi_cyclic_packed_v1" },
-            [],
-            vi.fn(),
-            vi.fn(),
-            worker,
-        );
-        const init = worker.messages[0] as { generation: number };
-        worker.onmessage?.(
-            new MessageEvent("message", {
-                data: { type: "ready", generation: init.generation },
-            }),
-        );
-        controller.request({ clip, frameIndex: 0 });
-        expect(mesh.geometry.getAttribute("tangent")).toBeDefined();
-        worker.onmessage?.(
-            new MessageEvent("message", {
-                data: {
-                    type: "frame",
-                    generation: init.generation,
-                    meshes: [
-                        {
-                            meshId: "mesh",
-                            positions: new Float32Array([9, 9, 9]).buffer,
-                            normals: new Float32Array([0, 0, 1]).buffer,
-                        },
-                    ],
-                },
-            }),
-        );
-        expect(mesh.geometry.getAttribute("tangent")).toBeUndefined();
-        controller.dispose();
-    });
+    it.each(["gimi_cyclic_packed_v1", "gimi_packed_dual_quaternion_v1"] as const)(
+        "handles omitted tangents for %s",
+        (kind) => {
+            const root = fixtureRoot();
+            const mesh = root.children[0] as Mesh;
+            const worker = new FakeWorker();
+            const controller = new ModelViewerComputeController(
+                root,
+                { ...deformer, kind },
+                [],
+                vi.fn(),
+                vi.fn(),
+                worker,
+            );
+            const init = worker.messages[0] as { generation: number };
+            worker.onmessage?.(
+                new MessageEvent("message", {
+                    data: { type: "ready", generation: init.generation },
+                }),
+            );
+            controller.request({ clip, frameIndex: 0 });
+            expect(mesh.geometry.getAttribute("tangent")).toBeDefined();
+            worker.onmessage?.(
+                new MessageEvent("message", {
+                    data: {
+                        type: "frame",
+                        generation: init.generation,
+                        meshes: [
+                            {
+                                meshId: "mesh",
+                                positions: new Float32Array([9, 9, 9]).buffer,
+                                normals: new Float32Array([0, 0, 1]).buffer,
+                            },
+                        ],
+                    },
+                }),
+            );
+            expect(Boolean(mesh.geometry.getAttribute("tangent"))).toBe(
+                kind === "gimi_packed_dual_quaternion_v1",
+            );
+            controller.dispose();
+        },
+    );
 
     it("reports a deformer whose mesh IDs do not match the rendered model", () => {
         const worker = new FakeWorker();

--- a/frontend/src/components/tools/model-viewer/model-viewer-compute-controller.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-compute-controller.ts
@@ -161,7 +161,7 @@ export class ModelViewerComputeController {
             setAttribute(baseline.mesh, "normal", new Float32Array(result.normals), 3);
             if (result.tangents && result.tangents.byteLength > 0) {
                 setAttribute(baseline.mesh, "tangent", new Float32Array(result.tangents), 4);
-            } else {
+            } else if (this.deformer.kind !== "gimi_packed_dual_quaternion_v1") {
                 baseline.mesh.geometry.deleteAttribute("tangent");
             }
         }

--- a/frontend/src/components/tools/model-viewer/model-viewer-compute-dual-quaternion.test.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-compute-dual-quaternion.test.ts
@@ -57,12 +57,12 @@ function expectVector(actual: Float32Array, expected: number[], precision = 3) {
 describe("packed dual-quaternion kernel", () => {
     it("preserves game coordinates and source tangent/UV while ignoring packed w", () => {
         const { deformer, buffers } = fixture();
-        const original = buffers.base.slice(0);
+        const original = new Uint8Array(buffers.base.slice(0));
         const result = computePackedDualQuaternionFrame(deformer, buffers, 0);
         expectVector(result.positions, [1, 2, 3]);
         expectVector(result.normals, [0, 0, 1]);
         expect(result.tangents).toBeUndefined();
-        expect(buffers.base).toEqual(original);
+        expect(new Uint8Array(buffers.base)).toEqual(original);
     });
 
     it("applies scale, bias and dual-quaternion translation in Blender axes", () => {
@@ -198,14 +198,18 @@ describe("packed dual-quaternion worker", () => {
         expect(scope.postMessage).toHaveBeenCalledWith(
             expect.objectContaining({
                 type: "frame",
-                meshes: [
-                    expect.objectContaining({
-                        positions: new Float32Array([1, 2, 3, 1, 2, 3]).buffer,
-                    }),
-                ],
+                meshes: [expect.objectContaining({ positions: expect.any(ArrayBuffer) })],
             }),
             expect.any(Array),
         );
+        const frame = scope.postMessage.mock.calls
+            .map(([message]) => message)
+            .find((message) => (message as { type?: string }).type === "frame");
+        expect(
+            new Float32Array(
+                (frame as { meshes: [{ positions: ArrayBuffer }] }).meshes[0].positions,
+            ),
+        ).toEqual(new Float32Array([1, 2, 3, 1, 2, 3]));
         scope.onmessage!({
             data: { type: "frame", generation: 1, id: 2, poseFrame: -1, phaseSeconds: 0 },
         });

--- a/frontend/src/components/tools/model-viewer/model-viewer-compute-dual-quaternion.test.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-compute-dual-quaternion.test.ts
@@ -1,0 +1,247 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { ViewerComputeDeformer } from "@shared/mod-viewer/types";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { GIMIShapePoseBuffers } from "./model-viewer-compute-kernel";
+
+import {
+    computePackedDualQuaternionFrame,
+    validatePackedDualQuaternionBuffers,
+} from "./model-viewer-compute-dual-quaternion";
+
+function fixture(poseValues?: number[], boneCount = 1) {
+    const identity = [1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0];
+    const pose = new Float32Array(poseValues ?? [...identity, ...identity]).buffer;
+    const base = new ArrayBuffer(20);
+    const vertex = new DataView(base);
+    vertex.setUint16(0, 0x3c00, true); // 1
+    vertex.setUint16(2, 0x4000, true); // 2
+    vertex.setUint16(4, 0x4200, true); // 3
+    vertex.setUint16(6, 0x4400, true); // w = 4 must be ignored
+    vertex.setInt8(10, 127);
+    vertex.setUint32(12, 0x12345678, true); // untouched tangent
+    vertex.setUint32(16, 0x76543210, true); // untouched UV
+    const blend = new ArrayBuffer(32);
+    new DataView(blend).setFloat32(0, 1, true);
+    const source = (url: string, byteLength: number, stride: number) => ({
+        url,
+        byteLength,
+        stride,
+    });
+    const deformer: ViewerComputeDeformer = {
+        id: "dq",
+        kind: "gimi_packed_dual_quaternion_v1",
+        meshIds: ["mesh"],
+        vertexCount: 1,
+        base: source("/base", 20, 20),
+        shapePasses: [],
+        shapeStages: [],
+        pose: {
+            blend: source("/blend", 32, 32),
+            frames: source("/pose", pose.byteLength, 56),
+            boneCount,
+            frameCount: pose.byteLength / (boneCount * 56),
+        },
+    };
+    const buffers: GIMIShapePoseBuffers = { base, blend, pose, shapeTargets: [] };
+    return { deformer, buffers };
+}
+
+function expectVector(actual: Float32Array, expected: number[], precision = 3) {
+    expect(actual.length).toBe(expected.length);
+    actual.forEach((value, index) => expect(value).toBeCloseTo(expected[index]!, precision));
+}
+
+describe("packed dual-quaternion kernel", () => {
+    it("preserves game coordinates and source tangent/UV while ignoring packed w", () => {
+        const { deformer, buffers } = fixture();
+        const original = buffers.base.slice(0);
+        const result = computePackedDualQuaternionFrame(deformer, buffers, 0);
+        expectVector(result.positions, [1, 2, 3]);
+        expectVector(result.normals, [0, 0, 1]);
+        expect(result.tangents).toBeUndefined();
+        expect(buffers.base).toEqual(original);
+    });
+
+    it("applies scale, bias and dual-quaternion translation in Blender axes", () => {
+        const pose = [2, 3, 4, 5, 6, 7, 0, 0, 0, 1, 1, 2, 3, 0];
+        const { deformer, buffers } = fixture([...pose, ...pose]);
+        // Blender input (1,-3,2) -> scale+bias (7,-3,15) -> translation (9,1,21).
+        expectVector(computePackedDualQuaternionFrame(deformer, buffers, 0).positions, [9, 21, -1]);
+    });
+
+    it("rotates positions and signed normals about the Blender Z axis", () => {
+        const q = Math.SQRT1_2;
+        const pose = [1, 1, 1, 0, 0, 0, 0, 0, q, q, 0, 0, 0, 0];
+        const { deformer, buffers } = fixture([...pose, ...pose]);
+        const result = computePackedDualQuaternionFrame(deformer, buffers, 0);
+        expectVector(result.positions, [3, 2, -1]);
+        expectVector(result.normals, [1, 0, 0]);
+    });
+
+    it("interpolates adjacent poses and resolves opposite quaternion signs", () => {
+        const first = [1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0];
+        const second = [1, 1, 1, 0, 0, 0, 0, 0, 0, -1, -2, 0, 0, 0];
+        const { deformer, buffers } = fixture([...first, ...second]);
+        expectVector(computePackedDualQuaternionFrame(deformer, buffers, 0.5).positions, [3, 2, 3]);
+        expectVector(computePackedDualQuaternionFrame(deformer, buffers, 1).positions, [5, 2, 3]);
+    });
+
+    it("keeps orthogonal quaternion contributions at dot zero across multiple bones", () => {
+        const identity = [1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0];
+        const halfTurn = [1, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0];
+        const { deformer, buffers } = fixture(
+            [...identity, ...halfTurn, ...identity, ...halfTurn],
+            2,
+        );
+        const blend = new DataView(buffers.blend!);
+        blend.setFloat32(0, 0.5, true);
+        blend.setFloat32(4, 0.5, true);
+        blend.setInt32(20, 1, true);
+        expectVector(computePackedDualQuaternionFrame(deformer, buffers, 0).positions, [3, 2, -1]);
+    });
+
+    it("rounds float16 ties to even and preserves half subnormals", () => {
+        const { deformer, buffers } = fixture();
+        const palette = new Float32Array(buffers.pose!);
+        palette[3] = 2 ** -11; // 1 + half a half-float ULP -> 1 (even).
+        expect(computePackedDualQuaternionFrame(deformer, buffers, 0).positions[0]).toBe(1);
+        palette[3] = 3 * 2 ** -11; // tie above an odd mantissa -> next even.
+        expect(computePackedDualQuaternionFrame(deformer, buffers, 0).positions[0]).toBe(
+            1 + 2 ** -9,
+        );
+        new DataView(buffers.base).setUint16(0, 1, true);
+        palette[3] = 0;
+        expect(computePackedDualQuaternionFrame(deformer, buffers, 0).positions[0]).toBe(2 ** -24);
+    });
+
+    it("truncates and saturates rotated packed normals before normalization", () => {
+        const q = Math.sin(Math.PI / 8),
+            w = Math.cos(Math.PI / 8);
+        const pose = [1, 1, 1, 0, 0, 0, 0, 0, q, w, 0, 0, 0, 0];
+        const { deformer, buffers } = fixture([...pose, ...pose]);
+        const base = new DataView(buffers.base);
+        base.setInt8(8, 127);
+        base.setInt8(9, 100);
+        base.setInt8(10, 127);
+        // Blender (127,-127,100) rotates to (~179.6,0,100), X saturates at 127.
+        const length = Math.hypot(127, 100);
+        expectVector(computePackedDualQuaternionFrame(deformer, buffers, 0).normals, [
+            127 / length,
+            100 / length,
+            0,
+        ]);
+    });
+
+    it("rejects invalid dimensions, bones, non-finite data and out-of-range positions", () => {
+        const { deformer, buffers } = fixture();
+        expect(() =>
+            validatePackedDualQuaternionBuffers(deformer, { ...buffers, pose: new ArrayBuffer(4) }),
+        ).toThrow();
+        expect(() =>
+            validatePackedDualQuaternionBuffers(
+                { ...deformer, base: { ...deformer.base, stride: 24 } },
+                buffers,
+            ),
+        ).toThrow();
+        expect(() => computePackedDualQuaternionFrame(deformer, buffers, Number.NaN)).toThrow();
+        expect(() => computePackedDualQuaternionFrame(deformer, buffers, -1)).toThrow();
+        new DataView(buffers.blend!).setInt32(20, 1, true);
+        expect(() => computePackedDualQuaternionFrame(deformer, buffers, 0)).toThrow(/influence/);
+        new DataView(buffers.blend!).setInt32(20, 0, true);
+        const pose = new Float32Array(buffers.pose!);
+        pose[3] = Number.NaN;
+        expect(() => computePackedDualQuaternionFrame(deformer, buffers, 0)).toThrow(/pose/);
+        pose[3] = 65520;
+        expect(() => computePackedDualQuaternionFrame(deformer, buffers, 0)).toThrow(/float16/);
+    });
+});
+
+describe("packed dual-quaternion worker", () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    it("loads the new kind, compacts source indices and reports invalid frames", async () => {
+        const { deformer, buffers } = fixture();
+        const scope = {
+            onmessage: undefined as ((event: { data: unknown }) => void) | undefined,
+            postMessage: vi.fn(),
+        };
+        const files: Record<string, ArrayBuffer> = {
+            "/base": buffers.base,
+            "/blend": buffers.blend!,
+            "/pose": buffers.pose!,
+            "/indices": new Uint32Array([0, 0]).buffer,
+        };
+        vi.stubGlobal("self", scope);
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (url: string) => ({ ok: true, arrayBuffer: async () => files[url]! })),
+        );
+        vi.resetModules();
+        await import("./model-viewer-compute.worker");
+        scope.onmessage!({
+            data: {
+                type: "init",
+                generation: 1,
+                deformer,
+                meshes: [{ id: "mesh", vertexCount: 2, sourceIndicesUrl: "/indices" }],
+            },
+        });
+        await vi.waitFor(() =>
+            expect(scope.postMessage).toHaveBeenCalledWith({ type: "ready", generation: 1 }),
+        );
+        scope.onmessage!({
+            data: { type: "frame", generation: 1, id: 1, poseFrame: 0, phaseSeconds: 0 },
+        });
+        expect(scope.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: "frame",
+                meshes: [
+                    expect.objectContaining({
+                        positions: new Float32Array([1, 2, 3, 1, 2, 3]).buffer,
+                    }),
+                ],
+            }),
+            expect.any(Array),
+        );
+        scope.onmessage!({
+            data: { type: "frame", generation: 1, id: 2, poseFrame: -1, phaseSeconds: 0 },
+        });
+        expect(scope.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ type: "error", generation: 1 }),
+        );
+    });
+});
+
+it.skipIf(!process.env.MODEL_VIEWER_PACKED_DQ_MOD)(
+    "computes start, middle and end frames of the local mod",
+    () => {
+        const dir = process.env.MODEL_VIEWER_PACKED_DQ_MOD!;
+        const read = (name: string) => new Uint8Array(readFileSync(join(dir, name))).buffer;
+        const { deformer } = fixture();
+        const buffers = {
+            base: read("NilouStandee.buf"),
+            blend: read("NilouStandeeBlend.buf"),
+            pose: read("pose.buf"),
+            shapeTargets: [],
+        };
+        deformer.vertexCount = 23775;
+        deformer.base.byteLength = buffers.base.byteLength;
+        deformer.pose!.blend.byteLength = buffers.blend.byteLength;
+        deformer.pose!.frames.byteLength = buffers.pose.byteLength;
+        deformer.pose!.boneCount = 446;
+        deformer.pose!.frameCount = 5160;
+        const frames = [6, 2581, 5157].map((index) =>
+            computePackedDualQuaternionFrame(deformer, buffers, index),
+        );
+        for (const frame of frames) {
+            expect(frame.positions.length).toBe(23775 * 3);
+            expect(frame.positions.every(Number.isFinite)).toBe(true);
+            expect(frame.normals.every(Number.isFinite)).toBe(true);
+        }
+        expect(frames[0]!.positions).not.toEqual(frames[1]!.positions);
+        expect(frames[1]!.positions).not.toEqual(frames[2]!.positions);
+    },
+);

--- a/frontend/src/components/tools/model-viewer/model-viewer-compute-dual-quaternion.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-compute-dual-quaternion.ts
@@ -1,0 +1,180 @@
+import type { ViewerComputeDeformer } from "@shared/mod-viewer/types";
+
+import type { GIMIShapePoseBuffers, GIMIShapePoseFrame } from "./model-viewer-compute-kernel";
+
+import {
+    normalizePackedVectors,
+    packedHalfToFloat,
+    validatePackedBuffer,
+} from "./model-viewer-packed-vertex";
+
+export function validatePackedDualQuaternionBuffers(
+    deformer: ViewerComputeDeformer,
+    buffers: GIMIShapePoseBuffers,
+): void {
+    const pose = deformer.pose;
+    if (
+        deformer.kind !== "gimi_packed_dual_quaternion_v1" ||
+        !pose ||
+        !buffers.pose ||
+        !buffers.blend ||
+        !Number.isSafeInteger(deformer.vertexCount) ||
+        deformer.vertexCount <= 0 ||
+        !Number.isSafeInteger(pose.boneCount) ||
+        pose.boneCount <= 0 ||
+        !Number.isSafeInteger(pose.frameCount) ||
+        pose.frameCount < 2 ||
+        deformer.shapePasses.length !== 0 ||
+        deformer.shapeStages.length !== 0 ||
+        buffers.shapeTargets.length !== 0
+    ) {
+        throw new Error("Packed dual-quaternion descriptor is invalid.");
+    }
+    for (const [label, source, buffer, stride, count] of [
+        ["base", deformer.base, buffers.base, 20, deformer.vertexCount],
+        ["blend", pose.blend, buffers.blend, 32, deformer.vertexCount],
+        ["pose", pose.frames, buffers.pose, 56, pose.boneCount * pose.frameCount],
+    ] as const) {
+        validatePackedBuffer(
+            `Packed dual-quaternion ${label}`,
+            source.byteLength,
+            source.stride,
+            buffer,
+        );
+        if (source.stride !== stride || buffer.byteLength !== count * stride) {
+            throw new Error(`Packed dual-quaternion ${label} dimensions are invalid.`);
+        }
+    }
+}
+
+export function computePackedDualQuaternionFrame(
+    deformer: ViewerComputeDeformer,
+    buffers: GIMIShapePoseBuffers,
+    poseFrame: number,
+): GIMIShapePoseFrame {
+    validatePackedDualQuaternionBuffers(deformer, buffers);
+    if (!Number.isFinite(poseFrame) || poseFrame < 0) {
+        throw new Error(`Invalid packed dual-quaternion frame: ${poseFrame}`);
+    }
+    const pose = deformer.pose!;
+    const frame = Math.min(poseFrame, pose.frameCount - 1);
+    const frame0 = Math.floor(frame);
+    const frame1 = Math.min(frame0 + 1, pose.frameCount - 1);
+    const inter = frame - frame0;
+    const base = new DataView(buffers.base);
+    const blend = new DataView(buffers.blend!);
+    const palette = new Float32Array(buffers.pose!);
+    const positions = new Float32Array(deformer.vertexCount * 3);
+    const normals = new Float32Array(deformer.vertexCount * 3);
+    const accumulated = new Float64Array(14);
+    for (let vertex = 0; vertex < deformer.vertexCount; vertex += 1) {
+        accumulated.fill(0);
+        const source = vertex * 20;
+        const blendOffset = vertex * 32;
+        const referenceBone = blend.getInt32(blendOffset + 16, true);
+        const reference = (frame0 * pose.boneCount + referenceBone) * 14 + 6;
+        for (let influence = 0; influence < 4; influence += 1) {
+            const bone = blend.getInt32(blendOffset + 16 + influence * 4, true);
+            const weight = blend.getFloat32(blendOffset + influence * 4, true);
+            // The shader fetches all four indices, including zero-weight influences.
+            if (bone < 0 || bone >= pose.boneCount || !Number.isFinite(weight)) {
+                throw new Error(
+                    `Invalid packed dual-quaternion influence at vertex ${vertex}: bone=${bone}`,
+                );
+            }
+            for (let sample = 0; sample < 2; sample += 1) {
+                const offset = ((sample === 0 ? frame0 : frame1) * pose.boneCount + bone) * 14;
+                const factor = weight * (sample === 0 ? 1 - inter : inter);
+                const dot =
+                    palette[reference]! * palette[offset + 6]! +
+                    palette[reference + 1]! * palette[offset + 7]! +
+                    palette[reference + 2]! * palette[offset + 8]! +
+                    palette[reference + 3]! * palette[offset + 9]!;
+                // Unlike Math.sign(dot), the shader preserves contributions at dot == 0.
+                const signedFactor = dot < 0 ? -factor : factor;
+                for (let component = 0; component < 14; component += 1) {
+                    accumulated[component] +=
+                        palette[offset + component]! * (component < 6 ? factor : signedFactor);
+                }
+            }
+        }
+        const length = Math.hypot(
+            accumulated[6]!,
+            accumulated[7]!,
+            accumulated[8]!,
+            accumulated[9]!,
+        );
+        if (length < 1e-8 || !accumulated.every(Number.isFinite)) {
+            throw new Error(`Invalid packed dual-quaternion pose at vertex ${vertex}`);
+        }
+        const qx = accumulated[6]! / length;
+        const qy = accumulated[7]! / length;
+        const qz = accumulated[8]! / length;
+        const qw = accumulated[9]! / length;
+        const dx = accumulated[10]! / length;
+        const dy = accumulated[11]! / length;
+        const dz = accumulated[12]! / length;
+        const dw = accumulated[13]! / length;
+        const m00 = 1 - 2 * qy * qy - 2 * qz * qz;
+        const m01 = 2 * (qx * qy - qw * qz);
+        const m02 = 2 * (qx * qz + qw * qy);
+        const m10 = 2 * (qx * qy + qw * qz);
+        const m11 = 1 - 2 * qx * qx - 2 * qz * qz;
+        const m12 = 2 * (qy * qz - qw * qx);
+        const m20 = 2 * (qx * qz - qw * qy);
+        const m21 = 2 * (qy * qz + qw * qx);
+        const m22 = 1 - 2 * qx * qx - 2 * qy * qy;
+        // Packed game axes -> Blender axes; this shader forces position.w = 1.
+        const x =
+            packedHalfToFloat(base.getUint16(source, true)) * accumulated[0]! + accumulated[3]!;
+        const y =
+            -packedHalfToFloat(base.getUint16(source + 4, true)) * accumulated[1]! +
+            accumulated[4]!;
+        const z =
+            packedHalfToFloat(base.getUint16(source + 2, true)) * accumulated[2]! + accumulated[5]!;
+        const nx = base.getInt8(source + 8);
+        const ny = -base.getInt8(source + 10);
+        const nz = base.getInt8(source + 9);
+        const destination = vertex * 3;
+        positions[destination] = roundPackedPosition(
+            m00 * x + m01 * y + m02 * z + 2 * (-dw * qx + dx * qw - dy * qz + dz * qy),
+        );
+        positions[destination + 1] = roundPackedPosition(
+            m20 * x + m21 * y + m22 * z + 2 * (-dw * qz - dx * qy + dy * qx + dz * qw),
+        );
+        positions[destination + 2] = roundPackedPosition(
+            -(m10 * x + m11 * y + m12 * z + 2 * (-dw * qy + dx * qz + dy * qw - dz * qx)),
+        );
+        normals[destination] = Math.max(
+            -128,
+            Math.min(127, Math.trunc(m00 * nx + m01 * ny + m02 * nz)),
+        );
+        normals[destination + 1] = Math.max(
+            -128,
+            Math.min(127, Math.trunc(m20 * nx + m21 * ny + m22 * nz)),
+        );
+        normals[destination + 2] = Math.max(
+            -128,
+            Math.min(127, Math.trunc(-(m10 * nx + m11 * ny + m12 * nz))),
+        );
+    }
+    normalizePackedVectors(normals);
+    return { positions, normals };
+}
+
+// f32tof16 output is rounded to nearest, ties to even, then decoded for Three.js.
+// Keeping the quantization prevents the preview from inventing extra precision.
+function roundPackedPosition(value: number): number {
+    const magnitude = Math.abs(Math.fround(value));
+    if (!Number.isFinite(magnitude) || magnitude >= 65520) {
+        throw new Error("Packed dual-quaternion position exceeds finite float16 range.");
+    }
+    if (magnitude === 0) {
+        return value;
+    }
+    const step = 2 ** Math.max(-24, Math.floor(Math.log2(magnitude)) - 10);
+    const scaled = magnitude / step;
+    const lower = Math.floor(scaled);
+    const rounded = scaled - lower === 0.5 ? lower + (lower % 2) : Math.round(scaled);
+    return Math.sign(value) * rounded * step;
+}

--- a/frontend/src/components/tools/model-viewer/model-viewer-compute.worker.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-compute.worker.ts
@@ -6,6 +6,10 @@ import {
     validateCyclicPackedBuffers,
 } from "./model-viewer-compute-cyclic";
 import {
+    computePackedDualQuaternionFrame,
+    validatePackedDualQuaternionBuffers,
+} from "./model-viewer-compute-dual-quaternion";
+import {
     compactGIMIShapePoseFrame,
     computeGIMIShapePoseFrame,
     type GIMIShapePoseBuffers,
@@ -131,6 +135,11 @@ async function bindDeformerCompute(
             const buffers = await loadShapePoseBuffers(deformer);
             validateCyclicPackedBuffers(deformer, buffers);
             return (poseFrame) => computeCyclicPackedFrame(deformer, buffers, poseFrame);
+        }
+        case "gimi_packed_dual_quaternion_v1": {
+            const buffers = await loadShapePoseBuffers(deformer);
+            validatePackedDualQuaternionBuffers(deformer, buffers);
+            return (poseFrame) => computePackedDualQuaternionFrame(deformer, buffers, poseFrame);
         }
         case "gimi_shape_pose_v1": {
             const buffers = await loadShapePoseBuffers(deformer);

--- a/frontend/src/components/tools/model-viewer/model-viewer-transport.test.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-transport.test.ts
@@ -164,42 +164,50 @@ describe("normalizeModelViewerTransport", () => {
         ]);
     });
 
-    it("keeps a cyclic packed compute descriptor", () => {
-        const source = { url: "/source", byteLength: 20, stride: 20 };
-        const input = {
-            memorySessionId: "session",
-            iniPath: "mod.ini",
-            modPath: "mod",
-            name: "Example",
-            meshes: null,
-            textures: null,
-            variables: null,
-            defaultState: null,
-            stateRules: null,
-            uiAssets: {},
-            animations: null,
-            computeDeformers: [
-                {
-                    kind: "gimi_cyclic_packed_v1",
-                    id: "closet",
-                    meshIds: ["mesh"],
-                    vertexCount: 1,
-                    base: source,
-                    shapePasses: null,
-                    pose: {
-                        blend: { url: "/blend", byteLength: 32, stride: 32 },
-                        frames: { url: "/pose", byteLength: 96, stride: 48 },
-                        boneCount: 1,
-                        frameCount: 2,
+    it.each(["gimi_cyclic_packed_v1", "gimi_packed_dual_quaternion_v1"] as const)(
+        "keeps a %s compute descriptor",
+        (kind) => {
+            const poseStride = kind === "gimi_packed_dual_quaternion_v1" ? 56 : 48;
+            const source = { url: "/source", byteLength: 20, stride: 20 };
+            const input = {
+                memorySessionId: "session",
+                iniPath: "mod.ini",
+                modPath: "mod",
+                name: "Example",
+                meshes: null,
+                textures: null,
+                variables: null,
+                defaultState: null,
+                stateRules: null,
+                uiAssets: {},
+                animations: null,
+                computeDeformers: [
+                    {
+                        kind,
+                        id: "closet",
+                        meshIds: ["mesh"],
+                        vertexCount: 1,
+                        base: source,
+                        shapePasses: null,
+                        pose: {
+                            blend: { url: "/blend", byteLength: 32, stride: 32 },
+                            frames: {
+                                url: "/pose",
+                                byteLength: 2 * poseStride,
+                                stride: poseStride,
+                            },
+                            boneCount: 1,
+                            frameCount: 2,
+                        },
                     },
-                },
-            ],
-        } satisfies WailsModelViewerTransport;
+                ],
+            } satisfies WailsModelViewerTransport;
 
-        expect(normalizeModelViewerTransport(input).computeDeformers).toEqual([
-            expect.objectContaining({ kind: "gimi_cyclic_packed_v1", id: "closet" }),
-        ]);
-    });
+            expect(normalizeModelViewerTransport(input).computeDeformers).toEqual([
+                expect.objectContaining({ kind, id: "closet" }),
+            ]);
+        },
+    );
 
     it("keeps a packed shapekey compute descriptor", () => {
         const source = { url: "/source", byteLength: 20, stride: 20 };

--- a/frontend/src/components/tools/model-viewer/model-viewer-transport.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-transport.ts
@@ -176,6 +176,7 @@ export function normalizeModelViewerTransport(
         computeDeformers: (value.computeDeformers ?? []).flatMap((deformer) => {
             if (
                 deformer.kind !== "gimi_shape_pose_v1" &&
+                deformer.kind !== "gimi_packed_dual_quaternion_v1" &&
                 deformer.kind !== "gimi_cyclic_packed_v1" &&
                 deformer.kind !== "gimi_cyclic_packed_shape_v1"
             ) {

--- a/frontend/src/shared/mod-viewer/types.ts
+++ b/frontend/src/shared/mod-viewer/types.ts
@@ -152,6 +152,7 @@ export type ViewerComputeShapeStage = {
 
 export type ViewerComputeDeformerKind =
     | "gimi_shape_pose_v1"
+    | "gimi_packed_dual_quaternion_v1"
     | "gimi_cyclic_packed_v1"
     | "gimi_cyclic_packed_shape_v1";
 

--- a/internal/tools/model_viewer_compute_animation.go
+++ b/internal/tools/model_viewer_compute_animation.go
@@ -13,8 +13,10 @@ import (
 )
 
 const (
-	modelViewerGIMIShapePoseKind     = "gimi_shape_pose_v1"
-	maxModelViewerComputeShaderBytes = 1 << 20
+	modelViewerGIMIShapePoseKind        = "gimi_shape_pose_v1"
+	modelViewerPackedDualQuaternionKind = "gimi_packed_dual_quaternion_v1"
+	maxModelViewerComputePoseFrames     = 65536
+	maxModelViewerComputeShaderBytes    = 1 << 20
 )
 
 var (
@@ -41,6 +43,8 @@ type modelViewerKnownBoneKernel struct {
 
 func modelViewerKnownBoneKernelForShader(shader string) (modelViewerKnownBoneKernel, bool) {
 	switch {
+	case isKnownModelViewerPackedDualQuaternionShader(shader):
+		return modelViewerKnownBoneKernel{kind: modelViewerPackedDualQuaternionKind, baseStride: 20, blendStride: 32, poseStride: 56}, true
 	case isKnownModelViewerGIMIShapePoseBoneShader(shader):
 		return modelViewerKnownBoneKernel{kind: modelViewerGIMIShapePoseKind, baseStride: 40, blendStride: 32, poseStride: 56, shapePasses: true}, true
 	case isKnownModelViewerGIMICyclicPackedBoneShader(shader):
@@ -49,7 +53,12 @@ func modelViewerKnownBoneKernelForShader(shader string) (modelViewerKnownBoneKer
 	return modelViewerKnownBoneKernel{}, false
 }
 
-func detectModelViewerComputeAnimation(root, shaderBaseDir, scopeID string, sections []modINISection, effectiveResources []modelViewerResource, meshes []modelViewerDirectMesh, names map[string]modelViewerVariableName) (*ModelViewerComputeDeformerTransport, []modelViewerPreparedAnimationClip) {
+func detectModelViewerComputeAnimation(root, shaderBaseDir, scopeID string, sections []modINISection, effectiveResources []modelViewerResource, meshes []modelViewerDirectMesh, names map[string]modelViewerVariableName, diagnostics ...func(string)) (*ModelViewerComputeDeformerTransport, []modelViewerPreparedAnimationClip) {
+	warn := func(message string) {
+		for _, diagnostic := range diagnostics {
+			diagnostic(message)
+		}
+	}
 	rawResources := modelViewerResourceMap(collectModelViewerResources(sections))
 	effective := modelViewerResourceMap(effectiveResources)
 	defaults := collectModelViewerDefaultVariables(sections)
@@ -74,6 +83,10 @@ func detectModelViewerComputeAnimation(root, shaderBaseDir, scopeID string, sect
 		return shapeOnly()
 	}
 	boneCount := int(boneCountValue)
+	declaredPoseStride := pose.Stride
+	if kernel.kind == modelViewerPackedDualQuaternionKind && pose.Stride == 52 {
+		pose.Stride = kernel.poseStride
+	}
 	if !baseOK || !blendOK || !poseOK || !outputRawOK || !outputEffectiveOK || outputRaw.Filename != "" || !samePathFold(outputEffective.Filename, base.Filename) || base.Stride != kernel.baseStride || blend.Stride != kernel.blendStride || pose.Stride != kernel.poseStride {
 		return shapeOnly()
 	}
@@ -92,6 +105,9 @@ func detectModelViewerComputeAnimation(root, shaderBaseDir, scopeID string, sect
 	if len(meshIDs) == 0 || frameCount < 2 {
 		return shapeOnly()
 	}
+	if declaredPoseStride != pose.Stride {
+		warn(fmt.Sprintf("Normalized pose stride: shader=%q pose=%q declaredStride=%d appliedStride=%d boneCount=%d frameCount=%d", filepath.Join(shaderBaseDir, posePass.shader), poseSource.sourcePath, declaredPoseStride, pose.Stride, boneCount, frameCount))
+	}
 	deformerID := modelViewerComputeDeformerID(scopeID, firstModelViewerString(posePass.outputName, base.Name))
 	deformer := &ModelViewerComputeDeformerTransport{
 		Kind:        kernel.kind,
@@ -106,8 +122,14 @@ func detectModelViewerComputeAnimation(root, shaderBaseDir, scopeID string, sect
 	if kernel.shapePasses {
 		deformer.ShapePasses = detectModelViewerKnownShapePasses(root, shaderBaseDir, sections, reachable, effective, defaults, base, vertexCount)
 	}
-	clips := detectModelViewerGIMIShapePoseClips(sections, poseSection, posePass.x88, defaults, names, deformerID, frameCount)
+	clips, explicitRange := detectModelViewerGIMIShapePoseClips(sections, poseSection, posePass.x88, defaults, names, deformerID, frameCount, func(message string) {
+		warn(fmt.Sprintf("shader=%q pose=%q %s", filepath.Join(shaderBaseDir, posePass.shader), poseSource.sourcePath, message))
+	})
 	if len(clips) == 0 {
+		if explicitRange || frameCount > maxModelViewerComputePoseFrames {
+			warn(fmt.Sprintf("Skipped invalid compute pose range: shader=%q pose=%q frameCount=%d explicitRange=%t", filepath.Join(shaderBaseDir, posePass.shader), poseSource.sourcePath, frameCount, explicitRange))
+			return shapeOnly()
+		}
 		fps := 30.0
 		if rate, ok := modelViewerComputePoseFPS(poseSection, posePass.x88, defaults); ok {
 			fps = rate
@@ -522,41 +544,76 @@ func modelViewerComputePoseFPS(section modINISection, frameExpression string, de
 	return fps, true
 }
 
-func detectModelViewerGIMIShapePoseClips(sections []modINISection, poseSection modINISection, frameExpression string, defaults map[string]any, names map[string]modelViewerVariableName, deformerID string, frameCount int) []modelViewerPreparedAnimationClip {
+func detectModelViewerGIMIShapePoseClips(sections []modINISection, poseSection modINISection, frameExpression string, defaults map[string]any, names map[string]modelViewerVariableName, deformerID string, frameCount int, diagnostics ...func(string)) ([]modelViewerPreparedAnimationClip, bool) {
 	frameVariable, _, ok := parseModelViewerPhaseExpression(frameExpression)
 	if !ok {
-		return nil
+		return nil, false
 	}
 	fps, ok := modelViewerComputePoseFPS(poseSection, frameExpression, defaults)
 	if !ok {
-		return nil
+		fps = 30
 	}
-	endVariable := ""
-	startVariable := ""
-	endPattern := regexp.MustCompile(fmt.Sprintf(`(?i)^if\s+\$%s\s*>\s*\$([\w.]+)\s*$`, regexp.QuoteMeta(frameVariable)))
-	resetPattern := regexp.MustCompile(fmt.Sprintf(`(?i)^\$%s\s*=\s*\$([\w.]+)\s*$`, regexp.QuoteMeta(frameVariable)))
+	endVariable, startVariable := "", ""
+	endOffset, startOffset := 0.0, 0.0
+	explicitRange, hasReset := false, false
+	endPattern := regexp.MustCompile(fmt.Sprintf(`(?i)^if\s+\$%s\s*>\s*(.+)$`, regexp.QuoteMeta(frameVariable)))
+	resetPattern := regexp.MustCompile(fmt.Sprintf(`(?i)^\$%s\s*=\s*(.+)$`, regexp.QuoteMeta(frameVariable)))
 	for _, raw := range poseSection.Lines {
-		line := strings.TrimSpace(raw)
+		line := strings.TrimSpace(strings.SplitN(raw, ";", 2)[0])
 		if match := endPattern.FindStringSubmatch(line); match != nil {
-			endVariable = modelViewerNormalizeKey(match[1])
+			explicitRange = true
+			var valid bool
+			endVariable, endOffset, valid = parseModelViewerComputeRangeToken(match[1])
+			if !valid {
+				return nil, true
+			}
 		}
 		if match := resetPattern.FindStringSubmatch(line); match != nil {
-			candidate := modelViewerNormalizeKey(match[1])
-			if candidate != frameVariable {
-				startVariable = candidate
+			candidate, offset, valid := parseModelViewerComputeRangeToken(match[1])
+			if valid && candidate != frameVariable {
+				startVariable, startOffset, hasReset = candidate, offset, true
 			}
 		}
 	}
-	if startVariable == "" || endVariable == "" {
-		return nil
+	if !explicitRange {
+		return nil, false
+	}
+	if !hasReset || endOffset != math.Trunc(endOffset) || startOffset != math.Trunc(startOffset) {
+		return nil, true
 	}
 	ranges := collectModelViewerStateRanges(sections, startVariable, endVariable)
+	if len(ranges) == 0 {
+		start, end := startOffset, endOffset
+		startOK, endOK := true, true
+		if startVariable != "" {
+			start, startOK = resolveModelViewerNumericToken("$"+startVariable, defaults)
+			start += startOffset
+		}
+		if endVariable != "" {
+			end, endOK = resolveModelViewerNumericToken("$"+endVariable, defaults)
+			end += endOffset
+		}
+		if !startOK || !endOK || !validModelViewerComputePoseRange(start, end, frameCount) {
+			return nil, true
+		}
+		clip := buildModelViewerComputeFallbackClip(deformerID, "Pose Animation", int(end-start)+1, fps)
+		clip.FrameStart, clip.FrameEnd = int(start), int(end)
+		for index := range clip.Frames {
+			clip.Frames[index].Index += int(start)
+		}
+		return []modelViewerPreparedAnimationClip{clip}, true
+	}
 	var clips []modelViewerPreparedAnimationClip
 	for _, value := range sortedModelViewerStateRangeKeys(ranges) {
 		rangeValue := ranges[value]
-		if rangeValue.start < 0 || rangeValue.end < rangeValue.start || rangeValue.end >= frameCount || rangeValue.end-rangeValue.start+1 > maxModelViewerAnimationFrames {
+		start, end := float64(rangeValue.start)+startOffset, float64(rangeValue.end)+endOffset
+		if !validModelViewerComputePoseRange(start, end, frameCount) {
+			for _, diagnostic := range diagnostics {
+				diagnostic(fmt.Sprintf("Skipped invalid compute pose state range: variable=%q state=%q frameStart=%g frameEnd=%g frameCount=%d", rangeValue.variable, value, start, end, frameCount))
+			}
 			continue
 		}
+		rangeValue.start, rangeValue.end = int(start), int(end)
 		stateVariable := rangeValue.variable
 		labelName := stateVariable
 		if name, exists := names[modelViewerNormalizeKey(stateVariable)]; exists {
@@ -572,7 +629,21 @@ func detectModelViewerGIMIShapePoseClips(sections []modINISection, poseSection m
 		}
 		clips = append(clips, clip)
 	}
-	return clips
+	return clips, true
+}
+
+// Numeric literals are common in older packed matrix mods; preserve those
+// ranges as well as named constants and their constant offsets.
+func parseModelViewerComputeRangeToken(expression string) (string, float64, bool) {
+	if variable, offset, ok := parseModelViewerPhaseExpression(expression); ok {
+		return variable, offset, true
+	}
+	value, err := strconv.ParseFloat(strings.TrimSpace(expression), 64)
+	return "", value, err == nil && !math.IsNaN(value) && !math.IsInf(value, 0)
+}
+
+func validModelViewerComputePoseRange(start, end float64, frameCount int) bool {
+	return !math.IsNaN(start) && !math.IsNaN(end) && start == math.Trunc(start) && end == math.Trunc(end) && start >= 0 && end >= start && end < float64(frameCount) && end-start+1 <= maxModelViewerComputePoseFrames
 }
 
 type modelViewerStateRange struct {

--- a/internal/tools/model_viewer_load.go
+++ b/internal/tools/model_viewer_load.go
@@ -282,7 +282,11 @@ func (t *Tools) prepareModelViewerGeometry(ctx context.Context, folder string, i
 		if multi {
 			computeScopeID = modelViewerString(iniIndex)
 		}
-		if deformer, clips := detectModelViewerComputeAnimation(folder, filepath.Dir(iniPath), computeScopeID, sections, resources, meshes, scopedNames); deformer != nil {
+		if deformer, clips := detectModelViewerComputeAnimation(folder, filepath.Dir(iniPath), computeScopeID, sections, resources, meshes, scopedNames, func(message string) {
+			if t.log != nil {
+				t.log.Warn(fmt.Sprintf("INI=%q %s", iniPath, message), "StaticGlb.loadForViewer")
+			}
+		}); deformer != nil {
 			prepared.computeDeformers = append(prepared.computeDeformers, *deformer)
 			prepared.computeAnimations = append(prepared.computeAnimations, clips...)
 		}

--- a/internal/tools/model_viewer_object_layout.go
+++ b/internal/tools/model_viewer_object_layout.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -33,6 +34,10 @@ func isModelViewerPackedObjectStride(stride int) bool {
 }
 
 func modelViewerPackedObjectLayout(indexFormat string, stride int) modelViewerFmtLayout {
+	return modelViewerPackedObjectLayoutAt(indexFormat, stride, 12)
+}
+
+func modelViewerPackedObjectLayoutAt(indexFormat string, stride, texcoordOffset int) modelViewerFmtLayout {
 	if indexFormat == "" {
 		indexFormat = "DXGI_FORMAT_R32_UINT"
 	}
@@ -46,7 +51,7 @@ func modelViewerPackedObjectLayout(indexFormat string, stride int) modelViewerFm
 		Elements: []modelViewerFmtElement{
 			{SemanticName: "POSITION", Format: "DXGI_FORMAT_R16G16B16A16_FLOAT", AlignedByteOffset: 0, InputSlotClass: "per-vertex"},
 			{SemanticName: "NORMAL", Format: "DXGI_FORMAT_R8G8B8A8_SINT", AlignedByteOffset: 8, InputSlotClass: "per-vertex"},
-			{SemanticName: "TEXCOORD", Format: "DXGI_FORMAT_R16G16_FLOAT", AlignedByteOffset: 12, InputSlotClass: "per-vertex"},
+			{SemanticName: "TEXCOORD", Format: "DXGI_FORMAT_R16G16_FLOAT", AlignedByteOffset: texcoordOffset, InputSlotClass: "per-vertex"},
 		},
 	}
 }
@@ -75,12 +80,12 @@ func isKnownModelViewerGIMICyclicPackedBoneShader(shader string) bool {
 	return strings.Contains(compact, "int4indicies") || strings.Contains(compact, "int4indices")
 }
 
-func collectModelViewerPackedObjectResources(root, shaderBaseDir string, sections []modINISection) map[string]bool {
-	packed := map[string]bool{}
+func collectModelViewerPackedObjectResources(root, shaderBaseDir string, sections []modINISection) map[string]int {
+	packed := map[string]int{}
 	reachable := collectModelViewerReachableComputeSections(sections)
-	add := func(name string) {
+	add := func(name string, texcoordOffset int) {
 		if key := modelViewerNormalizeKey(name); key != "" {
-			packed[key] = true
+			packed[key] = texcoordOffset
 		}
 	}
 	for _, section := range sections {
@@ -89,11 +94,17 @@ func collectModelViewerPackedObjectResources(root, shaderBaseDir string, section
 		}
 		for _, pass := range collectModelViewerComputePasses(section) {
 			shader, ok := readModelViewerComputeShader(root, shaderBaseDir, pass.shader)
-			if !ok || !isKnownModelViewerPackedObjectShader(shader) {
+			if !ok {
 				continue
 			}
-			add(pass.outputName)
-			add(pass.t50)
+			texcoordOffset := 12
+			if isKnownModelViewerPackedDualQuaternionShader(shader) {
+				texcoordOffset = 16
+			} else if !isKnownModelViewerPackedObjectShader(shader) {
+				continue
+			}
+			add(pass.outputName, texcoordOffset)
+			add(pass.t50, texcoordOffset)
 		}
 	}
 	return packed
@@ -222,6 +233,7 @@ func modelViewerResourceVertexCount(modDir string, resource modelViewerResource,
 
 type modelViewerDrawVertexSource struct {
 	kind                           string
+	packedTexcoordOffset           int
 	ib, position, texcoord, vector modelViewerResource
 	packed                         []byte
 	packedStride                   int
@@ -234,7 +246,7 @@ func resolveModelViewerDrawVertexSource(
 	resourceMap map[string]modelViewerResource,
 	resources []modelViewerResource,
 	cache *modelViewerBufferCache,
-	packedResources map[string]bool,
+	packedResources map[string]int,
 ) modelViewerDrawVertexSource {
 	ib, ibOK := resourceMap[modelViewerNormalizeKey(state.ib)]
 	position, posOK := resourceMap[modelViewerNormalizeKey(state.vb0)]
@@ -253,7 +265,14 @@ func resolveModelViewerDrawVertexSource(
 		source.texcoord = texcoord
 		return source
 	}
-	shaderPacked := packedResources[modelViewerNormalizeKey(position.Name)] || packedResources[modelViewerNormalizeKey(state.vb0)]
+	source.packedTexcoordOffset = packedResources[modelViewerNormalizeKey(state.vb0)]
+	if source.packedTexcoordOffset == 0 {
+		source.packedTexcoordOffset = packedResources[modelViewerNormalizeKey(position.Name)]
+	}
+	shaderPacked := source.packedTexcoordOffset != 0
+	if !shaderPacked {
+		source.packedTexcoordOffset = 12
+	}
 	texcoord, tcOK := resourceMap[modelViewerNormalizeKey(state.vb1)]
 	if !tcOK || texcoord.Filename == "" {
 		if raw, packedStride, packed := readModelViewerPackedObjectBuffer(modDir, position, cache, shaderPacked); packed {
@@ -316,11 +335,15 @@ func loadModelViewerDrawVertexBuffers(modDir string, source modelViewerDrawVerte
 		if stride <= 0 {
 			stride = modelViewerPackedObjectStride
 		}
+		texcoordOffset := source.packedTexcoordOffset
+		if texcoordOffset == 16 {
+			texcoordOffset = resolveModelViewerPackedTexcoordOffset(modDir, position, source.packed, stride, cache)
+		}
 		return modelViewerDrawVertexBuffers{
 			combined:  source.packed,
 			stride:    stride,
 			posStride: stride,
-			layout:    modelViewerPackedObjectLayout(source.ib.Format, stride),
+			layout:    modelViewerPackedObjectLayoutAt(source.ib.Format, stride, texcoordOffset),
 		}, true, nil
 	case modelViewerDrawVertexWWMI:
 		vectorStride := vector.Stride
@@ -372,6 +395,41 @@ func loadModelViewerDrawVertexBuffers(modDir string, source modelViewerDrawVerte
 	default:
 		return modelViewerDrawVertexBuffers{}, false, nil
 	}
+}
+
+// Some compute shaders name the untouched UV word "tangent". Only override
+// their declared layout when a separate UV stream matches every vertex byte.
+func resolveModelViewerPackedTexcoordOffset(modDir string, position modelViewerResource, packed []byte, stride int, cache *modelViewerBufferCache) int {
+	if stride < 20 || len(packed) == 0 || len(packed)%stride != 0 {
+		return 16
+	}
+	for _, filename := range modelViewerSiblingTexcoordFilenames(position) {
+		resolved, err := resolveModelViewerResourcePath(modDir, modDir, filename)
+		if err != nil || !modelViewerPathWithin(modDir, resolved) {
+			continue
+		}
+		info, err := os.Stat(resolved)
+		if err != nil || !info.Mode().IsRegular() || info.Size() != int64(len(packed)/stride)*4 {
+			continue
+		}
+		uv, err := cache.read(resolved)
+		if err != nil || len(uv) != len(packed)/stride*4 {
+			continue
+		}
+		for _, offset := range []int{16, 12} {
+			matches := true
+			for vertex := range len(uv) / 4 {
+				if !bytes.Equal(uv[vertex*4:vertex*4+4], packed[vertex*stride+offset:vertex*stride+offset+4]) {
+					matches = false
+					break
+				}
+			}
+			if matches {
+				return offset
+			}
+		}
+	}
+	return 16
 }
 
 func normalizeModelViewerPackedObjectNormals(normals []float32) {

--- a/internal/tools/model_viewer_packed_dual_quaternion.go
+++ b/internal/tools/model_viewer_packed_dual_quaternion.go
@@ -1,0 +1,43 @@
+package tools
+
+import "strings"
+
+// This kernel uses packed game vertices with Blender-space dual-quaternion poses.
+// In particular, its UV follows the tangent, unlike the cyclic matrix kernel.
+func isKnownModelViewerPackedDualQuaternionShader(shader string) bool {
+	compact := compactModelViewerShader(shader)
+	required := []string{
+		"structvertexattributes{uint2position;uintnormal;uinttangent;uinttexcoord;}",
+		"structposeattributes{float3s;float3t;float4qr;float4qd;}",
+		"rwstructuredbuffer<vertexattributes>", "register(u5)",
+		"structuredbuffer<vertexattributes>base:register(t50)",
+		"structuredbuffer<blendattributes>blend:register(t51)",
+		"structuredbuffer<poseattributes>pose:register(t52)",
+		"#definetimeiniparams[88].x", "#definevg_countiniparams[89].x",
+		"frame=(int)floor(time)", "inter=time-floor(time)",
+		"blend_indicy=frame*((int)vg_count)+blend[i].indicies",
+		"blend_indicy_next=(frame+1)*((int)vg_count)+blend[i].indicies",
+		"pos.x=f16tof32(base[i].position.x&0xffff)",
+		"pos.z=f16tof32(base[i].position.x>>16)",
+		"pos.y=f16tof32(base[i].position.y&0xffff)*-1.0f", "pos.w=1.0f",
+		"scale=pose[blend_indicy.x].s*blend[i].weights.x*(1.0f-inter)",
+		"bias=pose[blend_indicy.x].t*blend[i].weights.x*(1.0f-inter)",
+		"pos.xyz=pos.xyz*scale+bias",
+		"qr=pose[blend_indicy.x].qr*blend[i].weights.x*(1.0f-inter)",
+		"qd=pose[blend_indicy.x].qd*blend[i].weights.x*(1.0f-inter)",
+		"if(dot(pose[blend_indicy.x].qr,pose[blend_indicy.y].qr)<0)",
+		"if(dot(pose[blend_indicy.x].qr,pose[blend_indicy_next.x].qr)<0)",
+		"qd=qd/length(qr)", "qr=qr/length(qr)",
+		"-qd.w*qr.x+qd.x*qr.w-qd.y*qr.z+qd.z*qr.y",
+		"pos_result.x=dot(trans,pos)", "normal_result.x=dot(trans,normal)",
+		"rw_buffer[i].position.x=(uint)f32tof16(pos_result.z)<<16|(uint)f32tof16(pos_result.x)",
+		"rw_buffer[i].position.y=(uint)f32tof16(pos_result.w)<<16|(uint)f32tof16(pos_result.y*-1.0f)",
+		"i32toi8(int(normal_result.y*-1.0f))<<16",
+	}
+	for _, signature := range required {
+		if !strings.Contains(compact, signature) {
+			return false
+		}
+	}
+	return strings.Contains(compact, "structblendattributes{float4weights;int4indicies;}")
+}

--- a/internal/tools/model_viewer_packed_dual_quaternion_test.go
+++ b/internal/tools/model_viewer_packed_dual_quaternion_test.go
@@ -1,0 +1,417 @@
+package tools
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A small recognition fixture; pose arithmetic is verified independently in the
+// renderer tests rather than storing a third-party model or its large buffers.
+const packedDualQuaternionShader = `
+struct VertexAttributes { uint2 position; uint normal; uint tangent; uint texcoord; };
+struct BlendAttributes { float4 weights; int4 indicies; };
+struct PoseAttributes { float3 S; float3 T; float4 QR; float4 QD; };
+RWStructuredBuffer<VertexAttributes> rw_buffer : register(u5);
+StructuredBuffer<VertexAttributes> base : register(t50);
+StructuredBuffer<BlendAttributes> blend : register(t51);
+StructuredBuffer<PoseAttributes> pose : register(t52);
+#define TIME IniParams[88].x
+#define VG_COUNT IniParams[89].x
+void main(uint3 threadID : SV_DispatchThreadID) {
+ uint i = threadID.x;
+ float4 pos;
+ pos.x = f16tof32(base[i].position.x & 0xffff);
+ pos.z = f16tof32(base[i].position.x >> 16);
+ pos.y = f16tof32(base[i].position.y & 0xffff)*-1.0f;
+ pos.w = 1.0f;
+ int frame = (int)floor(TIME);
+ float inter = TIME - floor(TIME);
+ int4 blend_indicy = frame*((int)VG_COUNT)+blend[i].indicies;
+ int4 blend_indicy_next = (frame+1)*((int)VG_COUNT)+blend[i].indicies;
+ float3 scale = pose[blend_indicy.x].S * blend[i].weights.x *(1.0f-inter);
+ float3 bias = pose[blend_indicy.x].T * blend[i].weights.x *(1.0f-inter);
+ pos.xyz = pos.xyz*scale + bias;
+ float4 qr = pose[blend_indicy.x].QR * blend[i].weights.x *(1.0f-inter);
+ float4 qd = pose[blend_indicy.x].QD * blend[i].weights.x *(1.0f-inter);
+ if (dot(pose[blend_indicy.x].QR, pose[blend_indicy.y].QR) < 0) {
+   qr -= pose[blend_indicy.y].QR * blend[i].weights.y;
+ }
+ if (dot(pose[blend_indicy.x].QR, pose[blend_indicy_next.x].QR) < 0) {
+   qr -= pose[blend_indicy_next.x].QR * blend[i].weights.x * inter;
+ }
+ qd = qd / length(qr);
+ qr = qr / length(qr);
+ float4 trans = float4(1, 0, 0, 2*(-qd.w*qr.x+qd.x*qr.w-qd.y*qr.z+qd.z*qr.y));
+ float4 pos_result, normal_result, normal;
+ pos_result.x = dot(trans, pos);
+ normal_result.x = dot(trans, normal);
+ rw_buffer[i].position.x = (uint)f32tof16(pos_result.z)<<16 | (uint)f32tof16(pos_result.x);
+ rw_buffer[i].position.y = (uint)f32tof16(pos_result.w)<<16 | (uint)f32tof16(pos_result.y*-1.0f);
+ rw_buffer[i].normal = i32toi8(int(normal_result.y*-1.0f))<<16;
+}`
+
+const packedDualQuaternionINI = `
+[Constants]
+global $freq = 0
+global $bones = 1
+global $start = 6
+global $end = 5159
+global $dt
+post ResourcePosition = copy_desc ResourcePosition.1
+[Present]
+run = CustomShaderPose
+[CustomShaderPose]
+$freq = $freq + 24 * $dt
+if $freq > $end-2
+  $freq = $start
+endif
+x88 = $freq
+x89 = $bones
+cs-t50 = copy ResourcePosition.1
+cs-t51 = copy ResourceBlend
+cs-t52 = copy ResourcePose
+cs = anim.hlsl
+cs-u5 = copy ResourcePosition.1
+ResourcePosition = ref cs-u5
+Dispatch = 3, 1, 1
+[TextureOverridePosition]
+hash = 12345678
+vb0 = ResourcePosition
+[TextureOverrideHead]
+hash = 23456789
+handling = skip
+ib = ResourceIB
+drawindexed = auto
+[ResourcePosition]
+[ResourcePosition.1]
+type = Buffer
+stride = 20
+filename = base.buf
+[ResourceBlend]
+type = Buffer
+stride = 32
+filename = blend.buf
+[ResourcePose]
+type = Buffer
+stride = 52
+filename = pose.buf
+[ResourceIB]
+type = Buffer
+format = DXGI_FORMAT_R32_UINT
+filename = head.ib
+`
+
+func writePackedDualQuaternionFixture(t *testing.T, dir, ini string) {
+	t.Helper()
+	base := make([]byte, 3*20)
+	for vertex := range 3 {
+		binary.LittleEndian.PutUint16(base[vertex*20:], modelViewerFloatToHalfBits(float32(vertex)))
+		binary.LittleEndian.PutUint16(base[vertex*20+6:], modelViewerFloatToHalfBits(1))
+		base[vertex*20+10] = 127
+		binary.LittleEndian.PutUint16(base[vertex*20+12:], modelViewerFloatToHalfBits(0.75))
+		binary.LittleEndian.PutUint16(base[vertex*20+16:], modelViewerFloatToHalfBits(0.25))
+		binary.LittleEndian.PutUint16(base[vertex*20+18:], modelViewerFloatToHalfBits(0.75))
+	}
+	for name, data := range map[string][]byte{
+		"mod.ini": []byte(ini), "anim.hlsl": []byte(packedDualQuaternionShader),
+		"base.buf": base, "blend.buf": make([]byte, 3*32), "pose.buf": make([]byte, 5160*56),
+		"head.ib": {0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0},
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestPackedDualQuaternionDetection(t *testing.T) {
+	for _, tc := range []struct {
+		name, from, to string
+		valid          bool
+	}{
+		{"legacy stride", "", "", true},
+		{"correct stride", "stride = 52", "stride = 56", true},
+		{"wrong stride", "stride = 52", "stride = 48", false},
+		{"invalid bones", "$bones = 1", "$bones = 1.5", false},
+		{"invalid end", "$end = 5159", "$end = 6000", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			ini := strings.Replace(packedDualQuaternionINI, tc.from, tc.to, 1)
+			writePackedDualQuaternionFixture(t, dir, ini)
+			sections := parseModINI(ini)
+			resources := resolveModelViewerEffectiveResources(sections, collectModelViewerResources(sections))
+			var diagnostics []string
+			deformer, clips := detectModelViewerComputeAnimation(dir, dir, "", sections, resources, []modelViewerDirectMesh{{id: "mesh", positionFile: "base.buf", geometry: &modelViewerGeometry{VertexCount: 3}}}, nil, func(message string) { diagnostics = append(diagnostics, message) })
+			if !tc.valid {
+				if deformer != nil || len(clips) != 0 {
+					t.Fatal("invalid animation accepted")
+				}
+				return
+			}
+			if deformer == nil || deformer.Kind != modelViewerPackedDualQuaternionKind || deformer.Pose.Frames.Stride != 56 || deformer.Pose.FrameCount != 5160 || deformer.VertexCount != 3 {
+				t.Fatalf("unexpected deformer: %+v", deformer)
+			}
+			if len(clips) != 1 || clips[0].FrameStart != 6 || clips[0].FrameEnd != 5157 || clips[0].FPS != 24 || len(clips[0].Frames) != 5152 || clips[0].Frames[5151].Index != 5157 {
+				t.Fatalf("unexpected clips: %d", len(clips))
+			}
+			if tc.name == "legacy stride" && (len(diagnostics) != 1 || !strings.Contains(diagnostics[0], "declaredStride=52")) {
+				t.Fatalf("diagnostics: %v", diagnostics)
+			}
+			for _, resource := range resources {
+				if modelViewerNormalizeKey(resource.Name) == "pose" && tc.name == "legacy stride" && resource.Stride != 52 {
+					t.Fatal("original resource was mutated")
+				}
+			}
+			packed := collectModelViewerPackedObjectResources(dir, dir, sections)
+			if packed["position"] != 16 || packed["position1"] != 16 {
+				t.Fatalf("alias layouts: %v", packed)
+			}
+			cache := newModelViewerBufferCache()
+			defer cache.releaseAll()
+			source := resolveModelViewerDrawVertexSource(dir, "mihoyo", modelViewerDirectBufferState{vb0: "Position", ib: "IB"}, modelViewerResourceMap(resources), resources, cache, packed)
+			buffers, _, err := loadModelViewerDrawVertexBuffers(dir, source, cache)
+			if err != nil || len(buffers.layout.Elements) < 3 || buffers.layout.Elements[2].AlignedByteOffset != 16 {
+				t.Fatalf("UV layout: %+v %v source=%+v resources=%+v", buffers.layout, err, source, resources)
+			}
+			geometry, err := extractModelViewerGeometry(buffers.combined, buffers.stride, buffers.layout, []uint32{0, 1, 2}, true, false, true, nil)
+			if err != nil || geometry == nil || len(geometry.Texcoord0) != 6 || geometry.Texcoord0[0] != 0.25 || geometry.Texcoord0[1] != 0.75 {
+				t.Fatalf("decoded UV: %+v error=%v", geometry, err)
+			}
+
+		})
+	}
+}
+
+func TestPackedDualQuaternionRejectsChangedShaderAndBuffers(t *testing.T) {
+	for _, replacement := range []string{"float4 x; float4 y; float4 z;", "float3 S; float3 T; float4 QR;"} {
+		if isKnownModelViewerPackedDualQuaternionShader(strings.ReplaceAll(packedDualQuaternionShader, "float3 S; float3 T; float4 QR; float4 QD;", replacement)) {
+			t.Fatal("wrong pose accepted")
+		}
+	}
+	for _, filename := range []string{"pose.buf", "blend.buf", "base.buf", "anim.hlsl"} {
+		t.Run(filename, func(t *testing.T) {
+			dir := t.TempDir()
+			writePackedDualQuaternionFixture(t, dir, packedDualQuaternionINI)
+			if err := os.WriteFile(filepath.Join(dir, filename), []byte{0}, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			sections := parseModINI(packedDualQuaternionINI)
+			resources := resolveModelViewerEffectiveResources(sections, collectModelViewerResources(sections))
+			deformer, _ := detectModelViewerComputeAnimation(dir, dir, "", sections, resources, []modelViewerDirectMesh{{id: "mesh", positionFile: "base.buf", geometry: &modelViewerGeometry{VertexCount: 3}}}, nil)
+			if deformer != nil {
+				t.Fatal("corrupt buffer or unknown shader accepted")
+			}
+		})
+	}
+}
+
+func TestPackedDualQuaternionUVStreamEvidence(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		offset, size, want int
+		corrupt            bool
+	}{
+		{"actual UV at 12", 12, 12, 12, false},
+		{"actual UV at 16", 16, 12, 16, false},
+		{"one mismatched vertex", 12, 12, 16, true},
+		{"truncated stream", 12, 8, 16, false},
+		{"missing stream", 12, 0, 16, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writePackedDualQuaternionFixture(t, dir, packedDualQuaternionINI)
+			base, err := os.ReadFile(filepath.Join(dir, "base.buf"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			uv := make([]byte, 12)
+			for vertex := range 3 {
+				copy(uv[vertex*4:], base[vertex*20+tc.offset:vertex*20+tc.offset+4])
+			}
+			if tc.corrupt {
+				uv[11] ^= 1
+			}
+			if tc.size > 0 {
+				if err := os.WriteFile(filepath.Join(dir, "baseTexcoord.buf"), uv[:tc.size], 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			sections := parseModINI(packedDualQuaternionINI)
+			resources := resolveModelViewerEffectiveResources(sections, collectModelViewerResources(sections))
+			cache := newModelViewerBufferCache()
+			defer cache.releaseAll()
+			source := resolveModelViewerDrawVertexSource(dir, "mihoyo", modelViewerDirectBufferState{vb0: "Position", ib: "IB"}, modelViewerResourceMap(resources), resources, cache, collectModelViewerPackedObjectResources(dir, dir, sections))
+			buffers, ok, err := loadModelViewerDrawVertexBuffers(dir, source, cache)
+			if err != nil || !ok {
+				t.Fatalf("load: %v", err)
+			}
+			if got := buffers.layout.Elements[2].AlignedByteOffset; got != tc.want {
+				t.Fatalf("UV offset=%d want=%d", got, tc.want)
+			}
+			geometry, err := extractModelViewerGeometry(buffers.combined, buffers.stride, buffers.layout, []uint32{2, 0, 1}, false, false, true, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for vertex, index := range geometry.SourceIndices {
+				for axis := range 2 {
+					want := modelViewerHalfToFloat(binary.LittleEndian.Uint16(base[int(index)*20+tc.want+axis*2:]))
+					if geometry.Texcoord0[vertex*2+axis] != want {
+						t.Fatal("UV source-index mapping changed")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestComputePoseClipLimits(t *testing.T) {
+	for _, tc := range []struct {
+		start, end string
+		count      int
+		valid      bool
+	}{
+		{"0", "65535", 65537, true}, {"0", "65536", 65538, false},
+		{"-1", "5", 10, false}, {"2", "1", 10, false}, {"0", "10", 10, false},
+		{"0.5", "5", 10, false},
+	} {
+		sections := parseModINI("[Constants]\nglobal $first=" + tc.start + "\nglobal $last=" + tc.end + "\n[CustomShaderPose]\n$freq=$freq+24*$dt\nif $freq > $last\n$freq=$first\nendif")
+		clips, explicit := detectModelViewerGIMIShapePoseClips(sections, sections[1], "$freq", collectModelViewerDefaultVariables(sections), nil, "test", tc.count)
+		if !explicit || (len(clips) == 1) != tc.valid {
+			t.Fatalf("range %s..%s: clips=%d explicit=%t", tc.start, tc.end, len(clips), explicit)
+		}
+	}
+}
+
+func TestComputePoseInvalidStatePreservesValidClips(t *testing.T) {
+	for _, tc := range []struct {
+		name                   string
+		firstStart, firstEnd   string
+		secondStart, secondEnd string
+		validState             string
+	}{
+		{"invalid last", "0", "2", "10", "12", "0"},
+		{"invalid first", "10", "12", "0", "2", "1"},
+		{"all invalid", "10", "12", "20", "22", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			ini := strings.Replace(packedDualQuaternionINI, "[Present]\n", "[Present]\nif $mode == 0\n$start = "+tc.firstStart+"\n$end = "+tc.firstEnd+"\nelse if $mode == 1\n$start = "+tc.secondStart+"\n$end = "+tc.secondEnd+"\nendif\n", 1)
+			ini = strings.Replace(ini, "$end-2", "$end", 1)
+			ini = strings.Replace(ini, "stride = 52", "stride = 56", 1)
+			writePackedDualQuaternionFixture(t, dir, ini)
+			if err := os.Truncate(filepath.Join(dir, "pose.buf"), 3*56); err != nil {
+				t.Fatal(err)
+			}
+			sections := parseModINI(ini)
+			resources := resolveModelViewerEffectiveResources(sections, collectModelViewerResources(sections))
+			var diagnostics []string
+			deformer, clips := detectModelViewerComputeAnimation(dir, dir, "", sections, resources, []modelViewerDirectMesh{{id: "mesh", positionFile: "base.buf", geometry: &modelViewerGeometry{VertexCount: 3}}}, nil, func(message string) {
+				diagnostics = append(diagnostics, message)
+			})
+			if tc.validState == "" {
+				if deformer != nil || len(clips) != 0 {
+					t.Fatal("all-invalid state ranges must not create a full-pose fallback")
+				}
+				return
+			}
+			if deformer == nil || len(clips) != 1 {
+				t.Fatalf("valid state %s was lost: deformer=%v clips=%d", tc.validState, deformer, len(clips))
+			}
+			clip := clips[0]
+			if !strings.HasSuffix(clip.ID, ":"+tc.validState) || clip.FrameStart != 0 || clip.FrameEnd != 2 || len(clip.Frames) != 3 || clip.FPS != 24 {
+				t.Fatalf("unexpected surviving clip: %+v", clip)
+			}
+			if len(clip.VariableIDs) != 1 || clip.VariableIDs[0] != "mode" || modelViewerString(clip.Frames[0].Values["mode"]) != tc.validState {
+				t.Fatalf("surviving clip lost its state binding: %+v", clip)
+			}
+			if len(diagnostics) != 1 || !strings.Contains(diagnostics[0], "variable=\"mode\"") || !strings.Contains(diagnostics[0], "frameStart=10 frameEnd=12 frameCount=3") || !strings.Contains(diagnostics[0], "pose.buf") || !strings.Contains(diagnostics[0], "anim.hlsl") {
+				t.Fatalf("missing invalid-state diagnostic: %v", diagnostics)
+			}
+		})
+	}
+}
+
+func TestComputePoseLiteralRangeAndFallback(t *testing.T) {
+	sections := parseModINI("[CustomShaderPose]\n$freq=$freq+24*$dt\nif $freq > 9\n$freq=2\nendif")
+	clips, explicit := detectModelViewerGIMIShapePoseClips(sections, sections[0], "$freq", nil, nil, "test", 11)
+	if !explicit || len(clips) != 1 || clips[0].FrameStart != 2 || clips[0].FrameEnd != 9 || clips[0].FPS != 24 {
+		t.Fatal("literal range was lost")
+	}
+	sections = parseModINI("[CustomShaderPose]\n$freq=$freq+24*$dt")
+	clips, explicit = detectModelViewerGIMIShapePoseClips(sections, sections[0], "$freq", nil, nil, "test", 11)
+	if explicit || len(clips) != 0 {
+		t.Fatal("missing range must allow full-pose fallback")
+	}
+	for _, stride := range []int{20, 24} {
+		if modelViewerPackedObjectLayout("", stride).Elements[2].AlignedByteOffset != 12 {
+			t.Fatal("legacy packed UV offset changed")
+		}
+	}
+}
+
+// Opt-in integration test; no local mod assets or machine-specific paths enter CI.
+func TestPackedDualQuaternionLocalMod(t *testing.T) {
+	dir := os.Getenv("MODEL_VIEWER_PACKED_DQ_MOD")
+	if dir == "" {
+		t.Skip("set MODEL_VIEWER_PACKED_DQ_MOD to the sample mod folder")
+	}
+	paths, err := filepath.Glob(filepath.Join(dir, "*.ini"))
+	if err != nil || len(paths) == 0 {
+		t.Fatalf("INI discovery: %v", err)
+	}
+	budget, err := newModelViewerLoadBudget(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := &Tools{}
+	prepared, err := service.prepareModelViewerGeometry(context.Background(), dir, paths, budget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prepared.cache.releaseAll()
+	if len(prepared.computeDeformers) != 1 || len(prepared.computeAnimations) != 1 {
+		t.Fatalf("deformers=%d animations=%d", len(prepared.computeDeformers), len(prepared.computeAnimations))
+	}
+	d, c := prepared.computeDeformers[0], prepared.computeAnimations[0]
+	if d.Kind != modelViewerPackedDualQuaternionKind || d.VertexCount != 23775 || d.Pose.BoneCount != 446 || d.Pose.FrameCount != 5160 || c.FrameStart != 6 || c.FrameEnd != 5157 || c.FPS != 24 {
+		t.Fatalf("unexpected local mod: %+v clip=%d..%d fps=%g", d, c.FrameStart, c.FrameEnd, c.FPS)
+	}
+	t.Logf("vertices=%d bones=%d poseFrames=%d clip=%d..%d fps=%g", d.VertexCount, d.Pose.BoneCount, d.Pose.FrameCount, c.FrameStart, c.FrameEnd, c.FPS)
+	uv, err := os.ReadFile(filepath.Join(dir, "NilouStandeeTexcoord.buf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	checked := 0
+	for _, work := range prepared.textures {
+		for _, mesh := range work.meshes {
+			geometry := mesh.geometry
+			if geometry == nil || len(geometry.Texcoord0) != geometry.VertexCount*2 {
+				t.Fatal("missing local mesh UVs")
+			}
+			for vertex := range geometry.VertexCount {
+				index := vertex
+				if len(geometry.SourceIndices) > 0 {
+					index = int(geometry.SourceIndices[vertex])
+				}
+				for axis := range 2 {
+					want := modelViewerHalfToFloat(binary.LittleEndian.Uint16(uv[index*4+axis*2:]))
+					if axis == 1 {
+						want = 1 - want // Mesh construction flips V for renderer textures.
+					}
+					if geometry.Texcoord0[vertex*2+axis] != want {
+						t.Fatalf("local UV mismatch at source vertex %d axis %d", index, axis)
+					}
+				}
+				checked++
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no local UVs checked")
+	}
+	t.Logf("verified UVs against original stream for %d mesh vertices", checked)
+}

--- a/internal/tools/model_viewer_scan.go
+++ b/internal/tools/model_viewer_scan.go
@@ -370,7 +370,7 @@ func buildModelViewerDirectScannedMeshesAt(iniPath, modDir string, sections []mo
 	conditionVariables := modelViewerDirectConditionVariables(sections, variables)
 	hashPositions, hashTexcoords := collectHashVertexBuffers(sections)
 	componentPositions, componentTexcoords := collectModelViewerComponentBuffers(sections, resourceMap)
-	var packedResources map[string]bool
+	var packedResources map[string]int
 	if layoutName != "wwmi" {
 		packedResources = collectModelViewerPackedObjectResources(modDir, filepath.Dir(iniPath), sections)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for packed dual-quaternion deformation in the model viewer.
  - Model viewer animations can now process dual-quaternion poses, including position, normal, tangent, UV, scaling, translation, and rotation data.
  - Added support for detecting and loading compatible dual-quaternion model resources and animation ranges.

- **Bug Fixes**
  - Preserved tangent attributes when dual-quaternion deformation does not provide tangent data.
  - Improved validation and recovery for invalid animation data and worker errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->