### PR TITLE
fix(window): configure resize trigger borders

### DIFF
--- a/frontend/patches/@wailsio__runtime@3.0.0-beta.17.patch
+++ b/frontend/patches/@wailsio__runtime@3.0.0-beta.17.patch
@@ -1,0 +1,44 @@
+diff --git a/dist/drag.js b/dist/drag.js
+index b15d87a08cfc19cbb5f7082cf60299c368127030..3eebd6ee812799ad5a5b6c8bb9149ca4812eb298 100644
+--- a/dist/drag.js
++++ b/dist/drag.js
+@@ -242,25 +242,30 @@ function onMouseMove(event) {
+         }
+         return;
+     }
++    const configuredBorder = GetFlag("resizeBorderInside");
+     const resizeHandleHeight = GetFlag("system.resizeHandleHeight") || 5;
+     const resizeHandleWidth = GetFlag("system.resizeHandleWidth") || 5;
++    const leftWidth = configuredBorder?.left ?? resizeHandleWidth;
++    const rightWidth = configuredBorder?.right ?? resizeHandleWidth;
++    const topHeight = configuredBorder?.top ?? resizeHandleHeight;
++    const bottomHeight = configuredBorder?.bottom ?? resizeHandleHeight;
+     // Extra pixels for the corner areas.
+-    const cornerExtra = GetFlag("resizeCornerExtra") || 10;
++    const cornerExtra = configuredBorder ? 0 : GetFlag("resizeCornerExtra") || 10;
+     // When a scrollbar is present at the window edge it consumes mouse events in that strip.
+     // Shift the effective content edge inward so the resize zone sits just before the scrollbar.
+     const scrollbarWidth = Math.max(0, window.innerWidth - document.documentElement.clientWidth);
+     const scrollbarHeight = Math.max(0, window.innerHeight - document.documentElement.clientHeight);
+     const rightContentEdge = window.innerWidth - scrollbarWidth;
+     const bottomContentEdge = window.innerHeight - scrollbarHeight;
+-    const rightBorder = event.clientX < rightContentEdge && (rightContentEdge - event.clientX) < resizeHandleWidth;
+-    const leftBorder = event.clientX < resizeHandleWidth;
+-    const topBorder = event.clientY < resizeHandleHeight;
+-    const bottomBorder = event.clientY < bottomContentEdge && (bottomContentEdge - event.clientY) < resizeHandleHeight;
++    const rightBorder = event.clientX < rightContentEdge && (rightContentEdge - event.clientX) < rightWidth;
++    const leftBorder = event.clientX < leftWidth;
++    const topBorder = event.clientY < topHeight;
++    const bottomBorder = event.clientY < bottomContentEdge && (bottomContentEdge - event.clientY) < bottomHeight;
+     // Adjust for corner areas.
+-    const rightCorner = event.clientX < rightContentEdge && (rightContentEdge - event.clientX) < (resizeHandleWidth + cornerExtra);
+-    const leftCorner = event.clientX < (resizeHandleWidth + cornerExtra);
+-    const topCorner = event.clientY < (resizeHandleHeight + cornerExtra);
+-    const bottomCorner = event.clientY < bottomContentEdge && (bottomContentEdge - event.clientY) < (resizeHandleHeight + cornerExtra);
++    const rightCorner = event.clientX < rightContentEdge && (rightContentEdge - event.clientX) < (rightWidth + cornerExtra);
++    const leftCorner = event.clientX < (leftWidth + cornerExtra);
++    const topCorner = event.clientY < (topHeight + cornerExtra);
++    const bottomCorner = event.clientY < bottomContentEdge && (bottomContentEdge - event.clientY) < (bottomHeight + cornerExtra);
+     if (!leftCorner && !topCorner && !bottomCorner && !rightCorner) {
+         // Optimisation: out of all corner areas implies out of borders.
+         setResize();

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@wailsio/runtime@3.0.0-beta.17': b2f4f4cd14c2d748c07f69ab3f8c2196dc6c3da182d7c2b2819f7cf446b412ba
+
 importers:
 
   .:
@@ -37,7 +40,7 @@ importers:
         version: 3.14.11(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@wailsio/runtime':
         specifier: 3.0.0-beta.17
-        version: 3.0.0-beta.17
+        version: 3.0.0-beta.17(patch_hash=b2f4f4cd14c2d748c07f69ab3f8c2196dc6c3da182d7c2b2819f7cf446b412ba)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3127,7 +3130,7 @@ snapshots:
 
   '@vitest/spy@5.0.0': {}
 
-  '@wailsio/runtime@3.0.0-beta.17': {}
+  '@wailsio/runtime@3.0.0-beta.17(patch_hash=b2f4f4cd14c2d748c07f69ab3f8c2196dc6c3da182d7c2b2819f7cf446b412ba)': {}
 
   ansi-regex@5.0.1: {}
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 minimumReleaseAgeExclude:
   - "@wailsio/runtime@3.0.0-beta.14 || 3.0.0-beta.15 || 3.0.0-beta.16 || 3.0.0-beta.17"
+# Mirrors resize-border support from the pinned Wails fork until the npm runtime includes it.
+patchedDependencies:
+  "@wailsio/runtime@3.0.0-beta.17": patches/@wailsio__runtime@3.0.0-beta.17.patch

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	modernc.org/sqlite v1.57.0
 )
 
-replace github.com/wailsapp/wails/v3 => github.com/myparsleycat/wails/v3 v3.0.0-beta.17-nahida.2
+replace github.com/wailsapp/wails/v3 => github.com/myparsleycat/wails/v3 v3.0.0-beta.17-nahida.4
 
 require (
 	al.essio.dev/pkg/shellescape v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -386,8 +386,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/myparsleycat/ddsutil v0.2.0 h1:3zihxGGwlXwb/3mZkQ6QDQWAzl+O3mmbkncMAoImCyk=
 github.com/myparsleycat/ddsutil v0.2.0/go.mod h1:InioKuc7NG5WrBaWQ6LoqH0UsSyD4rIrDiSIqV+LsuQ=
-github.com/myparsleycat/wails/v3 v3.0.0-beta.17-nahida.2 h1:nVwsaB20SOhbGyFbPVaDVhrhPJFVGltTv1y3+eopRRo=
-github.com/myparsleycat/wails/v3 v3.0.0-beta.17-nahida.2/go.mod h1:zKZYhB3WjrN5LhJWbnOAVMN0Xf8qTozbw2nf5micKl4=
+github.com/myparsleycat/wails/v3 v3.0.0-beta.17-nahida.4 h1:GVxXPdbWnm1srZfSKtt/xfBlw381f9Ur+EV9ncwtqs0=
+github.com/myparsleycat/wails/v3 v3.0.0-beta.17-nahida.4/go.mod h1:zKZYhB3WjrN5LhJWbnOAVMN0Xf8qTozbw2nf5micKl4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=

--- a/internal/app/windowsvc.go
+++ b/internal/app/windowsvc.go
@@ -129,6 +129,16 @@ func (w *Window) Create() application.Window {
 			DisableMenu:                true,
 			NonClientRegionSupport:     true,
 			WebView2CompositionHosting: true,
+			ResizeBorder: &application.WindowsWindowResizeBorder{
+				Inside: application.LRTB{
+					Top: 8,
+				},
+				Outside: application.LRTB{
+					Left:   8,
+					Right:  8,
+					Bottom: 8,
+				},
+			},
 		},
 	}
 	if route != "" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added edge and corner resizing support for frameless Windows windows.
  - Configured resize borders independently on each side, including inside and outside border areas.

- **Bug Fixes**
  - Improved detection of resize areas by applying side-specific border widths.
  - Adjusted corner resize behavior when custom border settings are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->