### PR TITLE
feat(http): honor Retry-After and unify unreachable classification

### DIFF
--- a/internal/gamebanana/login.go
+++ b/internal/gamebanana/login.go
@@ -251,7 +251,7 @@ func classifyLoginError(err error) error {
 	if errors.As(err, &httpErr) && (httpErr.Status >= 500 || httpErr.Status == 429) {
 		return ErrServerUnreachable
 	}
-	if isUnreachable(err) {
+	if infra.IsUnreachable(err) {
 		return ErrServerUnreachable
 	}
 	return ErrAuthFailed
@@ -262,17 +262,4 @@ func errorCode(err error) string {
 		return ""
 	}
 	return strings.TrimSpace(err.Error())
-}
-
-func isUnreachable(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "connection refused") ||
-		strings.Contains(msg, "no such host") ||
-		strings.Contains(msg, "network is unreachable") ||
-		strings.Contains(msg, "i/o timeout") ||
-		strings.Contains(msg, "timeout") ||
-		strings.Contains(msg, "temporarily unavailable")
 }

--- a/internal/gamebanana/login_test.go
+++ b/internal/gamebanana/login_test.go
@@ -630,6 +630,17 @@ func TestClassifyLoginErrorTransportFailures(t *testing.T) {
 			},
 			ErrServerUnreachable,
 		},
+		{
+			"plain dial refused",
+			errors.New("dial tcp 127.0.0.1:443: connect: connection refused"),
+			ErrServerUnreachable,
+		},
+		{
+			"plain dns miss",
+			errors.New("dial tcp: lookup gamebanana.com: no such host"),
+			ErrServerUnreachable,
+		},
+		{"plain timeout", errors.New("read tcp 10.0.0.1:443: i/o timeout"), ErrServerUnreachable},
 		{"deadline", context.DeadlineExceeded, ErrServerUnreachable},
 		{
 			"malformed response",

--- a/internal/gamebanana/login_test.go
+++ b/internal/gamebanana/login_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -599,6 +601,56 @@ func TestConcurrentEnsureSessionOpensOnce(t *testing.T) {
 	}
 	if opens.Load() != 1 {
 		t.Fatalf("opens = %d", opens.Load())
+	}
+}
+
+func TestClassifyLoginErrorTransportFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{
+			"dial refused",
+			&url.Error{
+				Op:  "Get",
+				URL: "https://gamebanana.com/api",
+				Err: &net.OpError{Op: "dial", Err: errors.New("connection refused")},
+			},
+			ErrServerUnreachable,
+		},
+		{
+			"dns miss",
+			&url.Error{
+				Op:  "Get",
+				URL: "https://gamebanana.com/api",
+				Err: &net.DNSError{Err: "no such host", Name: "gamebanana.com"},
+			},
+			ErrServerUnreachable,
+		},
+		{"deadline", context.DeadlineExceeded, ErrServerUnreachable},
+		{
+			"malformed response",
+			&url.Error{Op: "Get", URL: "https://gamebanana.com/api", Err: errors.New("malformed HTTP response")},
+			ErrServerUnreachable,
+		},
+		{
+			"redirect loop",
+			&url.Error{Op: "Get", URL: "https://gamebanana.com/api", Err: errors.New("stopped after 10 redirects")},
+			ErrAuthFailed,
+		},
+		{"http status", &gameBananaHTTPError{Status: http.StatusBadGateway}, ErrServerUnreachable},
+		{"rate limited", &gameBananaHTTPError{Status: http.StatusTooManyRequests}, ErrServerUnreachable},
+		{"auth failure", errors.New("invalid rmc cookie"), ErrAuthFailed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClassifyLoginError(tt.err); !errors.Is(got, tt.want) {
+				t.Fatalf("classify(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/infra/http.go
+++ b/internal/infra/http.go
@@ -820,7 +820,8 @@ func retryAfterWait(raw string) (time.Duration, bool) {
 	if raw == "" {
 		return 0, false
 	}
-	if secs, err := strconv.Atoi(raw); err == nil {
+	secs, err := strconv.Atoi(raw)
+	if err == nil || errors.Is(err, strconv.ErrRange) {
 		if secs < 0 {
 			return 0, false
 		}
@@ -843,7 +844,8 @@ func retryAfterWait(raw string) (time.Duration, bool) {
 // IsUnreachable reports transport-level unreachability. Application failures
 // such as TLS certificate validation and redirect policy failures are excluded
 // first; *url.Error implements net.Error, so that check must not run before
-// the exclusion.
+// the exclusion. Opaque errors from embedded browsers or platform transports
+// fall back to matching known transport message fragments.
 func IsUnreachable(err error) bool {
 	if err == nil || errors.Is(err, context.Canceled) || isNonReachabilityURLCause(err) || isRedirectPolicyError(err) {
 		return false
@@ -856,7 +858,30 @@ func IsUnreachable(err error) bool {
 		return true
 	}
 	var netErr net.Error
-	return errors.As(err, &netErr)
+	if errors.As(err, &netErr) {
+		return true
+	}
+	return hasUnreachableMessage(err)
+}
+
+func hasUnreachableMessage(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	for _, fragment := range []string{
+		"connection refused",
+		"no such host",
+		"network is unreachable",
+		"i/o timeout",
+		"timeout",
+		"temporarily unavailable",
+	} {
+		if strings.Contains(message, fragment) {
+			return true
+		}
+	}
+	return false
 }
 
 func isNonReachabilityURLCause(err error) bool {

--- a/internal/infra/http.go
+++ b/internal/infra/http.go
@@ -384,12 +384,14 @@ func (c *Client) Fetch(
 
 	var resp *http.Response
 	var retryAfter time.Duration
+	var hasRetryAfter bool
 	for attempt := range attempts {
 		if attempt > 0 {
 			wait := c.retryWait
-			if retryAfter > 0 {
+			if hasRetryAfter {
 				wait = retryAfter
 				retryAfter = 0
+				hasRetryAfter = false
 			}
 			if wait > 0 {
 				timer := time.NewTimer(wait)
@@ -425,7 +427,7 @@ func (c *Client) Fetch(
 			return nil, err
 		}
 		if attempt+1 < attempts && isRetryStatus(resp.StatusCode) {
-			retryAfter = retryAfterWait(resp.Header.Get("Retry-After"))
+			retryAfter, hasRetryAfter = retryAfterWait(resp.Header.Get("Retry-After"))
 			drainClose(resp.Body)
 			continue
 		}
@@ -810,31 +812,32 @@ func canRetryMethod(method string) bool {
 }
 
 // retryAfterWait parses a Retry-After value (delay seconds or an HTTP-date)
-// into a wait hint capped at maxRetryAfterWait. Unparseable or past values
-// return zero so the caller's default retry wait applies.
-func retryAfterWait(raw string) time.Duration {
+// into a wait hint capped at maxRetryAfterWait. The boolean reports whether
+// the value was valid; this keeps an explicit zero-second delay distinct from
+// an absent, unparseable, or past value.
+func retryAfterWait(raw string) (time.Duration, bool) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		return 0
+		return 0, false
 	}
 	if secs, err := strconv.Atoi(raw); err == nil {
-		if secs <= 0 {
-			return 0
+		if secs < 0 {
+			return 0, false
 		}
 		if secs >= int(maxRetryAfterWait/time.Second) {
-			return maxRetryAfterWait
+			return maxRetryAfterWait, true
 		}
-		return time.Duration(secs) * time.Second
+		return time.Duration(secs) * time.Second, true
 	}
 	when, err := http.ParseTime(raw)
 	if err != nil {
-		return 0
+		return 0, false
 	}
 	delay := time.Until(when)
 	if delay <= 0 {
-		return 0
+		return 0, false
 	}
-	return min(delay, maxRetryAfterWait)
+	return min(delay, maxRetryAfterWait), true
 }
 
 // IsUnreachable reports transport-level unreachability. Application failures

--- a/internal/infra/http.go
+++ b/internal/infra/http.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -25,6 +26,7 @@ const (
 	defaultHTTPTimeout = 100 * time.Second
 	defaultRetryLimit  = 2
 	defaultRetryWait   = 300 * time.Millisecond
+	maxRetryAfterWait  = 10 * time.Second
 	probeTimeout       = 5 * time.Second
 
 	sessionPath = "/api/auth/get-session"
@@ -381,14 +383,22 @@ func (c *Client) Fetch(
 	}
 
 	var resp *http.Response
+	var retryAfter time.Duration
 	for attempt := range attempts {
-		if attempt > 0 && c.retryWait > 0 {
-			timer := time.NewTimer(c.retryWait)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return nil, ctx.Err()
-			case <-timer.C:
+		if attempt > 0 {
+			wait := c.retryWait
+			if retryAfter > 0 {
+				wait = retryAfter
+				retryAfter = 0
+			}
+			if wait > 0 {
+				timer := time.NewTimer(wait)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return nil, ctx.Err()
+				case <-timer.C:
+				}
 			}
 		}
 		var body io.Reader
@@ -406,15 +416,16 @@ func (c *Client) Fetch(
 		resp, err = c.http.Do(req)
 		diagnosticResponse = resp
 		if err != nil {
-			if attempt+1 < attempts && isUnreachable(err) {
+			if attempt+1 < attempts && IsUnreachable(err) {
 				continue
 			}
-			if nhd && isUnreachable(err) {
+			if nhd && IsUnreachable(err) {
 				c.triggerProbe()
 			}
 			return nil, err
 		}
 		if attempt+1 < attempts && isRetryStatus(resp.StatusCode) {
+			retryAfter = retryAfterWait(resp.Header.Get("Retry-After"))
 			drainClose(resp.Body)
 			continue
 		}
@@ -447,7 +458,7 @@ func (c *Client) Fetch(
 			resp, requestErr = c.http.Do(request)
 			diagnosticResponse = resp
 			if requestErr != nil {
-				if isUnreachable(requestErr) {
+				if IsUnreachable(requestErr) {
 					c.triggerProbe()
 				}
 				return nil, requestErr
@@ -508,7 +519,7 @@ func (c *Client) Stream(
 	}
 	response, err := c.http.Do(request)
 	if err != nil {
-		if nhd && isUnreachable(err) {
+		if nhd && IsUnreachable(err) {
 			c.triggerProbe()
 		}
 		return nil, err
@@ -798,11 +809,39 @@ func canRetryMethod(method string) bool {
 	}
 }
 
-// isUnreachable reports transport-level unreachability. Application failures
+// retryAfterWait parses a Retry-After value (delay seconds or an HTTP-date)
+// into a wait hint capped at maxRetryAfterWait. Unparseable or past values
+// return zero so the caller's default retry wait applies.
+func retryAfterWait(raw string) time.Duration {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(raw); err == nil {
+		if secs <= 0 {
+			return 0
+		}
+		if secs >= int(maxRetryAfterWait/time.Second) {
+			return maxRetryAfterWait
+		}
+		return time.Duration(secs) * time.Second
+	}
+	when, err := http.ParseTime(raw)
+	if err != nil {
+		return 0
+	}
+	delay := time.Until(when)
+	if delay <= 0 {
+		return 0
+	}
+	return min(delay, maxRetryAfterWait)
+}
+
+// IsUnreachable reports transport-level unreachability. Application failures
 // such as TLS certificate validation and redirect policy failures are excluded
 // first; *url.Error implements net.Error, so that check must not run before
 // the exclusion.
-func isUnreachable(err error) bool {
+func IsUnreachable(err error) bool {
 	if err == nil || errors.Is(err, context.Canceled) || isNonReachabilityURLCause(err) || isRedirectPolicyError(err) {
 		return false
 	}

--- a/internal/infra/http_diagnostic.go
+++ b/internal/infra/http_diagnostic.go
@@ -6,7 +6,7 @@ func (c *Client) reportProbe(err error, endpoint, stage string, response *http.R
 	diagnostic := HTTPDiagnostic(http.MethodGet, endpoint, stage, response)
 	diagnostic.Operation, diagnostic.Severity = "probe", DiagnosticWarn
 	// Transport failures are the probe's offline signal, not a user-facing defect.
-	if stage == "request" && isUnreachable(err) {
+	if stage == "request" && IsUnreachable(err) {
 		diagnostic.Severity = DiagnosticDebug
 	}
 	c.probeDiagnostic.Report(c.log, err, "HTTP", diagnostic)

--- a/internal/infra/http_test.go
+++ b/internal/infra/http_test.go
@@ -1135,7 +1135,6 @@ func TestFetchRetryLimitOverrideMakesOneShotRequest(t *testing.T) {
 func TestRetryAfterWait(t *testing.T) {
 	t.Parallel()
 
-	future := time.Now().Add(2 * time.Second).UTC().Format(http.TimeFormat)
 	farFuture := time.Now().Add(time.Hour).UTC().Format(http.TimeFormat)
 	tests := []struct {
 		name string
@@ -1150,7 +1149,7 @@ func TestRetryAfterWait(t *testing.T) {
 		{"garbage", "later", 0, 0, false},
 		{"seconds", "2", 2 * time.Second, 2 * time.Second, true},
 		{"seconds capped", "3600", maxRetryAfterWait, maxRetryAfterWait, true},
-		{"http-date", future, time.Second, maxRetryAfterWait, true},
+		{"seconds overflow", "99999999999999999999", maxRetryAfterWait, maxRetryAfterWait, true},
 		{"http-date capped", farFuture, maxRetryAfterWait, maxRetryAfterWait, true},
 		{"past http-date", "Mon, 02 Jan 2006 15:04:05 GMT", 0, 0, false},
 	}
@@ -1162,6 +1161,31 @@ func TestRetryAfterWait(t *testing.T) {
 			}
 			if ok != tt.ok {
 				t.Fatalf("retryAfterWait(%q) valid = %v, want %v", tt.raw, ok, tt.ok)
+			}
+		})
+	}
+}
+
+func TestIsUnreachableOpaqueTransportMessages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"connection refused", errors.New("dial tcp 127.0.0.1:443: connect: connection refused"), true},
+		{"no such host", errors.New("dial tcp: lookup gamebanana.com: no such host"), true},
+		{"timeout", errors.New("read tcp 10.0.0.1:443: i/o timeout"), true},
+		{"network unreachable", errors.New("connect: network is unreachable"), true},
+		{"temporarily unavailable", errors.New("connect: resource temporarily unavailable"), true},
+		{"canceled", context.Canceled, false},
+		{"application failure", errors.New("invalid rmc cookie"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsUnreachable(tt.err); got != tt.want {
+				t.Fatalf("IsUnreachable(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
 	}

--- a/internal/infra/http_test.go
+++ b/internal/infra/http_test.go
@@ -1132,6 +1132,101 @@ func TestFetchRetryLimitOverrideMakesOneShotRequest(t *testing.T) {
 	waitClosed(t, probed)
 }
 
+func TestRetryAfterWait(t *testing.T) {
+	t.Parallel()
+
+	future := time.Now().Add(2 * time.Second).UTC().Format(http.TimeFormat)
+	farFuture := time.Now().Add(time.Hour).UTC().Format(http.TimeFormat)
+	tests := []struct {
+		name string
+		raw  string
+		min  time.Duration
+		max  time.Duration
+	}{
+		{"empty", "", 0, 0},
+		{"zero", "0", 0, 0},
+		{"negative", "-3", 0, 0},
+		{"garbage", "later", 0, 0},
+		{"seconds", "2", 2 * time.Second, 2 * time.Second},
+		{"seconds capped", "3600", maxRetryAfterWait, maxRetryAfterWait},
+		{"http-date", future, time.Second, maxRetryAfterWait},
+		{"http-date capped", farFuture, maxRetryAfterWait, maxRetryAfterWait},
+		{"past http-date", "Mon, 02 Jan 2006 15:04:05 GMT", 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := retryAfterWait(tt.raw)
+			if got < tt.min || got > tt.max {
+				t.Fatalf("retryAfterWait(%q) = %s, want [%s, %s]", tt.raw, got, tt.min, tt.max)
+			}
+		})
+	}
+}
+
+func TestFetchHonorsRetryAfterHeader(t *testing.T) {
+	t.Parallel()
+
+	var n atomic.Int32
+	limit := 1
+	wait := 5 * time.Second
+	c := testClient(t, ClientOptions{
+		RetryLimit: &limit,
+		RetryWait:  &wait,
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if n.Add(1) == 1 {
+				resp := textResp(r, http.StatusTooManyRequests, "slow down")
+				resp.Header.Set("Retry-After", "1")
+				return resp, nil
+			}
+			return textResp(r, 200, "ok"), nil
+		}),
+	})
+
+	start := time.Now()
+	resp, err := c.Fetch(context.Background(), "https://api.nahida.live/api/drive", FetchOptions{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	closeBody(t, resp)
+	if n.Load() != 2 {
+		t.Fatalf("attempts = %d", n.Load())
+	}
+	if elapsed := time.Since(start); elapsed < 900*time.Millisecond || elapsed >= 5*time.Second {
+		t.Fatalf("elapsed = %s, want the ~1s Retry-After wait instead of the 5s default", elapsed)
+	}
+}
+
+func TestFetchRetriesWithDefaultWaitWithoutRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	var n atomic.Int32
+	limit := 1
+	wait := 200 * time.Millisecond
+	c := testClient(t, ClientOptions{
+		RetryLimit: &limit,
+		RetryWait:  &wait,
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if n.Add(1) == 1 {
+				return textResp(r, http.StatusTooManyRequests, "slow down"), nil
+			}
+			return textResp(r, 200, "ok"), nil
+		}),
+	})
+
+	start := time.Now()
+	resp, err := c.Fetch(context.Background(), "https://api.nahida.live/api/drive", FetchOptions{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	closeBody(t, resp)
+	if n.Load() != 2 {
+		t.Fatalf("attempts = %d", n.Load())
+	}
+	if elapsed := time.Since(start); elapsed < 200*time.Millisecond {
+		t.Fatalf("elapsed = %s, want the default retry wait", elapsed)
+	}
+}
+
 func TestProbeSetsMaintenanceFromBody(t *testing.T) {
 	t.Parallel()
 

--- a/internal/infra/http_test.go
+++ b/internal/infra/http_test.go
@@ -1142,22 +1142,26 @@ func TestRetryAfterWait(t *testing.T) {
 		raw  string
 		min  time.Duration
 		max  time.Duration
+		ok   bool
 	}{
-		{"empty", "", 0, 0},
-		{"zero", "0", 0, 0},
-		{"negative", "-3", 0, 0},
-		{"garbage", "later", 0, 0},
-		{"seconds", "2", 2 * time.Second, 2 * time.Second},
-		{"seconds capped", "3600", maxRetryAfterWait, maxRetryAfterWait},
-		{"http-date", future, time.Second, maxRetryAfterWait},
-		{"http-date capped", farFuture, maxRetryAfterWait, maxRetryAfterWait},
-		{"past http-date", "Mon, 02 Jan 2006 15:04:05 GMT", 0, 0},
+		{"empty", "", 0, 0, false},
+		{"zero", "0", 0, 0, true},
+		{"negative", "-3", 0, 0, false},
+		{"garbage", "later", 0, 0, false},
+		{"seconds", "2", 2 * time.Second, 2 * time.Second, true},
+		{"seconds capped", "3600", maxRetryAfterWait, maxRetryAfterWait, true},
+		{"http-date", future, time.Second, maxRetryAfterWait, true},
+		{"http-date capped", farFuture, maxRetryAfterWait, maxRetryAfterWait, true},
+		{"past http-date", "Mon, 02 Jan 2006 15:04:05 GMT", 0, 0, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := retryAfterWait(tt.raw)
+			got, ok := retryAfterWait(tt.raw)
 			if got < tt.min || got > tt.max {
 				t.Fatalf("retryAfterWait(%q) = %s, want [%s, %s]", tt.raw, got, tt.min, tt.max)
+			}
+			if ok != tt.ok {
+				t.Fatalf("retryAfterWait(%q) valid = %v, want %v", tt.raw, ok, tt.ok)
 			}
 		})
 	}
@@ -1224,6 +1228,37 @@ func TestFetchRetriesWithDefaultWaitWithoutRetryAfter(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed < 200*time.Millisecond {
 		t.Fatalf("elapsed = %s, want the default retry wait", elapsed)
+	}
+}
+
+func TestFetchHonorsZeroRetryAfterHeader(t *testing.T) {
+	t.Parallel()
+
+	var n atomic.Int32
+	limit := 1
+	wait := 2 * time.Second
+	c := testClient(t, ClientOptions{
+		RetryLimit: &limit,
+		RetryWait:  &wait,
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if n.Add(1) == 1 {
+				resp := textResp(r, http.StatusTooManyRequests, "slow down")
+				resp.Header.Set("Retry-After", "0")
+				return resp, nil
+			}
+			return textResp(r, http.StatusOK, "ok"), nil
+		}),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	resp, err := c.Fetch(ctx, "https://api.nahida.live/api/drive", FetchOptions{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	closeBody(t, resp)
+	if n.Load() != 2 {
+		t.Fatalf("attempts = %d", n.Load())
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of temporary network and server failures during login.
  - Login errors now more accurately distinguish unreachable services from authentication failures.
  - Retry attempts now respect server-provided `Retry-After` guidance, including zero-delay retries and bounded wait times.
  - Improved handling of retry timing information provided in seconds or HTTP-date formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->