### PR TITLE
feat(model-viewer): support inline object shape animation

### DIFF
--- a/frontend/src/components/tools/model-viewer/model-viewer-compute-kernel.test.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-compute-kernel.test.ts
@@ -195,6 +195,38 @@ describe("GIMI shape/pose compute kernel", () => {
         expect([...atStart.positions]).toEqual([...atLoop.positions]);
     });
 
+    it("applies the accumulator reset when no wrap range exists", () => {
+        const deformer: ViewerComputeDeformer = {
+            kind: "gimi_shape_pose_v1",
+            id: "stove",
+            meshIds: ["mesh"],
+            vertexCount: 1,
+            base: source(44, 44),
+            shapePasses: [
+                {
+                    target: source(44, 44),
+                    phaseRate: 1,
+                    wrapAt: 0,
+                    phaseStart: Math.PI / 2,
+                    phaseOffset: 0,
+                    angularScale: 1,
+                    amplitude: 1,
+                    bias: 0,
+                },
+            ],
+            shapeStages: [],
+            pose: undefined,
+        };
+        const frame = computeGIMIShapePoseFrame(
+            deformer,
+            { base: objectVertex([1, 0, 0]), shapeTargets: [objectVertex([3, 0, 0])] },
+            0,
+            0,
+        );
+        // sin(phaseStart) = 1, so a nonzero reset must survive the no-wrap path.
+        expect([...frame.positions]).toEqual([3, 0, 0]);
+    });
+
     it("rejects pose buffers on 44-byte object shape records", () => {
         const deformer: ViewerComputeDeformer = {
             kind: "gimi_shape_pose_v1",

--- a/frontend/src/components/tools/model-viewer/model-viewer-compute-kernel.test.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-compute-kernel.test.ts
@@ -195,37 +195,46 @@ describe("GIMI shape/pose compute kernel", () => {
         expect([...atStart.positions]).toEqual([...atLoop.positions]);
     });
 
-    it("applies the accumulator reset when no wrap range exists", () => {
-        const deformer: ViewerComputeDeformer = {
-            kind: "gimi_shape_pose_v1",
-            id: "stove",
-            meshIds: ["mesh"],
-            vertexCount: 1,
-            base: source(44, 44),
-            shapePasses: [
-                {
-                    target: source(44, 44),
-                    phaseRate: 1,
-                    wrapAt: 0,
-                    phaseStart: Math.PI / 2,
-                    phaseOffset: 0,
-                    angularScale: 1,
-                    amplitude: 1,
-                    bias: 0,
-                },
-            ],
-            shapeStages: [],
-            pose: undefined,
-        };
-        const frame = computeGIMIShapePoseFrame(
-            deformer,
-            { base: objectVertex([1, 0, 0]), shapeTargets: [objectVertex([3, 0, 0])] },
-            0,
-            0,
-        );
-        // sin(phaseStart) = 1, so a nonzero reset must survive the no-wrap path.
-        expect([...frame.positions]).toEqual([3, 0, 0]);
-    });
+    it.each([
+        { wrapAt: undefined, phaseStart: Math.PI / 2 },
+        { wrapAt: 0, phaseStart: Math.PI / 2 },
+        { wrapAt: undefined, phaseStart: -Math.PI / 2 },
+        { wrapAt: 0, phaseStart: -Math.PI / 2 },
+    ])(
+        "advances without wrapping from $phaseStart with wrapAt=$wrapAt",
+        ({ wrapAt, phaseStart }) => {
+            const deformer: ViewerComputeDeformer = {
+                kind: "gimi_shape_pose_v1",
+                id: "stove",
+                meshIds: ["mesh"],
+                vertexCount: 1,
+                base: source(44, 44),
+                shapePasses: [
+                    {
+                        target: source(44, 44),
+                        phaseRate: 1,
+                        wrapAt,
+                        phaseStart,
+                        phaseOffset: 0,
+                        angularScale: 1,
+                        amplitude: 1,
+                        bias: 0,
+                    },
+                ],
+                shapeStages: [],
+                pose: undefined,
+            };
+            for (const time of [0, 1, 2]) {
+                const frame = computeGIMIShapePoseFrame(
+                    deformer,
+                    { base: objectVertex([1, 0, 0]), shapeTargets: [objectVertex([3, 0, 0])] },
+                    0,
+                    time,
+                );
+                expect(frame.positions[0]).toBeCloseTo(1 + 2 * Math.sin(phaseStart + time), 6);
+            }
+        },
+    );
 
     it("rejects pose buffers on 44-byte object shape records", () => {
         const deformer: ViewerComputeDeformer = {

--- a/frontend/src/components/tools/model-viewer/model-viewer-compute-kernel.test.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-compute-kernel.test.ts
@@ -14,6 +14,16 @@ function vertex(position: number[], normal = [0, 1, 0], tangent = [1, 0, 0, 1]):
     return new Float32Array([...position, ...normal, ...tangent]).buffer;
 }
 
+function objectVertex(position: number[], normal = [0, 1, 0]): ArrayBuffer {
+    const values = new Float32Array(11);
+    values.set(position, 0);
+    values.set(normal, 3);
+    values[6] = 0.25;
+    values[7] = 0.5;
+    values[8] = 0.75;
+    return values.buffer;
+}
+
 function poseBuffer(
     scale = [1, 1, 1],
     translation = [0, 0, 0],
@@ -112,6 +122,103 @@ describe("GIMI shape/pose compute kernel", () => {
         expect(frame.tangents[1]).toBeCloseTo(1);
         expect(frame.tangents[2]).toBeCloseTo(0);
         expect(frame.tangents[3]).toBe(1);
+    });
+
+    it("blends 44-byte object shape records without touching the tangent stream", () => {
+        const deformer: ViewerComputeDeformer = {
+            kind: "gimi_shape_pose_v1",
+            id: "stove",
+            meshIds: ["mesh"],
+            vertexCount: 1,
+            base: source(44, 44),
+            shapePasses: [
+                {
+                    target: source(44, 44),
+                    phaseRate: 2,
+                    wrapAt: 5.18364,
+                    phaseStart: -0.05236,
+                    phaseOffset: 0,
+                    angularScale: 30,
+                    amplitude: 0.5,
+                    bias: 0.5,
+                },
+            ],
+            shapeStages: [],
+            pose: undefined,
+        };
+        const frame = computeGIMIShapePoseFrame(
+            deformer,
+            { base: objectVertex([1, 0, 0]), shapeTargets: [objectVertex([3, 2, -1])] },
+            0,
+            // phase = -0.05236 + 0.10472 => sin(phase * 30) = 1, so the full delta applies.
+            0.05236,
+        );
+        expect([...frame.positions]).toEqual([3, 2, -1]);
+        expect([...frame.normals]).toEqual([0, 1, 0]);
+        expect(frame.tangents).toBeUndefined();
+    });
+
+    it("wraps 44-byte object shape phases back to the accumulator reset", () => {
+        const deformer: ViewerComputeDeformer = {
+            kind: "gimi_shape_pose_v1",
+            id: "stove",
+            meshIds: ["mesh"],
+            vertexCount: 1,
+            base: source(44, 44),
+            shapePasses: [
+                {
+                    target: source(44, 44),
+                    phaseRate: 2,
+                    wrapAt: 5.18364,
+                    phaseStart: -0.05236,
+                    phaseOffset: 0,
+                    angularScale: 30,
+                    amplitude: 0.5,
+                    bias: 0.5,
+                },
+            ],
+            shapeStages: [],
+            pose: undefined,
+        };
+        const atStart = computeGIMIShapePoseFrame(
+            deformer,
+            { base: objectVertex([1, 0, 0]), shapeTargets: [objectVertex([3, 0, 0])] },
+            0,
+            0,
+        );
+        const atLoop = computeGIMIShapePoseFrame(
+            deformer,
+            { base: objectVertex([1, 0, 0]), shapeTargets: [objectVertex([3, 0, 0])] },
+            0,
+            (5.18364 + 0.05236) / 2,
+        );
+        expect([...atStart.positions]).toEqual([...atLoop.positions]);
+    });
+
+    it("rejects pose buffers on 44-byte object shape records", () => {
+        const deformer: ViewerComputeDeformer = {
+            kind: "gimi_shape_pose_v1",
+            id: "stove",
+            meshIds: ["mesh"],
+            vertexCount: 1,
+            base: source(44, 44),
+            shapePasses: [],
+            shapeStages: [],
+            pose: {
+                blend: source(32, 32),
+                frames: source(56, 56),
+                boneCount: 1,
+                frameCount: 1,
+            },
+        };
+        expect(() =>
+            computeGIMIShapePoseFrame(
+                deformer,
+                { base: objectVertex([1, 0, 0]), shapeTargets: [] },
+                0,
+                0,
+            ),
+        ).toThrow("40-byte");
     });
 
     it("rejects invalid bone indices and source-index mappings", () => {

--- a/frontend/src/components/tools/model-viewer/model-viewer-compute-kernel.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-compute-kernel.ts
@@ -118,7 +118,9 @@ export function computeGIMIShapePoseFrame(
         const phaseStart = pass.phaseStart ?? 0;
         const wrapAt = pass.wrapAt ?? 0;
         const phase =
-            wrapAt > phaseStart ? phaseStart + (rawPhase % (wrapAt - phaseStart)) : rawPhase;
+            wrapAt > phaseStart
+                ? phaseStart + (rawPhase % (wrapAt - phaseStart))
+                : phaseStart + rawPhase;
         const weight =
             pass.amplitude * Math.sin((phase + pass.phaseOffset) * pass.angularScale) + pass.bias;
         for (let vertex = 0; vertex < deformer.vertexCount; vertex += 1) {

--- a/frontend/src/components/tools/model-viewer/model-viewer-compute-kernel.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-compute-kernel.ts
@@ -13,13 +13,27 @@ export type GIMIShapePoseFrame = {
     tangents?: Float32Array;
 };
 
+// Character shape/pose records pack position, normal, and a float4 tangent;
+// object shape records keep position and normal and store a packed texcoord
+// where the tangent would sit, so their tangent stream must stay untouched.
+const MODEL_VIEWER_SHAPE_POSE_STRIDE = 40;
+const MODEL_VIEWER_INLINE_OBJECT_STRIDE = 44;
+
 export function validateGIMIShapePoseBuffers(
     deformer: ViewerComputeDeformer,
     buffers: GIMIShapePoseBuffers,
 ): void {
     validateSource("base", deformer.base.byteLength, deformer.base.stride, buffers.base);
-    if (deformer.base.stride !== 40 || buffers.base.byteLength !== deformer.vertexCount * 40) {
-        throw new Error("GIMI shape/pose base buffer must use a 40-byte vertex stride.");
+    const baseStride = deformer.base.stride;
+    if (
+        (baseStride !== MODEL_VIEWER_SHAPE_POSE_STRIDE &&
+            baseStride !== MODEL_VIEWER_INLINE_OBJECT_STRIDE) ||
+        buffers.base.byteLength !== deformer.vertexCount * baseStride
+    ) {
+        throw new Error("GIMI shape/pose base buffer must use a 40-byte or 44-byte vertex stride.");
+    }
+    if (deformer.pose && baseStride !== MODEL_VIEWER_SHAPE_POSE_STRIDE) {
+        throw new Error("GIMI shape/pose buffers with pose data must use a 40-byte vertex stride.");
     }
     if (buffers.shapeTargets.length !== deformer.shapePasses.length) {
         throw new Error("GIMI shape/pose target count does not match the descriptor.");
@@ -31,7 +45,10 @@ export function validateGIMIShapePoseBuffers(
             pass.target.stride,
             buffers.shapeTargets[index]!,
         );
-        if (pass.target.stride !== 40 || pass.target.byteLength !== buffers.base.byteLength) {
+        if (
+            pass.target.stride !== baseStride ||
+            pass.target.byteLength !== buffers.base.byteLength
+        ) {
             throw new Error(
                 `GIMI shape/pose target ${index} is incompatible with the base buffer.`,
             );
@@ -80,41 +97,50 @@ export function computeGIMIShapePoseFrame(
         throw new Error(`Invalid GIMI shape/pose frame: ${poseFrame}`);
     }
     const base = new Float32Array(buffers.base);
+    const strideFloats = deformer.base.stride / 4;
     const positions = new Float32Array(deformer.vertexCount * 3);
     const normals = new Float32Array(deformer.vertexCount * 3);
-    const tangents = new Float32Array(deformer.vertexCount * 4);
+    const tangents =
+        deformer.base.stride === MODEL_VIEWER_SHAPE_POSE_STRIDE
+            ? new Float32Array(deformer.vertexCount * 4)
+            : undefined;
     for (let vertex = 0; vertex < deformer.vertexCount; vertex += 1) {
-        const source = vertex * 10;
+        const source = vertex * strideFloats;
         positions.set(base.subarray(source, source + 3), vertex * 3);
         normals.set(base.subarray(source + 3, source + 6), vertex * 3);
-        tangents.set(base.subarray(source + 6, source + 10), vertex * 4);
+        tangents?.set(base.subarray(source + 6, source + 10), vertex * 4);
     }
 
     for (let passIndex = 0; passIndex < deformer.shapePasses.length; passIndex += 1) {
         const pass = deformer.shapePasses[passIndex]!;
         const target = new Float32Array(buffers.shapeTargets[passIndex]!);
         const rawPhase = Math.max(phaseSeconds, 0) * pass.phaseRate;
-        const phase = pass.wrapAt && pass.wrapAt > 0 ? rawPhase % pass.wrapAt : rawPhase;
+        const phaseStart = pass.phaseStart ?? 0;
+        const wrapAt = pass.wrapAt ?? 0;
+        const phase =
+            wrapAt > phaseStart ? phaseStart + (rawPhase % (wrapAt - phaseStart)) : rawPhase;
         const weight =
             pass.amplitude * Math.sin((phase + pass.phaseOffset) * pass.angularScale) + pass.bias;
         for (let vertex = 0; vertex < deformer.vertexCount; vertex += 1) {
-            const source = vertex * 10;
+            const source = vertex * strideFloats;
             const position = vertex * 3;
-            const tangent = vertex * 4;
             for (let axis = 0; axis < 3; axis += 1) {
                 positions[position + axis] +=
                     (target[source + axis]! - base[source + axis]!) * weight;
                 normals[position + axis] +=
                     (target[source + 3 + axis]! - base[source + 3 + axis]!) * weight;
             }
-            for (let axis = 0; axis < 4; axis += 1) {
-                tangents[tangent + axis] +=
-                    (target[source + 6 + axis]! - base[source + 6 + axis]!) * weight;
+            if (tangents) {
+                const tangent = vertex * 4;
+                for (let axis = 0; axis < 4; axis += 1) {
+                    tangents[tangent + axis] +=
+                        (target[source + 6 + axis]! - base[source + 6 + axis]!) * weight;
+                }
             }
         }
     }
 
-    if (!deformer.pose || !buffers.blend || !buffers.pose) {
+    if (!deformer.pose || !buffers.blend || !buffers.pose || !tangents) {
         normalizeVectors(normals);
         return { positions, normals, tangents };
     }

--- a/frontend/src/components/tools/model-viewer/model-viewer-compute-kernel.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-compute-kernel.ts
@@ -118,7 +118,7 @@ export function computeGIMIShapePoseFrame(
         const phaseStart = pass.phaseStart ?? 0;
         const wrapAt = pass.wrapAt ?? 0;
         const phase =
-            wrapAt > phaseStart
+            wrapAt !== 0 && wrapAt > phaseStart
                 ? phaseStart + (rawPhase % (wrapAt - phaseStart))
                 : phaseStart + rawPhase;
         const weight =

--- a/frontend/src/components/tools/model-viewer/model-viewer-transport.ts
+++ b/frontend/src/components/tools/model-viewer/model-viewer-transport.ts
@@ -202,6 +202,7 @@ export function normalizeModelViewerTransport(
                         target: normalizeComputeSource(pass.target),
                         phaseRate: pass.phaseRate,
                         wrapAt: pass.wrapAt,
+                        phaseStart: pass.phaseStart,
                         phaseOffset: pass.phaseOffset,
                         angularScale: pass.angularScale,
                         amplitude: pass.amplitude,

--- a/frontend/src/shared/mod-viewer/types.ts
+++ b/frontend/src/shared/mod-viewer/types.ts
@@ -134,6 +134,7 @@ export type ViewerComputeShapePass = {
     target: ViewerComputeBinarySource;
     phaseRate: number;
     wrapAt?: number;
+    phaseStart?: number;
     phaseOffset: number;
     angularScale: number;
     amplitude: number;

--- a/internal/tools/model_viewer.go
+++ b/internal/tools/model_viewer.go
@@ -133,6 +133,7 @@ type ModelViewerComputeShapePass struct {
 	Target       ModelViewerComputeBinarySource `json:"target"`
 	PhaseRate    float64                        `json:"phaseRate"`
 	WrapAt       float64                        `json:"wrapAt,omitempty"`
+	PhaseStart   float64                        `json:"phaseStart,omitempty"`
 	PhaseOffset  float64                        `json:"phaseOffset"`
 	AngularScale float64                        `json:"angularScale"`
 	Amplitude    float64                        `json:"amplitude"`

--- a/internal/tools/model_viewer_compute_animation.go
+++ b/internal/tools/model_viewer_compute_animation.go
@@ -328,7 +328,7 @@ func detectModelViewerShapeOnlyAnimation(
 		ShapePasses: passes,
 	}
 	duration := 1.0
-	if passes[0].WrapAt > passes[0].PhaseStart && passes[0].PhaseRate > 0 {
+	if passes[0].WrapAt != 0 && passes[0].WrapAt > passes[0].PhaseStart && passes[0].PhaseRate > 0 {
 		duration = (passes[0].WrapAt - passes[0].PhaseStart) / passes[0].PhaseRate
 	} else if passes[0].AngularScale > 0 && passes[0].PhaseRate > 0 {
 		duration = 2 * math.Pi / (passes[0].AngularScale * passes[0].PhaseRate)
@@ -541,11 +541,7 @@ func detectModelViewerKnownShapePasses(
 	if !rateOK {
 		return nil
 	}
-	wrap := findModelViewerAccumulatorWrap(sections, phaseVariable, defaults)
-	phaseStart := 0.0
-	if reset, ok := findModelViewerAccumulatorReset(sections, phaseVariable, defaults); ok {
-		phaseStart = reset
-	}
+	wrap, phaseStart := findModelViewerAccumulatorLoop(sections, phaseVariable, defaults)
 	for index := range output {
 		output[index].PhaseRate = rate
 		output[index].WrapAt = wrap
@@ -812,26 +808,56 @@ func findModelViewerAccumulatorRateInLines(lines []string, variable string, defa
 	return 0, false
 }
 
-func findModelViewerAccumulatorReset(
+func findModelViewerAccumulatorLoop(
 	sections []modINISection,
 	variable string,
 	defaults map[string]any,
-) (float64, bool) {
+) (float64, float64) {
+	guardPattern := regexp.MustCompile(fmt.Sprintf(`(?i)^if\s+\$%s\s*>\s*(\$?[\w.-]+)\s*$`, regexp.QuoteMeta(variable)))
+	resetPattern := regexp.MustCompile(fmt.Sprintf(`(?i)^\$%s\s*=\s*(\$?[\w.-]+)\s*$`, regexp.QuoteMeta(variable)))
 	for _, section := range sections {
-		if value, ok := findModelViewerAccumulatorResetInLines(section.Lines, variable, defaults); ok {
-			return value, true
-		}
-	}
-	return 0, false
-}
+		depth, guardDepth := 0, 0
+		wrap := 0.0
+		for _, raw := range section.Lines {
+			line := strings.TrimSpace(strings.SplitN(raw, ";", 2)[0])
+			lower := strings.ToLower(line)
+			if strings.HasPrefix(lower, "if ") {
+				depth++
+				if guardDepth == 0 {
+					if match := guardPattern.FindStringSubmatch(line); match != nil {
+						if value, ok := resolveModelViewerNumericToken(match[1], defaults); ok && value != 0 {
+							wrap, guardDepth = value, depth
+						}
+					}
+				}
+				continue
+			}
 
-func findModelViewerAccumulatorWrap(sections []modINISection, variable string, defaults map[string]any) float64 {
-	for _, section := range sections {
-		if value := findModelViewerAccumulatorWrapInLines(section.Lines, variable, defaults); value != 0 {
-			return value
+			// Only a direct reset in this guard belongs to its loop; key bindings,
+			// nested conditions, and else branches must not supply the start value.
+			if guardDepth > 0 && depth == guardDepth && (lower == "endif" || lower == "else" ||
+				strings.HasPrefix(lower, "elif ") || strings.HasPrefix(lower, "else if ")) {
+				return wrap, 0
+			}
+			if lower == "endif" {
+				depth--
+				continue
+			}
+			if guardDepth == 0 || depth != guardDepth {
+				continue
+			}
+			if match := resetPattern.FindStringSubmatch(line); match != nil &&
+				modelViewerNormalizeKey(match[1]) != modelViewerNormalizeKey(variable) {
+				if reset, ok := resolveModelViewerNumericToken(match[1], defaults); ok {
+					return wrap, reset
+				}
+			}
+		}
+		if guardDepth > 0 {
+			return wrap, 0
 		}
 	}
-	return 0
+	return 0, 0
 }
 
 func findModelViewerAccumulatorWrapInLines(lines []string, variable string, defaults map[string]any) float64 {

--- a/internal/tools/model_viewer_compute_animation.go
+++ b/internal/tools/model_viewer_compute_animation.go
@@ -543,7 +543,7 @@ func detectModelViewerKnownShapePasses(
 	}
 	wrap := findModelViewerAccumulatorWrap(sections, phaseVariable, defaults)
 	phaseStart := 0.0
-	if reset, ok := findModelViewerAccumulatorReset(sections, phaseVariable); ok {
+	if reset, ok := findModelViewerAccumulatorReset(sections, phaseVariable, defaults); ok {
 		phaseStart = reset
 	}
 	for index := range output {
@@ -812,9 +812,13 @@ func findModelViewerAccumulatorRateInLines(lines []string, variable string, defa
 	return 0, false
 }
 
-func findModelViewerAccumulatorReset(sections []modINISection, variable string) (float64, bool) {
+func findModelViewerAccumulatorReset(
+	sections []modINISection,
+	variable string,
+	defaults map[string]any,
+) (float64, bool) {
 	for _, section := range sections {
-		if value, ok := findModelViewerAccumulatorResetInLines(section.Lines, variable); ok {
+		if value, ok := findModelViewerAccumulatorResetInLines(section.Lines, variable, defaults); ok {
 			return value, true
 		}
 	}

--- a/internal/tools/model_viewer_compute_animation.go
+++ b/internal/tools/model_viewer_compute_animation.go
@@ -328,8 +328,8 @@ func detectModelViewerShapeOnlyAnimation(
 		ShapePasses: passes,
 	}
 	duration := 1.0
-	if passes[0].WrapAt > 0 && passes[0].PhaseRate > 0 {
-		duration = passes[0].WrapAt / passes[0].PhaseRate
+	if passes[0].WrapAt > passes[0].PhaseStart && passes[0].PhaseRate > 0 {
+		duration = (passes[0].WrapAt - passes[0].PhaseStart) / passes[0].PhaseRate
 	} else if passes[0].AngularScale > 0 && passes[0].PhaseRate > 0 {
 		duration = 2 * math.Pi / (passes[0].AngularScale * passes[0].PhaseRate)
 	}
@@ -352,13 +352,14 @@ func findModelViewerKnownShapeBase(
 		}
 		for _, pass := range collectModelViewerComputePasses(section) {
 			shader, shaderOK := readModelViewerComputeShader(root, shaderBaseDir, pass.shader)
-			if _, _, _, known := knownModelViewerShapeShaderParameters(shader); !shaderOK || !known {
+			stride, strideOK := modelViewerShapeShaderStride(shader)
+			if _, _, _, known := knownModelViewerShapeShaderParameters(shader); !shaderOK || !strideOK || !known {
 				continue
 			}
 			base, exists := resources[modelViewerNormalizeKey(pass.t50)]
 			source, sourceOK := modelViewerComputeSource(root, base)
-			if exists && sourceOK && source.Stride == 40 && source.ByteLength%40 == 0 {
-				return base, source, int(source.ByteLength / 40), true
+			if exists && sourceOK && source.Stride == stride && source.ByteLength%int64(stride) == 0 {
+				return base, source, int(source.ByteLength / int64(stride)), true
 			}
 		}
 	}
@@ -483,6 +484,11 @@ func detectModelViewerKnownShapePasses(
 	var output []ModelViewerComputeShapePass
 	phaseVariable := ""
 	hasLinkedOutput := false
+	resourceList := make([]modelViewerResource, 0, len(resources))
+	for _, resource := range resources {
+		resourceList = append(resourceList, resource)
+	}
+	aliases := collectModelViewerResourceAliases(sections, resourceList)
 	for _, section := range sections {
 		if !strings.EqualFold(section.Header, "CustomShader") ||
 			!reachable[modelViewerNormalizeKey(section.Header+section.Name)] {
@@ -523,9 +529,7 @@ func detectModelViewerKnownShapePasses(
 					Bias:         bias,
 				},
 			)
-			if outputResource, exists := resources[modelViewerNormalizeKey(pass.outputName)]; exists &&
-				outputResource.Filename != "" &&
-				samePathFold(outputResource.Filename, base.Filename) {
+			if modelViewerComputeOutputMatchesBase(resources, aliases, pass.outputName, base.Filename) {
 				hasLinkedOutput = true
 			}
 		}
@@ -538,11 +542,36 @@ func detectModelViewerKnownShapePasses(
 		return nil
 	}
 	wrap := findModelViewerAccumulatorWrap(sections, phaseVariable, defaults)
+	phaseStart := 0.0
+	if reset, ok := findModelViewerAccumulatorReset(sections, phaseVariable); ok {
+		phaseStart = reset
+	}
 	for index := range output {
 		output[index].PhaseRate = rate
 		output[index].WrapAt = wrap
+		output[index].PhaseStart = phaseStart
 	}
 	return output
+}
+
+// modelViewerComputeOutputMatchesBase accepts the declared output resource
+// alias as well as the named resource: object mods commonly alias an unnamed
+// output to the shader UAV inside the compute section.
+func modelViewerComputeOutputMatchesBase(
+	resources map[string]modelViewerResource,
+	aliases modelViewerResourceAliases,
+	outputName, baseFilename string,
+) bool {
+	if outputName == "" || baseFilename == "" {
+		return false
+	}
+	if resource, exists := resources[modelViewerNormalizeKey(outputName)]; exists &&
+		resource.Filename != "" &&
+		samePathFold(resource.Filename, baseFilename) {
+		return true
+	}
+	resolved, ok := aliases.resolve(outputName)
+	return ok && resolved.Filename != "" && samePathFold(resolved.Filename, baseFilename)
 }
 
 func collectModelViewerReachableComputeSections(sections []modINISection) map[string]bool {
@@ -677,14 +706,41 @@ func isKnownModelViewerGIMIShapePoseBoneShader(shader string) bool {
 	return strings.Contains(compact, "int4indicies") || strings.Contains(compact, "int4indices")
 }
 
+// modelViewerShapeShaderStride reports the vertex record size for known
+// cyclic shapekey shaders. The 40-byte form blends position, normal, and
+// tangent; the 44-byte object form blends position and normal and keeps a
+// packed texcoord where the tangent would sit.
+func modelViewerShapeShaderStride(shader string) (int, bool) {
+	compact := compactModelViewerShader(shader)
+	switch {
+	case strings.Contains(compact, "structvertexattributes{float3position;float3normal;float4tangent;}"):
+		return 40, true
+	case strings.Contains(
+		compact,
+		"structvertexattributes{float3position;float3normal;uinttexcoord0;float2texcoord1;uint2tangent;}",
+	):
+		return 44, true
+	default:
+		return 0, false
+	}
+}
+
 func knownModelViewerShapeShaderParameters(shader string) (float64, float64, float64, bool) {
 	compact := compactModelViewerShader(shader)
+	stride, known := modelViewerShapeShaderStride(shader)
+	if !known {
+		return 0, 0, 0, false
+	}
 	required := []string{
-		"structvertexattributes{float3position;float3normal;float4tangent;}",
 		"structuredbuffer<vertexattributes>", "register(t50)", "register(t51)",
 		"shapekey[i].position-base[i].position", "shapekey[i].normal-base[i].normal",
-		"shapekey[i].tangent-base[i].tangent", ".position+=diff.position*",
-		".normal+=diff.normal*", ".tangent+=diff.tangent*",
+		".position+=diff.position*", ".normal+=diff.normal*",
+	}
+	if stride == 40 {
+		required = append(
+			required,
+			"shapekey[i].tangent-base[i].tangent", ".tangent+=diff.tangent*",
+		)
 	}
 	for _, signature := range required {
 		if !strings.Contains(compact, signature) {
@@ -751,6 +807,15 @@ func findModelViewerAccumulatorRateInLines(lines []string, variable string, defa
 	for _, raw := range lines {
 		if match := pattern.FindStringSubmatch(strings.TrimSpace(raw)); match != nil {
 			return resolveModelViewerNumericToken(match[1], defaults)
+		}
+	}
+	return 0, false
+}
+
+func findModelViewerAccumulatorReset(sections []modINISection, variable string) (float64, bool) {
+	for _, section := range sections {
+		if value, ok := findModelViewerAccumulatorResetInLines(section.Lines, variable); ok {
+			return value, true
 		}
 	}
 	return 0, false

--- a/internal/tools/model_viewer_compute_animation_test.go
+++ b/internal/tools/model_viewer_compute_animation_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"slices"
@@ -739,6 +740,73 @@ filename = key.buf
 	}
 }
 
+func TestDetectModelViewerPackedShapeIncomingVariableReset(t *testing.T) {
+	dir := t.TempDir()
+	writePackedShapeBuffer(t, dir, "base.buf")
+	writePackedShapeBuffer(t, dir, "key.buf")
+	if err := os.WriteFile(filepath.Join(dir, "anim.hlsl"), []byte(packedShapeAnimShader), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	parsed := parseModelViewerINI(`[Constants]
+global $start = 1
+global $next = 3
+global $Freq = 0
+global $dt
+global $anime_state = 0
+post run = CustomShaderComputeAnim
+[CustomShaderComputeAnim]
+if $anime_state == 0
+    $Freq = $Freq + 1 * $dt
+    if $Freq > 10
+        $Freq = $next
+        $anime_state = 1
+    endif
+    x88 = $Freq
+    cs-t50 = copy ResourceKimono.1
+    cs-t51 = copy ResourceKimono.2
+    cs = anim.hlsl
+    cs-u5 = copy ResourceKimono.1
+    ResourceKimono = ref cs-u5
+    Dispatch = 3, 1, 1
+else if $anime_state == 1
+    $Freq = $Freq + 1 * $dt
+    if $Freq > 9
+        $Freq = $start
+        $anime_state = 0
+    endif
+    x88 = $Freq
+    cs-t50 = copy ResourceKimono.2
+    cs-t51 = copy ResourceKimono.1
+    cs = anim.hlsl
+    cs-u5 = copy ResourceKimono.2
+    ResourceKimono = ref cs-u5
+    Dispatch = 3, 1, 1
+endif
+[ResourceKimono.1]
+stride = 20
+filename = base.buf
+[ResourceKimono.2]
+stride = 20
+filename = key.buf
+`, filepath.Join(dir, "mod.ini"))
+	sections, names := scopeModelViewerSections(parsed.Sections, 0, "")
+	resources := resolveModelViewerEffectiveResources(sections, collectModelViewerResources(sections))
+	meshes := []modelViewerDirectMesh{
+		{id: "mesh", positionFile: "base.buf", geometry: &modelViewerGeometry{VertexCount: 3}},
+	}
+	deformer, _ := detectModelViewerComputeAnimation(dir, dir, "", sections, resources, meshes, names)
+	if deformer == nil || len(deformer.ShapeStages) != 2 {
+		t.Fatalf("deformer = %+v", deformer)
+	}
+	stage0, stage1 := deformer.ShapeStages[0], deformer.ShapeStages[1]
+	if stage0.PhaseStart != 1 || stage0.WrapAt != 10 || stage0.Duration != 9 {
+		t.Fatalf("stage0 = %+v; want the $start-backed incoming reset", stage0)
+	}
+	if stage1.PhaseStart != 3 || stage1.WrapAt != 9 || stage1.Duration != 6 {
+		t.Fatalf("stage1 = %+v; want the $next-backed incoming reset", stage1)
+	}
+}
+
 func TestDetectModelViewerPackedShapeSinglePass(t *testing.T) {
 	dir := t.TempDir()
 	writePackedShapeBuffer(t, dir, "base.buf")
@@ -784,6 +852,71 @@ filename = key.buf
 		deformer.ShapeStages[0].Duration <= 0 ||
 		len(clips) != 1 {
 		t.Fatalf("stage=%+v clips=%+v", deformer.ShapeStages[0], clips)
+	}
+}
+
+func TestDetectModelViewerPackedShapeVariableBackedReset(t *testing.T) {
+	dir := t.TempDir()
+	writePackedShapeBuffer(t, dir, "base.buf")
+	writePackedShapeBuffer(t, dir, "key.buf")
+	if err := os.WriteFile(filepath.Join(dir, "anim.hlsl"), []byte(packedShapeAnimShader), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	parsed := parseModelViewerINI(`[Constants]
+global $start = -0.05236
+global $Freq = 0
+global $dt
+global $speed = 0.5
+post run = CustomShaderComputeAnim
+[CustomShaderComputeAnim]
+$Freq = $Freq + $speed * $dt
+if $Freq > 10
+    $Freq = $start
+endif
+x88 = $Freq
+cs-t50 = copy ResourceKimono.1
+cs-t51 = copy ResourceKimono.2
+cs = anim.hlsl
+cs-u5 = copy ResourceKimono.1
+ResourceKimono = ref cs-u5
+Dispatch = 3, 1, 1
+[ResourceKimono.1]
+stride = 20
+filename = base.buf
+[ResourceKimono.2]
+stride = 20
+filename = key.buf
+`, filepath.Join(dir, "mod.ini"))
+	sections, names := scopeModelViewerSections(parsed.Sections, 0, "")
+	resources := resolveModelViewerEffectiveResources(sections, collectModelViewerResources(sections))
+	meshes := []modelViewerDirectMesh{
+		{id: "mesh", positionFile: "base.buf", geometry: &modelViewerGeometry{VertexCount: 3}},
+	}
+	deformer, clips := detectModelViewerComputeAnimation(dir, dir, "", sections, resources, meshes, names)
+	if deformer == nil || len(deformer.ShapeStages) != 1 {
+		t.Fatalf("deformer = %+v", deformer)
+	}
+	stage := deformer.ShapeStages[0]
+	if stage.PhaseStart != -0.05236 {
+		t.Fatalf("phase start = %v; want the $start default", stage.PhaseStart)
+	}
+	if want := (10 + 0.05236) / 0.5; math.Abs(stage.Duration-want) > 1e-9 {
+		t.Fatalf("duration = %v; want %v", stage.Duration, want)
+	}
+	if len(clips) != 1 {
+		t.Fatalf("clips = %+v", clips)
+	}
+}
+
+func TestFindModelViewerAccumulatorResetResolvesDefaultVariables(t *testing.T) {
+	sections := parseModINI(`[CustomShaderComputeAnim]
+$Freq = $Freq + 0.2 * $dt
+if $Freq > 5.18364
+    $Freq = $start
+endif`)
+	reset, ok := findModelViewerAccumulatorReset(sections, "Freq", map[string]any{"start": -0.05236})
+	if !ok || reset != -0.05236 {
+		t.Fatalf("reset = %v ok = %t; want the $start default", reset, ok)
 	}
 }
 

--- a/internal/tools/model_viewer_compute_animation_test.go
+++ b/internal/tools/model_viewer_compute_animation_test.go
@@ -908,15 +908,91 @@ filename = key.buf
 	}
 }
 
-func TestFindModelViewerAccumulatorResetResolvesDefaultVariables(t *testing.T) {
+func TestFindModelViewerAccumulatorLoopResolvesDefaultVariables(t *testing.T) {
 	sections := parseModINI(`[CustomShaderComputeAnim]
 $Freq = $Freq + 0.2 * $dt
 if $Freq > 5.18364
     $Freq = $start
 endif`)
-	reset, ok := findModelViewerAccumulatorReset(sections, "Freq", map[string]any{"start": -0.05236})
-	if !ok || reset != -0.05236 {
-		t.Fatalf("reset = %v ok = %t; want the $start default", reset, ok)
+	wrap, reset := findModelViewerAccumulatorLoop(sections, "Freq", map[string]any{"start": -0.05236})
+	if wrap != 5.18364 || reset != -0.05236 {
+		t.Fatalf("wrap = %v reset = %v; want the $start default", wrap, reset)
+	}
+}
+
+func TestFindModelViewerAccumulatorLoopKeepsResetInsideSelectedGuard(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		ini   string
+		wrap  float64
+		reset float64
+	}{
+		{
+			name: "ignore key and state entry assignments",
+			ini: `[KeySeek]
+$Freq = 1
+[CustomShaderComputeAnim]
+$Freq = 2
+if $Freq > 5 ; loop boundary
+    $Freq = 0 ; loop reset
+endif`,
+			wrap: 5,
+		},
+		{
+			name: "ignore nested assignments",
+			ini: `[CustomShaderComputeAnim]
+if $enabled
+    if $Freq > 5
+        if $mode
+            $Freq = 2
+        endif
+        $Freq = -0.5
+    endif
+endif`,
+			wrap:  5,
+			reset: -0.5,
+		},
+		{
+			name: "ignore else branch",
+			ini: `[CustomShaderComputeAnim]
+if $Freq > 5
+    $unrelated = 1
+else
+    $Freq = 2
+endif`,
+			wrap: 5,
+		},
+		{
+			name: "do not borrow reset from another loop",
+			ini: `[CustomShaderComputeAnim]
+if $Freq > 5
+    $unrelated = 1
+endif
+[CustomShaderOther]
+if $Freq > 10
+    $Freq = 3
+endif`,
+			wrap: 5,
+		},
+		{
+			name: "no loop guard",
+			ini: `[KeySeek]
+$Freq = -0.5`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			wrap, reset := findModelViewerAccumulatorLoop(parseModINI(test.ini), "Freq", nil)
+			if wrap != test.wrap || reset != test.reset {
+				t.Fatalf("loop = (%v, %v); want (%v, %v)", wrap, reset, test.wrap, test.reset)
+			}
+		})
+	}
+}
+
+func TestModelViewerPackedShapeDurationWithoutWrap(t *testing.T) {
+	stage := ModelViewerComputeShapeStage{PhaseStart: -0.5, PhaseRate: 1, AngularScale: 1}
+	if duration := modelViewerPackedShapeStageDuration(stage); math.Abs(duration-2*math.Pi) > 1e-9 {
+		t.Fatalf("duration = %v; want a complete sine period without a wrap boundary", duration)
 	}
 }
 

--- a/internal/tools/model_viewer_compute_packed_shape.go
+++ b/internal/tools/model_viewer_compute_packed_shape.go
@@ -347,7 +347,7 @@ func modelViewerComputeBranchLines(section modINISection, variable, value string
 }
 
 func modelViewerPackedShapeStageDuration(stage ModelViewerComputeShapeStage) float64 {
-	if stage.WrapAt > stage.PhaseStart && stage.PhaseRate > 0 {
+	if stage.WrapAt != 0 && stage.WrapAt > stage.PhaseStart && stage.PhaseRate > 0 {
 		return (stage.WrapAt - stage.PhaseStart) / stage.PhaseRate
 	}
 	if stage.AngularScale > 0 && stage.PhaseRate > 0 {

--- a/internal/tools/model_viewer_compute_packed_shape.go
+++ b/internal/tools/model_viewer_compute_packed_shape.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"regexp"
-	"strconv"
 	"strings"
 )
 
@@ -51,7 +50,7 @@ func detectModelViewerPackedShapeAnimation(
 	if len(meshIDs) == 0 {
 		return nil, nil
 	}
-	incomingStarts := collectModelViewerPackedShapeIncomingStarts(selected, stateVariable)
+	incomingStarts := collectModelViewerPackedShapeIncomingStarts(selected, stateVariable, defaults)
 	stages := make([]ModelViewerComputeShapeStage, 0, len(selected))
 	duration := 0.0
 	for _, item := range selected {
@@ -360,6 +359,7 @@ func modelViewerPackedShapeStageDuration(stage ModelViewerComputeShapeStage) flo
 func collectModelViewerPackedShapeIncomingStarts(
 	selected []modelViewerPackedShapeCandidate,
 	stateVariable string,
+	defaults map[string]any,
 ) map[string]float64 {
 	incoming := map[string]float64{}
 	if stateVariable == "" {
@@ -372,7 +372,7 @@ func collectModelViewerPackedShapeIncomingStarts(
 			continue
 		}
 		lines := modelViewerComputeBranchLines(item.section, stateVariable, value)
-		reset, hasReset := findModelViewerAccumulatorResetInLines(lines, phaseVariable)
+		reset, hasReset := findModelViewerAccumulatorResetInLines(lines, phaseVariable, defaults)
 		next, hasNext := findModelViewerNumericAssignmentInLines(lines, stateVariable)
 		if !hasReset || !hasNext {
 			continue
@@ -392,7 +392,7 @@ func modelViewerPackedShapePhaseStart(
 		return start
 	}
 	if stateVariable == "" {
-		if reset, ok := findModelViewerAccumulatorResetInLines(branchLines, phaseVariable); ok {
+		if reset, ok := findModelViewerAccumulatorResetInLines(branchLines, phaseVariable, defaults); ok {
 			return reset
 		}
 	}
@@ -412,16 +412,18 @@ func findModelViewerNumericAssignmentInLines(lines []string, variable string) (s
 	return "", false
 }
 
-func findModelViewerAccumulatorResetInLines(lines []string, variable string) (float64, bool) {
-	text, ok := findModelViewerNumericAssignmentInLines(lines, variable)
-	if !ok {
-		return 0, false
+func findModelViewerAccumulatorResetInLines(
+	lines []string,
+	variable string,
+	defaults map[string]any,
+) (float64, bool) {
+	pattern := regexp.MustCompile(fmt.Sprintf(`(?i)^\$%s\s*=\s*(\$?[\w.-]+)\s*$`, regexp.QuoteMeta(variable)))
+	for _, raw := range lines {
+		if match := pattern.FindStringSubmatch(strings.TrimSpace(raw)); match != nil {
+			return resolveModelViewerNumericToken(match[1], defaults)
+		}
 	}
-	value, err := strconv.ParseFloat(text, 64)
-	if err != nil {
-		return 0, false
-	}
-	return value, true
+	return 0, false
 }
 
 func isKnownModelViewerPackedShapeShader(shader string) bool {

--- a/internal/tools/model_viewer_inline_object_test.go
+++ b/internal/tools/model_viewer_inline_object_test.go
@@ -1,0 +1,188 @@
+package tools
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"nahida.live/desktop/internal/infra"
+)
+
+// Zlevir's cyclic object animation shader keeps the vertex record unpacked and
+// blends only position and normal, so it advertises a 44-byte stride.
+const inlineObjectAnimShader = `
+// **** CYCLIC ANIMATION SHADER ****
+struct VertexAttributes {
+    float3 position;
+    float3 normal;
+    uint texcoord0;
+    float2 texcoord1;
+    uint2 tangent;
+};
+RWStructuredBuffer<VertexAttributes> rw_buffer : register(u5);
+StructuredBuffer<VertexAttributes> base : register(t50);
+StructuredBuffer<VertexAttributes> shapekey : register(t51);
+Texture1D<float4> IniParams : register(t120);
+#define FREQ IniParams[88].x
+[numthreads(1, 1, 1)]
+void main(uint3 threadID : SV_DispatchThreadID)
+{
+    uint i = threadID.x;
+    VertexAttributes diff;
+    diff.position = shapekey[i].position - base[i].position;
+    diff.normal = shapekey[i].normal - base[i].normal;
+    //diff.tangent = shapekey[i].tangent - base[i].tangent;
+    rw_buffer[i].position += diff.position*(0.5*(sin(FREQ*30)+1));
+    rw_buffer[i].normal += diff.normal*(0.5*(sin(FREQ*30)+1));
+}
+`
+
+func writeInlineObjectVertex(buf []byte, offset int, x, y, z, u, v, nx, ny, nz float32) {
+	binary.LittleEndian.PutUint32(buf[offset:], math.Float32bits(x))
+	binary.LittleEndian.PutUint32(buf[offset+4:], math.Float32bits(y))
+	binary.LittleEndian.PutUint32(buf[offset+8:], math.Float32bits(z))
+	binary.LittleEndian.PutUint32(buf[offset+12:], math.Float32bits(nx))
+	binary.LittleEndian.PutUint32(buf[offset+16:], math.Float32bits(ny))
+	binary.LittleEndian.PutUint32(buf[offset+20:], math.Float32bits(nz))
+	binary.LittleEndian.PutUint16(buf[offset+24:], modelViewerFloatToHalfBits(u))
+	binary.LittleEndian.PutUint16(buf[offset+26:], modelViewerFloatToHalfBits(v))
+}
+
+func TestModelViewerInlineObjectShaderLayout(t *testing.T) {
+	stride, offset, known := modelViewerInlineObjectShaderLayout(inlineObjectAnimShader)
+	if !known || stride != 44 || offset != 24 {
+		t.Fatalf("layout=%d/%d known=%t", stride, offset, known)
+	}
+	if _, _, known := modelViewerInlineObjectShaderLayout(
+		`struct VertexAttributes { float3 position; float3 normal; float4 tangent; };`,
+	); known {
+		t.Fatal("character shape layout must not be treated as an inline object record")
+	}
+}
+
+func TestModelViewerInlineObjectCyclicShapeLoadsAnimationAndDiffuseUVs(t *testing.T) {
+	dir := t.TempDir()
+	vertices := make([]byte, 3*44)
+	writeInlineObjectVertex(vertices, 0, 1, 2, 3, 0.25, 0.75, 0, 1, 0)
+	writeInlineObjectVertex(vertices, 44, 4, 5, 6, 0.5, 0.5, 0, 1, 0)
+	writeInlineObjectVertex(vertices, 88, 7, 8, 9, 0, 1, 0, 1, 0)
+	ini := `[Constants]
+global $Speed = 0.2
+global $Freq = 0
+global $dt
+post ResourceStove = copy_desc ResourceStove.1
+post run = CustomShaderComputeAnim
+
+[Present]
+run = CustomShaderComputeAnim
+
+[CustomShaderComputeAnim]
+$Freq = $Freq + $Speed * $dt
+if $Freq > 5.18364
+    $Freq = -0.05236
+endif
+x88 = $Freq
+cs-t50 = copy ResourceStove.1
+cs-t51 = copy ResourceStove.2
+cs = ./anim.hlsl
+cs-u5 = copy ResourceStove.1
+ResourceStove = ref cs-u5
+Dispatch = 3, 1, 1
+
+[TextureOverrideStove]
+hash = d168f116
+vb0 = ResourceStove
+
+[TextureOverrideStoveBody]
+hash = 79f0c7ff
+match_first_index = 0
+ib = ResourceStoveBodyIB
+ps-t0 = ResourceStoveBodyDiffuse
+ps-t1 = ResourceStoveBodyNormalMap
+
+[ResourceStove]
+[ResourceStove.1]
+type = Buffer
+stride = 44
+filename = Stove1.buf
+[ResourceStove.2]
+type = Buffer
+stride = 44
+filename = Stove2.buf
+[ResourceStoveBodyIB]
+format = DXGI_FORMAT_R32_UINT
+filename = StoveBody.ib
+[ResourceStoveBodyDiffuse]
+filename = StoveBodyDiffuse.png
+[ResourceStoveBodyNormalMap]
+filename = StoveBodyNormalMap.png
+`
+	writeTextureFile(t, dir, "StoveBodyDiffuse.png", encodeTinyPNG())
+	writeTextureFile(t, dir, "StoveBodyNormalMap.png", encodeTinyPNG())
+	for name, data := range map[string][]byte{
+		"mod.ini": []byte(ini), "anim.hlsl": []byte(inlineObjectAnimShader),
+		"Stove1.buf": vertices, "Stove2.buf": vertices,
+		"StoveBody.ib": modelViewerUint32Bytes([]uint32{0, 1, 2}),
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	iniPath := filepath.Join(dir, "mod.ini")
+	sections := parseModINI(ini)
+	inline := collectModelViewerInlineObjectResources(dir, dir, sections)
+	if inline[modelViewerNormalizeKey("Stove")].texcoordOffset != 24 ||
+		inline[modelViewerNormalizeKey("Stove.1")].stride != 44 {
+		t.Fatalf("inline resources = %+v", inline)
+	}
+	meshes, err := buildModelViewerDirectScannedMeshes(
+		iniPath,
+		sections,
+		collectModelViewerDefaultVariables(sections),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(meshes) != 1 || meshes[0].geometry == nil {
+		t.Fatalf("meshes = %#v", meshes)
+	}
+	geometry := meshes[0].geometry
+	if !slices.Equal(geometry.Position, []float32{1, 2, 3, 4, 5, 6, 7, 8, 9}) {
+		t.Fatalf("positions = %v", geometry.Position)
+	}
+	if !slices.Equal(geometry.Normal, []float32{0, 1, 0, 0, 1, 0, 0, 1, 0}) {
+		t.Fatalf("normals = %v", geometry.Normal)
+	}
+	if want := []float32{0.25, 0.25, 0.5, 0.5, 0, 0}; !slices.Equal(geometry.Texcoord0, want) {
+		t.Fatalf("diffuse UVs = %v; want the half2 word at byte 24 with V flipped", geometry.Texcoord0)
+	}
+
+	service := NewWithOptions(Options{Protocol: infra.NewProtocol()})
+	payload, err := service.LoadModViewer(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _, _ = service.CleanupModelViewer(context.Background(), payload.MemorySessionID) })
+	if len(payload.ComputeDeformers) != 1 || len(payload.Animations) != 1 {
+		t.Fatalf("deformers=%d animations=%d", len(payload.ComputeDeformers), len(payload.Animations))
+	}
+	deformer, clip := payload.ComputeDeformers[0], payload.Animations[0]
+	if deformer.Kind != modelViewerGIMIShapePoseKind || deformer.VertexCount != 3 ||
+		deformer.Base.Stride != 44 || deformer.Pose != nil || len(deformer.ShapePasses) != 1 ||
+		clip.DeformerID != deformer.ID || len(clip.Frames) < 2 {
+		t.Fatalf("deformer=%+v clip=%+v", deformer, clip)
+	}
+	pass := deformer.ShapePasses[0]
+	if pass.PhaseRate != 0.2 || pass.WrapAt != 5.18364 || pass.PhaseStart != -0.05236 ||
+		pass.AngularScale != 30 || pass.Amplitude != 0.5 || pass.Bias != 0.5 {
+		t.Fatalf("shape pass = %+v", pass)
+	}
+	state := evaluateViewerTransport(payload, nil)
+	if len(state.Meshes) != 1 || state.Meshes[0].TexKey != "diffuse::StoveBodyDiffuse.png" {
+		t.Fatalf("material = %+v", state.Meshes)
+	}
+}

--- a/internal/tools/model_viewer_inline_object_test.go
+++ b/internal/tools/model_viewer_inline_object_test.go
@@ -77,6 +77,10 @@ global $dt
 post ResourceStove = copy_desc ResourceStove.1
 post run = CustomShaderComputeAnim
 
+[KeySeek]
+key = VK_F6
+$Freq = 1
+
 [Present]
 run = CustomShaderComputeAnim
 

--- a/internal/tools/model_viewer_object_layout.go
+++ b/internal/tools/model_viewer_object_layout.go
@@ -448,12 +448,19 @@ func resolveModelViewerDrawVertexSource(
 	return source
 }
 
-func readModelViewerInlineObjectBuffer(
+// readModelViewerObjectBuffer resolves an object buffer inside modDir before
+// the cache touches the filesystem: resource filenames come from mod INI files
+// and must not escape the mod folder.
+func readModelViewerObjectBuffer(
 	modDir string,
 	position modelViewerResource,
 	cache *modelViewerBufferCache,
 ) ([]byte, bool) {
-	raw, err := cache.read(filepath.Join(modDir, filepath.FromSlash(position.Filename)))
+	path, err := resolveModelViewerResourcePath(modDir, modDir, position.Filename)
+	if err != nil || !modelViewerPathWithin(modDir, path) {
+		return nil, false
+	}
+	raw, err := cache.read(path)
 	if err != nil {
 		return nil, false
 	}
@@ -466,8 +473,8 @@ func readModelViewerPackedObjectBuffer(
 	cache *modelViewerBufferCache,
 	shaderPacked bool,
 ) ([]byte, int, bool) {
-	raw, err := cache.read(filepath.Join(modDir, filepath.FromSlash(position.Filename)))
-	if err != nil {
+	raw, ok := readModelViewerObjectBuffer(modDir, position, cache)
+	if !ok {
 		return nil, 0, false
 	}
 	stride, packed := modelViewerUsePackedObjectLayout(position, raw, shaderPacked)
@@ -502,7 +509,7 @@ func loadModelViewerDrawVertexBuffers(
 		if stride <= 0 {
 			return modelViewerDrawVertexBuffers{}, false, nil
 		}
-		raw, ok := readModelViewerInlineObjectBuffer(modDir, position, cache)
+		raw, ok := readModelViewerObjectBuffer(modDir, position, cache)
 		if !ok {
 			return modelViewerDrawVertexBuffers{}, false, nil
 		}

--- a/internal/tools/model_viewer_object_layout.go
+++ b/internal/tools/model_viewer_object_layout.go
@@ -19,9 +19,10 @@ const (
 	modelViewerPackedObjectKind     = "gimi_cyclic_packed_v1"
 	modelViewerPackedObjectWEpsilon = 0.05
 
-	modelViewerDrawVertexMihoyo = "mihoyo"
-	modelViewerDrawVertexWWMI   = "wwmi"
-	modelViewerDrawVertexPacked = "packed"
+	modelViewerDrawVertexMihoyo       = "mihoyo"
+	modelViewerDrawVertexWWMI         = "wwmi"
+	modelViewerDrawVertexPacked       = "packed"
+	modelViewerDrawVertexInlineObject = "inline_object"
 )
 
 var (
@@ -92,6 +93,58 @@ func modelViewerPackedObjectShaderLayout(shader string) (stride, texcoordOffset 
 	default:
 		return 0, 0, false
 	}
+}
+
+// modelViewerInlineObjectShaderLayout recognizes unpacked GIMI object vertex
+// records that keep the diffuse texcoord inside the same buffer. Stride alone
+// cannot identify the layout, so only compute shaders that declare the exact
+// record are trusted.
+func modelViewerInlineObjectShaderLayout(shader string) (stride, texcoordOffset int, known bool) {
+	compact := compactModelViewerShader(shader)
+	switch {
+	case strings.Contains(
+		compact,
+		"structvertexattributes{float3position;float3normal;uinttexcoord0;float2texcoord1;uint2tangent;}",
+	):
+		return 44, 24, true
+	default:
+		return 0, 0, false
+	}
+}
+
+type modelViewerInlineObjectLayout struct {
+	stride         int
+	texcoordOffset int
+}
+
+func collectModelViewerInlineObjectResources(
+	root, shaderBaseDir string,
+	sections []modINISection,
+) map[string]modelViewerInlineObjectLayout {
+	inline := map[string]modelViewerInlineObjectLayout{}
+	reachable := collectModelViewerReachableComputeSections(sections)
+	for _, section := range sections {
+		if !strings.EqualFold(section.Header, "CustomShader") ||
+			!reachable[modelViewerNormalizeKey(section.Header+section.Name)] {
+			continue
+		}
+		for _, pass := range collectModelViewerComputePasses(section) {
+			shader, ok := readModelViewerComputeShader(root, shaderBaseDir, pass.shader)
+			if !ok {
+				continue
+			}
+			stride, texcoordOffset, known := modelViewerInlineObjectShaderLayout(shader)
+			if !known {
+				continue
+			}
+			for _, name := range []string{pass.outputName, pass.t50} {
+				if key := modelViewerNormalizeKey(name); key != "" {
+					inline[key] = modelViewerInlineObjectLayout{stride: stride, texcoordOffset: texcoordOffset}
+				}
+			}
+		}
+	}
+	return inline
 }
 
 func isKnownModelViewerGIMICyclicPackedBoneShader(shader string) bool {
@@ -301,10 +354,23 @@ type modelViewerDrawVertexSource struct {
 	kind                           string
 	packedTexcoordOffset           int
 	packedTexcoordDeclared         bool
+	inlineTexcoordOffset           int
 	ib, position, texcoord, vector modelViewerResource
 	packed                         []byte
 	packedStride                   int
 	missingTexcoord                bool
+}
+
+func modelViewerInlineObjectForResource(
+	inline map[string]modelViewerInlineObjectLayout,
+	names ...string,
+) (modelViewerInlineObjectLayout, bool) {
+	for _, name := range names {
+		if layout, ok := inline[modelViewerNormalizeKey(name)]; ok {
+			return layout, true
+		}
+	}
+	return modelViewerInlineObjectLayout{}, false
 }
 
 func resolveModelViewerDrawVertexSource(
@@ -314,6 +380,7 @@ func resolveModelViewerDrawVertexSource(
 	resources []modelViewerResource,
 	cache *modelViewerBufferCache,
 	packedResources map[string]int,
+	inlineResources map[string]modelViewerInlineObjectLayout,
 ) modelViewerDrawVertexSource {
 	ib, ibOK := resourceMap[modelViewerNormalizeKey(state.ib)]
 	position, posOK := resourceMap[modelViewerNormalizeKey(state.vb0)]
@@ -321,6 +388,12 @@ func resolveModelViewerDrawVertexSource(
 		return modelViewerDrawVertexSource{}
 	}
 	source := modelViewerDrawVertexSource{ib: ib, position: position}
+	if offset, ok := modelViewerInlineObjectForResource(inlineResources, state.vb0, position.Name); ok &&
+		position.Stride == offset.stride {
+		source.kind = modelViewerDrawVertexInlineObject
+		source.inlineTexcoordOffset = offset.texcoordOffset
+		return source
+	}
 	if layoutName == "wwmi" {
 		vector, vectorOK := resourceMap[modelViewerNormalizeKey(state.vb1)]
 		texcoord, tcOK := resourceMap[modelViewerNormalizeKey(state.vb2)]
@@ -375,6 +448,18 @@ func resolveModelViewerDrawVertexSource(
 	return source
 }
 
+func readModelViewerInlineObjectBuffer(
+	modDir string,
+	position modelViewerResource,
+	cache *modelViewerBufferCache,
+) ([]byte, bool) {
+	raw, err := cache.read(filepath.Join(modDir, filepath.FromSlash(position.Filename)))
+	if err != nil {
+		return nil, false
+	}
+	return raw, true
+}
+
 func readModelViewerPackedObjectBuffer(
 	modDir string,
 	position modelViewerResource,
@@ -412,6 +497,45 @@ func loadModelViewerDrawVertexBuffers(
 		tcStride = 20
 	}
 	switch source.kind {
+	case modelViewerDrawVertexInlineObject:
+		stride := position.Stride
+		if stride <= 0 {
+			return modelViewerDrawVertexBuffers{}, false, nil
+		}
+		raw, ok := readModelViewerInlineObjectBuffer(modDir, position, cache)
+		if !ok {
+			return modelViewerDrawVertexBuffers{}, false, nil
+		}
+		return modelViewerDrawVertexBuffers{
+			combined:  raw,
+			stride:    stride,
+			posStride: stride,
+			layout: modelViewerFmtLayout{
+				Stride:      stride,
+				Topology:    "trianglelist",
+				IndexFormat: source.ib.Format,
+				Elements: []modelViewerFmtElement{
+					{
+						SemanticName:      "POSITION",
+						Format:            "DXGI_FORMAT_R32G32B32_FLOAT",
+						AlignedByteOffset: 0,
+						InputSlotClass:    "per-vertex",
+					},
+					{
+						SemanticName:      "NORMAL",
+						Format:            "DXGI_FORMAT_R32G32B32_FLOAT",
+						AlignedByteOffset: 12,
+						InputSlotClass:    "per-vertex",
+					},
+					{
+						SemanticName:      "TEXCOORD",
+						Format:            "DXGI_FORMAT_R16G16_FLOAT",
+						AlignedByteOffset: source.inlineTexcoordOffset,
+						InputSlotClass:    "per-vertex",
+					},
+				},
+			},
+		}, true, nil
 	case modelViewerDrawVertexPacked:
 		stride := source.packedStride
 		if stride <= 0 {

--- a/internal/tools/model_viewer_object_layout_test.go
+++ b/internal/tools/model_viewer_object_layout_test.go
@@ -209,6 +209,41 @@ filename = ObjectHead.ib`
 	}
 }
 
+func TestModelViewerObjectBufferRejectsParentDirectoryTraversal(t *testing.T) {
+	dir := t.TempDir()
+	outsideName := filepath.Base(dir) + "-sensitive.buf"
+	outside := filepath.Join(filepath.Dir(dir), outsideName)
+	if err := os.WriteFile(outside, make([]byte, 3*44), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(outside) })
+	cache := newModelViewerBufferCache()
+	position := modelViewerResource{
+		Name:     "ResourceStovePosition",
+		Filename: `..\` + outsideName,
+		Stride:   44,
+	}
+	if _, ok := readModelViewerObjectBuffer(dir, position, cache); ok {
+		t.Fatal("inline object buffer read a file outside the mod folder")
+	}
+	if _, _, ok := readModelViewerPackedObjectBuffer(dir, position, cache, true); ok {
+		t.Fatal("packed object buffer read a file outside the mod folder")
+	}
+
+	if err := os.MkdirAll(filepath.Join(dir, "Resources"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	inside := make([]byte, 3*44)
+	if err := os.WriteFile(filepath.Join(dir, "Resources", "Stove.buf"), inside, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	position.Filename = `Resources\Stove.buf`
+	raw, ok := readModelViewerObjectBuffer(dir, position, cache)
+	if !ok || len(raw) != len(inside) {
+		t.Fatalf("in-mod buffer rejected: ok=%t len=%d", ok, len(raw))
+	}
+}
+
 func TestModelViewerStaticStride24ObjectKeepsTrailingUV0(t *testing.T) {
 	dir := t.TempDir()
 	position := make([]byte, 3*modelViewerPackedObjectStride24)

--- a/internal/tools/model_viewer_packed_dual_quaternion_test.go
+++ b/internal/tools/model_viewer_packed_dual_quaternion_test.go
@@ -417,6 +417,7 @@ func TestPackedDualQuaternion28LegacyBody(t *testing.T) {
 		resources,
 		cache,
 		packed,
+		nil,
 	)
 	buffers, _, err := loadModelViewerDrawVertexBuffers(dir, source, cache)
 	if err != nil || len(buffers.layout.Elements) < 3 || buffers.layout.Elements[2].AlignedByteOffset != 20 {
@@ -506,6 +507,7 @@ func TestPackedDualQuaternion28ObjectBody(t *testing.T) {
 		resources,
 		cache,
 		packed,
+		nil,
 	)
 	buffers, _, err := loadModelViewerDrawVertexBuffers(dir, source, cache)
 	if err != nil || len(buffers.layout.Elements) < 3 || buffers.layout.Elements[2].AlignedByteOffset != 20 {
@@ -630,6 +632,7 @@ func TestPackedDualQuaternionDetection(t *testing.T) {
 				resources,
 				cache,
 				packed,
+				nil,
 			)
 			buffers, _, err := loadModelViewerDrawVertexBuffers(dir, source, cache)
 			if err != nil || len(buffers.layout.Elements) < 3 || buffers.layout.Elements[2].AlignedByteOffset != 16 {
@@ -732,6 +735,7 @@ func TestPackedDualQuaternionUVStreamEvidence(t *testing.T) {
 				resources,
 				cache,
 				collectModelViewerPackedObjectResources(dir, dir, sections),
+				nil,
 			)
 			buffers, ok, err := loadModelViewerDrawVertexBuffers(dir, source, cache)
 			if err != nil || !ok {

--- a/internal/tools/model_viewer_resource_alias.go
+++ b/internal/tools/model_viewer_resource_alias.go
@@ -33,7 +33,7 @@ func resolveModelViewerEffectiveResources(
 	output := append([]modelViewerResource(nil), resources...)
 	for index := range output {
 		resource := output[index]
-		if resource.Filename != "" || parseModelViewerMihoyoResourceName(resource.Name) == nil {
+		if resource.Filename != "" {
 			continue
 		}
 		resolved, ok := aliases.resolve(resource.Name)

--- a/internal/tools/model_viewer_scan.go
+++ b/internal/tools/model_viewer_scan.go
@@ -336,6 +336,7 @@ type modelViewerDrawGeometryKey struct {
 	kind                               string
 	packedTexcoordOffset               int
 	packedTexcoordDeclared             bool
+	inlineTexcoordOffset               int
 	indexCount, startIndex, baseVertex int
 	auto                               bool
 }
@@ -440,8 +441,10 @@ func buildModelViewerDirectScannedMeshesAt(
 	hashPositions, hashTexcoords := collectHashVertexBuffers(sections)
 	componentPositions, componentTexcoords := collectModelViewerComponentBuffers(sections, resourceMap)
 	var packedResources map[string]int
+	var inlineResources map[string]modelViewerInlineObjectLayout
 	if layoutName != "wwmi" {
 		packedResources = collectModelViewerPackedObjectResources(modDir, filepath.Dir(iniPath), sections)
+		inlineResources = collectModelViewerInlineObjectResources(modDir, filepath.Dir(iniPath), sections)
 	}
 	draws := completeModelViewerResolvedDraws(
 		records,
@@ -474,6 +477,7 @@ func buildModelViewerDirectScannedMeshesAt(
 			resources,
 			cache,
 			packedResources,
+			inlineResources,
 		)
 		if source.kind == "" {
 			if source.missingTexcoord && timing != nil {
@@ -487,6 +491,7 @@ func buildModelViewerDirectScannedMeshesAt(
 			ibFormat: ib.Format,
 			kind:     source.kind, packedTexcoordOffset: source.packedTexcoordOffset,
 			packedTexcoordDeclared: source.packedTexcoordDeclared,
+			inlineTexcoordOffset:   source.inlineTexcoordOffset,
 			indexCount:             record.draw.IndexCount, startIndex: record.draw.StartIndex,
 			baseVertex: record.draw.BaseVertex, auto: record.auto,
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for inline object model layouts with embedded diffuse texture coordinates.
  - Added support for 44-byte object vertex records in model-viewer shape animations.
  - Added configurable animation phase-start handling for shape passes.
  - Improved resource alias resolution for resources with non-standard names.

- **Bug Fixes**
  - Preserved inline object tangent data during shape blending.
  - Improved cyclic animation phase wrapping and pose-buffer validation.
  - Improved detection of linked outputs and associated geometry.
  - Prevented object-buffer paths from accessing files outside the mod directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->