### PR TITLE
perf(platform): skip unchanged registry writes on startup

### DIFF
--- a/internal/platform/model_viewer_menu_windows.go
+++ b/internal/platform/model_viewer_menu_windows.go
@@ -55,6 +55,14 @@ func UpdateModelViewerContextMenu(language string) error {
 }
 
 func updateModelViewerMenu(hive registry.Key, path, language, executable string) (bool, error) {
+	label := modelViewerMenuLabel(language)
+	icon := ""
+	command := ""
+	if executable != "" {
+		executable = filepath.Clean(executable)
+		icon = fmt.Sprintf(`"%s",0`, executable)
+		command = fmt.Sprintf(`"%s" --model-viewer "%%1"`, executable)
+	}
 	key, err := registry.OpenKey(hive, path, registry.QUERY_VALUE|registry.SET_VALUE|registry.CREATE_SUB_KEY)
 	if errors.Is(err, registry.ErrNotExist) {
 		if executable == "" {
@@ -66,29 +74,53 @@ func updateModelViewerMenu(hive registry.Key, path, language, executable string)
 		return false, fmt.Errorf("open or create model viewer context menu key: %w", err)
 	}
 	defer func() { _ = key.Close() }()
-	if err := key.SetStringValue("", modelViewerMenuLabel(language)); err != nil {
+	if modelViewerMenuMatches(key, label, icon, command) {
+		return false, nil
+	}
+	if err := key.SetStringValue("", label); err != nil {
 		return false, fmt.Errorf("set model viewer context menu label: %w", err)
 	}
 	if executable == "" {
 		return true, nil
 	}
-	executable = filepath.Clean(executable)
-	if err := key.SetStringValue("Icon", fmt.Sprintf(`"%s",0`, executable)); err != nil {
+	if err := key.SetStringValue("Icon", icon); err != nil {
 		return false, fmt.Errorf("set model viewer context menu icon: %w", err)
 	}
 	if err := key.SetStringValue("MultiSelectModel", "Single"); err != nil {
 		return false, fmt.Errorf("set model viewer context menu selection mode: %w", err)
 	}
-	command, _, err := registry.CreateKey(key, "command", registry.SET_VALUE)
+	commandKey, _, err := registry.CreateKey(key, "command", registry.SET_VALUE)
 	if err != nil {
 		return false, fmt.Errorf("create model viewer context menu command key: %w", err)
 	}
-	if err := command.SetStringValue("", fmt.Sprintf(`"%s" --model-viewer "%%1"`, executable)); err != nil {
-		_ = command.Close()
+	if err := commandKey.SetStringValue("", command); err != nil {
+		_ = commandKey.Close()
 		return false, fmt.Errorf("set model viewer context menu command: %w", err)
 	}
-	if err := command.Close(); err != nil {
+	if err := commandKey.Close(); err != nil {
 		return false, fmt.Errorf("close model viewer context menu command key: %w", err)
 	}
 	return true, nil
+}
+
+// modelViewerMenuMatches reports whether the stored registration already
+// matches the values this version would write. Read failures and missing
+// values count as mismatches so registration is repaired conservatively.
+// icon is empty for portable runs, where only the label is managed.
+func modelViewerMenuMatches(key registry.Key, label, icon, command string) bool {
+	if !stringValueEquals(key, "", label) {
+		return false
+	}
+	if icon == "" {
+		return true
+	}
+	if !stringValueEquals(key, "Icon", icon) || !stringValueEquals(key, "MultiSelectModel", "Single") {
+		return false
+	}
+	commandKey, err := registry.OpenKey(key, "command", registry.QUERY_VALUE)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = commandKey.Close() }()
+	return stringValueEquals(commandKey, "", command)
 }

--- a/internal/platform/model_viewer_menu_windows_test.go
+++ b/internal/platform/model_viewer_menu_windows_test.go
@@ -100,6 +100,60 @@ func TestUpdateModelViewerMenuRewritesLabel(t *testing.T) {
 	}
 }
 
+func TestUpdateModelViewerMenuSkipsWhenLabelCurrent(t *testing.T) {
+	root := fmt.Sprintf(`Software\Classes\nahida-mv-test-%d`, time.Now().UnixNano())
+	path := root + `\shell\verb`
+	r, _, err := registry.CreateKey(registry.CURRENT_USER, path, registry.SET_VALUE|registry.CREATE_SUB_KEY)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if r != 0 {
+			_ = r.Close()
+		}
+		for _, suffix := range []string{`\shell\verb`, `\shell`, ``} {
+			_ = registry.DeleteKey(registry.CURRENT_USER, root+suffix)
+		}
+	})
+	if err := r.SetStringValue("", modelViewerMenuLabel("ko")); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	r = 0
+
+	updated, err := updateModelViewerMenu(registry.CURRENT_USER, path, "ko", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated {
+		t.Fatal("matching label must be skipped")
+	}
+}
+
+func TestUpdateModelViewerMenuSkipsWhenInstalledCurrent(t *testing.T) {
+	root := fmt.Sprintf(`Software\Classes\nahida-mv-test-%d`, time.Now().UnixNano())
+	path := root + `\shell\verb`
+	t.Cleanup(func() {
+		for _, suffix := range []string{`\shell\verb\command`, `\shell\verb`, `\shell`, ``} {
+			_ = registry.DeleteKey(registry.CURRENT_USER, root+suffix)
+		}
+	})
+	executable := filepath.Join(t.TempDir(), "Nahida Desktop.exe")
+	if _, err := updateModelViewerMenu(registry.CURRENT_USER, path, "ko", executable); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := updateModelViewerMenu(registry.CURRENT_USER, path, "ko", executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated {
+		t.Fatal("matching installed registration must be skipped")
+	}
+}
+
 func TestUpdateModelViewerMenuCreatesInstalledRegistration(t *testing.T) {
 	root := fmt.Sprintf(`Software\Classes\nahida-mv-test-%d`, time.Now().UnixNano())
 	path := root + `\shell\verb`

--- a/internal/platform/url_protocol_windows.go
+++ b/internal/platform/url_protocol_windows.go
@@ -10,44 +10,85 @@ import (
 )
 
 func RegisterNahidaURLProtocol(executable string) error {
-	return registerURLProtocol("nahida", "Nahida Desktop deep link", executable)
+	_, err := registerURLProtocol("nahida", "Nahida Desktop deep link", executable)
+	return err
 }
 
-func registerURLProtocol(scheme, description, executable string) error {
+func registerURLProtocol(scheme, description, executable string) (bool, error) {
 	executable = filepath.Clean(executable)
+	icon := fmt.Sprintf(`"%s",0`, executable)
+	command := fmt.Sprintf(`"%s" "%%1"`, executable)
+	if urlProtocolRegistered(scheme, description, icon, command) {
+		return false, nil
+	}
 	root, _, err := registry.CreateKey(
 		registry.CURRENT_USER,
 		`Software\Classes\`+scheme,
 		registry.SET_VALUE|registry.CREATE_SUB_KEY,
 	)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer func() { _ = root.Close() }()
 	if err := root.SetStringValue("", description); err != nil {
-		return err
+		return false, err
 	}
 	if err := root.SetStringValue("URL Protocol", ""); err != nil {
-		return err
+		return false, err
 	}
-	icon, _, err := registry.CreateKey(root, `DefaultIcon`, registry.SET_VALUE)
+	iconKey, _, err := registry.CreateKey(root, `DefaultIcon`, registry.SET_VALUE)
 	if err != nil {
-		return err
+		return false, err
 	}
-	if err := icon.SetStringValue("", fmt.Sprintf(`"%s",0`, executable)); err != nil {
-		_ = icon.Close()
-		return err
+	if err := iconKey.SetStringValue("", icon); err != nil {
+		_ = iconKey.Close()
+		return false, err
 	}
-	if err := icon.Close(); err != nil {
-		return err
+	if err := iconKey.Close(); err != nil {
+		return false, err
 	}
-	command, _, err := registry.CreateKey(root, `shell\open\command`, registry.SET_VALUE)
+	commandKey, _, err := registry.CreateKey(root, `shell\open\command`, registry.SET_VALUE)
 	if err != nil {
-		return err
+		return false, err
 	}
-	if err := command.SetStringValue("", fmt.Sprintf(`"%s" "%%1"`, executable)); err != nil {
-		_ = command.Close()
-		return err
+	if err := commandKey.SetStringValue("", command); err != nil {
+		_ = commandKey.Close()
+		return false, err
 	}
-	return command.Close()
+	return true, commandKey.Close()
+}
+
+// urlProtocolRegistered reports whether the stored registration already
+// matches the values this version would write. Read failures and missing
+// values count as mismatches so registration is repaired conservatively;
+// in particular the marker "URL Protocol" value must exist, not just be
+// empty.
+func urlProtocolRegistered(scheme, description, icon, command string) bool {
+	root, err := registry.OpenKey(registry.CURRENT_USER, `Software\Classes\`+scheme, registry.QUERY_VALUE)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = root.Close() }()
+	if !stringValueEquals(root, "", description) || !stringValueEquals(root, "URL Protocol", "") {
+		return false
+	}
+	iconKey, err := registry.OpenKey(root, `DefaultIcon`, registry.QUERY_VALUE)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = iconKey.Close() }()
+	if !stringValueEquals(iconKey, "", icon) {
+		return false
+	}
+	commandKey, err := registry.OpenKey(root, `shell\open\command`, registry.QUERY_VALUE)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = commandKey.Close() }()
+	return stringValueEquals(commandKey, "", command)
+}
+
+func stringValueEquals(key registry.Key, name, want string) bool {
+	got, _, err := key.GetStringValue(name)
+	return err == nil && got == want
 }

--- a/internal/platform/url_protocol_windows_test.go
+++ b/internal/platform/url_protocol_windows_test.go
@@ -20,8 +20,12 @@ func TestRegisterURLProtocolWritesPerUserCommand(t *testing.T) {
 		}
 	})
 	executable := filepath.Join(t.TempDir(), "Nahida Desktop.exe")
-	if err := registerURLProtocol(scheme, "Nahida test protocol", executable); err != nil {
+	updated, err := registerURLProtocol(scheme, "Nahida test protocol", executable)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if !updated {
+		t.Fatal("fresh registration must be written")
 	}
 
 	root, err := registry.OpenKey(registry.CURRENT_USER, keyPath, registry.QUERY_VALUE)
@@ -38,6 +42,72 @@ func TestRegisterURLProtocolWritesPerUserCommand(t *testing.T) {
 		t.Fatalf("URL Protocol = %q, error = %v", protocol, err)
 	}
 
+	commandKey, err := registry.OpenKey(registry.CURRENT_USER, keyPath+`\shell\open\command`, registry.QUERY_VALUE)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = commandKey.Close() }()
+	command, _, err := commandKey.GetStringValue("")
+	wantCommand := fmt.Sprintf(`"%s" "%%1"`, filepath.Clean(executable))
+	if err != nil || command != wantCommand {
+		t.Fatalf("command = %q, want %q, error = %v", command, wantCommand, err)
+	}
+}
+
+func TestRegisterURLProtocolSkipsWhenCurrent(t *testing.T) {
+	scheme := fmt.Sprintf("nahida-test-%d", time.Now().UnixNano())
+	keyPath := `Software\Classes\` + scheme
+	t.Cleanup(func() {
+		for _, suffix := range []string{`\shell\open\command`, `\shell\open`, `\shell`, `\DefaultIcon`, ``} {
+			_ = registry.DeleteKey(registry.CURRENT_USER, keyPath+suffix)
+		}
+	})
+	executable := filepath.Join(t.TempDir(), "Nahida Desktop.exe")
+	if _, err := registerURLProtocol(scheme, "Nahida test protocol", executable); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := registerURLProtocol(scheme, "Nahida test protocol", executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated {
+		t.Fatal("matching registration must be skipped")
+	}
+}
+
+func TestRegisterURLProtocolRepairsStaleCommand(t *testing.T) {
+	scheme := fmt.Sprintf("nahida-test-%d", time.Now().UnixNano())
+	keyPath := `Software\Classes\` + scheme
+	t.Cleanup(func() {
+		for _, suffix := range []string{`\shell\open\command`, `\shell\open`, `\shell`, `\DefaultIcon`, ``} {
+			_ = registry.DeleteKey(registry.CURRENT_USER, keyPath+suffix)
+		}
+	})
+	commandRoot, _, err := registry.CreateKey(
+		registry.CURRENT_USER,
+		keyPath+`\shell\open\command`,
+		registry.SET_VALUE|registry.CREATE_SUB_KEY,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := commandRoot.SetStringValue("", `"C:\stale\Nahida.exe" "%1"`); err != nil {
+		_ = commandRoot.Close()
+		t.Fatal(err)
+	}
+	if err := commandRoot.Close(); err != nil {
+		t.Fatal(err)
+	}
+	executable := filepath.Join(t.TempDir(), "Nahida Desktop.exe")
+
+	updated, err := registerURLProtocol(scheme, "Nahida test protocol", executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated {
+		t.Fatal("stale registration must be repaired")
+	}
 	commandKey, err := registry.OpenKey(registry.CURRENT_USER, keyPath+`\shell\open\command`, registry.QUERY_VALUE)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows model viewer integration by repairing missing or outdated context-menu registrations.
  - Improved URL protocol registration to restore incorrect or incomplete entries, including commands pointing to an outdated application path.
  - Avoided unnecessary system registration updates when existing model viewer and URL protocol settings are already current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->