### PR TITLE
perf(app): show the window before startup maintenance

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"errors"
 	"os"
+	"sync"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"github.com/wailsapp/wails/v3/pkg/events"
@@ -34,13 +35,19 @@ func Run(assets embed.FS, icon []byte) (runErr error) {
 			},
 		},
 		Assets: application.AssetOptions{
-			Handler: application.AssetFileServerFS(assets),
+			Handler:    application.AssetFileServerFS(assets),
+			Middleware: rt.startup.middleware,
 		},
 		// Closing the last window must not tear down the process. Tray and
 		// background work stay alive; WindowClosing still calls Quit when
 		// runInBackground is off.
 		Windows: windowsApplicationOptions(),
 	})
+	defer rt.startup.stop()
+	if err := rt.configureStartupBindings(); err != nil {
+		return err
+	}
+	app.OnShutdown(rt.startup.stop)
 	// newLockedApplication waits for a relaunch parent, then application.New
 	// acquires Wails' single-instance lock. Keep all database,
 	// local HTTP, watcher, and cleanup startup work after it so a forwarding
@@ -58,6 +65,7 @@ func Run(assets embed.FS, icon []byte) (runErr error) {
 	if _, err := bootRuntime(context.Background(), rt, in, app.SetWindowsBrowserArguments); err != nil {
 		return err
 	}
+	rt.logStartupMilestone("essential-ready")
 	defer func() {
 		runErr = errors.Join(runErr, rt.Close())
 	}()
@@ -147,8 +155,14 @@ func Run(assets embed.FS, icon []byte) (runErr error) {
 	}
 
 	rt.window.Configure(app, rt.setting, rt.log)
+	var windowCreated, windowReady sync.Once
 	app.Window.OnCreate(func(window application.Window) {
+		windowCreated.Do(func() { rt.logStartupMilestone("window-created") })
+		window.OnWindowEvent(events.Common.WindowRuntimeReady, func(*application.WindowEvent) {
+			windowReady.Do(func() { rt.logStartupMilestone("window-runtime-ready") })
+		})
 		window.RegisterHook(events.Common.WindowClosing, func(*application.WindowEvent) {
+			rt.startup.cancelWindow(window.ID(), window.Name())
 			rt.tools.CleanupModelViewerWindow(window.ID())
 		})
 	})
@@ -171,6 +185,7 @@ func Run(assets embed.FS, icon []byte) (runErr error) {
 		return err
 	}
 	app.Event.OnApplicationEvent(events.Common.ApplicationStarted, func(*application.ApplicationEvent) {
+		rt.startup.start(rt.runStartupWork)
 		launches.Start(application.SecondInstanceData{Args: os.Args, WorkingDir: in.Cwd},
 			newLaunchHandler(viewers.Open, func() { newWindow(app, rt.window) }, rt.window.HandleArguments))
 	})

--- a/internal/app/localhttp.go
+++ b/internal/app/localhttp.go
@@ -26,6 +26,11 @@ func (rt *runtime) handleLocalHTTPMessage(ctx context.Context, payload []byte) (
 	if err := cbor.Unmarshal(payload, &message); err != nil {
 		return "invalid data", fmt.Errorf("decode extension message: %w", err)
 	}
+	if message.Type == "live" || message.Type == "hui" {
+		if err := rt.startup.wait(ctx); err != nil {
+			return "download error", err
+		}
+	}
 	switch message.Type {
 	case "live":
 		return rt.handleLiveDownload(ctx, message)

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -19,6 +19,7 @@ import (
 )
 
 type runtime struct {
+	startup         *startupWork
 	proxyRelay      *infra.ProxyRelay
 	appData         *appdata.Store
 	log             *infra.Log
@@ -117,6 +118,7 @@ func newRuntime() *runtime {
 	updaterService := infra.NewUpdater()
 	settings.UseHooks(runtimeSettingHooks(log, transferService, updaterService, nil, window, nil, eventEmit, nil))
 	rt := &runtime{
+		startup:  newStartupWork(),
 		log:      log,
 		store:    infra.NewStore(),
 		http:     httpClient,
@@ -228,6 +230,20 @@ func (rt *runtime) services() []application.Service {
 		newLoggedService(rt, "Updater", rt.updater),
 		newLoggedService(rt, "Window", rt.window),
 		newLoggedService(rt, "XXMI", rt.xxmi),
+	}
+}
+
+// fileMutatingServices are Wails services whose bindings wait for startup
+// maintenance. Add a service here when it writes user files.
+func (rt *runtime) fileMutatingServices() []application.Service {
+	return []application.Service{
+		application.NewService(rt.drive),
+		application.NewService(rt.fs),
+		application.NewService(rt.menuMaker),
+		application.NewService(rt.mod),
+		application.NewService(rt.tools),
+		application.NewService(rt.transfer),
+		application.NewService(rt.xxmi),
 	}
 }
 

--- a/internal/app/runtime_lifecycle.go
+++ b/internal/app/runtime_lifecycle.go
@@ -149,66 +149,12 @@ func (rt *runtime) Init(ctx context.Context, dbPath string, configureBrowserArgu
 	if rt.mod != nil {
 		rt.mod.UseClient(store.DB)
 		rt.mod.UseSettings(rt.setting)
-		if err := rt.mod.StartCompression(ctx); err != nil {
-			_ = infra.ReportError(
-				rt.log,
-				err,
-				"Mod:compression:start",
-				infra.Diagnostic{
-					Severity:  infra.DiagnosticError,
-					Operation: "Mod:compression:start",
-					Stage:     "background",
-				},
-			)
-		}
 	}
 	if rt.native != nil {
 		rt.native.StartFocusTracking()
 	}
 	if rt.tools != nil {
 		rt.tools.UseClient(store.DB)
-		if err := rt.tools.CleanupStaleModelViewerDirs(); err != nil {
-			_ = infra.ReportError(
-				rt.log,
-				err,
-				"StaticGlb.cleanupStaleViewerTempDirs",
-				infra.Diagnostic{
-					Severity:  infra.DiagnosticWarn,
-					Operation: "StaticGlb.cleanupStaleViewerTempDirs",
-					Stage:     "background",
-				},
-			)
-		}
-		if err := rt.tools.CleanupStaleD3DBuilds(ctx); err != nil {
-			_ = infra.ReportError(
-				rt.log,
-				err,
-				"4001Fixer:cleanupStaleBuildDirs",
-				infra.Diagnostic{
-					Severity:  infra.DiagnosticWarn,
-					Operation: "4001Fixer:cleanupStaleBuildDirs",
-					Stage:     "background",
-				},
-			)
-		}
-		rt.tools.Start4001ReleasePrefetch()
-		if err := rt.tools.RecoverBisects(ctx); err != nil {
-			_ = infra.ReportError(
-				rt.log,
-				err,
-				"ModBisect",
-				infra.Diagnostic{Severity: infra.DiagnosticError, Operation: "ModBisect", Stage: "background"},
-			)
-		}
-		rt.tools.StartWuwaAutoUpdateCheck()
-		if err := rt.tools.StartPersistWatcher(ctx); err != nil {
-			_ = infra.ReportError(
-				rt.log,
-				err,
-				"TogglePersist",
-				infra.Diagnostic{Severity: infra.DiagnosticError, Operation: "TogglePersist", Stage: "background"},
-			)
-		}
 	}
 	return nil
 }
@@ -217,6 +163,7 @@ func (rt *runtime) Close() error {
 	if rt == nil {
 		return nil
 	}
+	rt.startup.stop()
 	if rt.gameBananaLogin != nil {
 		rt.gameBananaLogin.Close()
 	}

--- a/internal/app/startup.go
+++ b/internal/app/startup.go
@@ -1,0 +1,352 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+
+	"nahida.live/desktop/internal/infra"
+)
+
+// Wails objectNames.Call / objectNames.CancelCall. CancelCall is unexported in
+// the v3 beta.20 application package.
+const (
+	wailsCallObject       = 0
+	wailsCancelCallObject = 10
+	maxRuntimeBodyBytes   = 64 << 20
+)
+
+// startupWork owns deferred maintenance and the IPC requests that depend on it.
+// The gate is at the application boundary so internal recovery calls do not
+// deadlock on their own readiness.
+type startupWork struct {
+	ctx          context.Context
+	cancel       context.CancelFunc
+	once         sync.Once
+	done         chan struct{}
+	bindings     *application.Bindings
+	gatedIDs     map[uint32]struct{}
+	gatedNames   map[string]struct{}
+	mu           sync.Mutex
+	pending      map[string]*startupCall
+	launched     time.Time
+	prefetchDone <-chan struct{}
+}
+
+type startupCall struct {
+	cancel     context.CancelFunc
+	windowID   string
+	windowName string
+}
+
+type startupStep struct {
+	name string
+	run  func(context.Context) error
+}
+
+func newStartupWork() *startupWork {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &startupWork{
+		ctx:      ctx,
+		cancel:   cancel,
+		done:     make(chan struct{}),
+		pending:  make(map[string]*startupCall),
+		launched: time.Now(),
+	}
+}
+
+func (s *startupWork) start(work func(context.Context)) {
+	s.once.Do(func() {
+		go func() {
+			defer close(s.done)
+			if s.ctx.Err() == nil {
+				work(s.ctx)
+			}
+		}()
+	})
+}
+
+func (s *startupWork) stop() {
+	if s == nil {
+		return
+	}
+	s.cancel()
+
+	// Also finish a runtime that failed before ApplicationStarted.
+	s.once.Do(func() { close(s.done) })
+	<-s.done
+	if s.prefetchDone != nil {
+		<-s.prefetchDone
+	}
+}
+
+func (s *startupWork) wait(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	case <-s.done:
+		return errors.Join(ctx.Err(), s.ctx.Err())
+	}
+}
+
+func (s *startupWork) cancelWindow(id uint, name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, call := range s.pending {
+		if call.windowID == strconv.FormatUint(uint64(id), 10) || call.windowID == "" && call.windowName == name {
+			call.cancel()
+		}
+	}
+}
+
+func (rt *runtime) configureStartupBindings() error {
+	s := rt.startup
+	s.bindings = application.NewBindings(nil, nil)
+	s.gatedIDs = make(map[uint32]struct{})
+	s.gatedNames = make(map[string]struct{})
+	for _, service := range rt.fileMutatingServices() {
+		if err := s.bindings.Add(service); err != nil {
+			return err
+		}
+		s.gateMethods(service.Instance(), nil)
+	}
+	if err := s.bindings.Add(application.NewService(rt.setting)); err != nil {
+		return err
+	}
+	if err := s.bindings.Add(application.NewService(rt.shell)); err != nil {
+		return err
+	}
+	s.gateMethods(rt.setting, isSettingWrite)
+	s.gateMethods(rt.shell, func(name string) bool { return name == "Trash" })
+	return nil
+}
+
+func (s *startupWork) gateMethods(instance any, keep func(string) bool) {
+	ptr := reflect.TypeOf(instance)
+	if ptr == nil || ptr.Kind() != reflect.Pointer {
+		return
+	}
+	named := ptr.Elem()
+	for i := range ptr.NumMethod() {
+		name := ptr.Method(i).Name
+		if keep != nil && !keep(name) {
+			continue
+		}
+		method := s.bindings.Get(&application.CallOptions{
+			MethodName: named.PkgPath() + "." + named.Name() + "." + name,
+		})
+		if method == nil {
+			continue
+		}
+		s.gatedNames[method.FQN] = struct{}{}
+		s.gatedIDs[method.ID] = struct{}{}
+	}
+}
+
+func isSettingWrite(name string) bool {
+	return strings.HasPrefix(name, "Set") || name == "ClearImageCache" || name == "AdvancedSet"
+}
+
+func (s *startupWork) needsWait(options application.CallOptions) bool {
+	if s.gatedIDs == nil {
+		return true
+	}
+	if options.MethodName != "" {
+		_, ok := s.gatedNames[options.MethodName]
+		return ok
+	}
+	_, ok := s.gatedIDs[options.MethodID]
+	return ok
+}
+
+func (s *startupWork) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/wails/runtime" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		select {
+		case <-s.done:
+			if s.ctx.Err() == nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+		default:
+		}
+
+		// Chunks are assembled below this middleware, and the Windows runtime
+		// always sends a JSON envelope. Unclassifiable submissions fail closed.
+		if r.Header.Get("x-wails-chunk-id") != "" {
+			http.Error(
+				w,
+				"Application maintenance is still running; retry after startup",
+				http.StatusServiceUnavailable,
+			)
+			return
+		}
+		body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxRuntimeBodyBytes))
+		if err != nil {
+			http.Error(w, "Unable to read runtime request", http.StatusRequestEntityTooLarge)
+			return
+		}
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		var request struct {
+			Object *int `json:"object"`
+			Method *int `json:"method"`
+			Args   struct {
+				application.CallOptions
+				CallID string `json:"call-id"`
+			} `json:"args"`
+		}
+		if (len(body) == 0 && r.URL.RawQuery != "") ||
+			json.Unmarshal(body, &request) != nil || request.Object == nil || request.Method == nil {
+			http.Error(
+				w,
+				"Application maintenance is still running; retry after startup",
+				http.StatusServiceUnavailable,
+			)
+			return
+		}
+
+		if *request.Object == wailsCancelCallObject {
+			s.mu.Lock()
+			call := s.pending[request.Args.CallID]
+			if call != nil {
+				call.cancel()
+			}
+			s.mu.Unlock()
+			if call != nil {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte("null"))
+				return
+			}
+		}
+		if *request.Object != wailsCallObject || *request.Method != application.CallBinding ||
+			request.Args.CallID == "" || !s.needsWait(request.Args.CallOptions) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		call := &startupCall{
+			cancel:     cancel,
+			windowID:   r.Header.Get("x-wails-window-id"),
+			windowName: r.Header.Get("x-wails-window-name"),
+		}
+		s.mu.Lock()
+		if s.pending[request.Args.CallID] != nil {
+			s.mu.Unlock()
+			http.Error(w, "Ambiguous runtime call ID", http.StatusUnprocessableEntity)
+			return
+		}
+		s.pending[request.Args.CallID] = call
+		s.mu.Unlock()
+		err = s.wait(ctx)
+		s.mu.Lock()
+		delete(s.pending, request.Args.CallID)
+		s.mu.Unlock()
+		if err != nil || ctx.Err() != nil {
+			http.Error(w, "Startup request cancelled", http.StatusServiceUnavailable)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (rt *runtime) logStartupMilestone(stage string) {
+	fields := map[string]any{"stage": stage, "sinceLaunchMs": time.Since(rt.startup.launched).Milliseconds()}
+	if time.Since(rt.startup.launched) >= time.Second {
+		rt.log.Warn(fields, "Startup")
+	} else {
+		rt.log.Info(fields, "Startup")
+	}
+}
+
+func (rt *runtime) runStartupWork(ctx context.Context) {
+	rt.runStartupStepsParallel(ctx, []startupStep{
+		{"zzmi-staging", rt.tools.CleanupZZMIAbandonedStaging},
+		{"model-viewer-temp", rt.tools.CleanupStaleModelViewerDirs},
+		{"d3d-builds", rt.tools.CleanupStaleD3DBuilds},
+	})
+	rt.runStartupSteps(ctx, []startupStep{
+		{"bisect-recovery", rt.tools.RecoverBisects},
+		{"compression", rt.mod.StartCompression},
+		{"persist-watcher", rt.tools.StartPersistWatcher},
+	})
+	if ctx.Err() != nil {
+		return
+	}
+
+	// Network warmup does not hold the readiness gate, but still belongs to
+	// startup shutdown so it cannot access the store after it is closed.
+	done := make(chan struct{})
+	rt.startup.prefetchDone = done
+	go func() {
+		defer close(done)
+		prefetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		if err := rt.tools.FourThousandOneFixerUpdateReleases(prefetchCtx); err != nil && ctx.Err() == nil {
+			_ = infra.ReportError(rt.log, err, "Startup", infra.Diagnostic{
+				Severity: infra.DiagnosticWarn, Operation: "maintenance", Stage: "release-prefetch",
+			})
+		}
+	}()
+	rt.tools.StartWuwaAutoUpdateCheck()
+}
+
+func (rt *runtime) runStartupSteps(ctx context.Context, steps []startupStep) {
+	for _, step := range steps {
+		rt.runStartupStep(ctx, step)
+	}
+}
+
+func (rt *runtime) runStartupStepsParallel(ctx context.Context, steps []startupStep) {
+	if ctx.Err() != nil {
+		return
+	}
+	var wg sync.WaitGroup
+	for _, step := range steps {
+		wg.Add(1)
+		go func(step startupStep) {
+			defer wg.Done()
+			rt.runStartupStep(ctx, step)
+		}(step)
+	}
+	wg.Wait()
+}
+
+func (rt *runtime) runStartupStep(ctx context.Context, step startupStep) {
+	if ctx.Err() != nil {
+		return
+	}
+	started := time.Now()
+	err := step.run(ctx)
+	elapsed := time.Since(started).Milliseconds()
+	if err != nil && ctx.Err() == nil {
+		_ = infra.ReportError(rt.log, err, "Startup", infra.Diagnostic{
+			Operation: "maintenance", Stage: step.name, Fields: map[string]any{"elapsedMs": elapsed},
+		})
+	}
+	fields := map[string]any{"stage": step.name, "elapsedMs": elapsed}
+	if elapsed >= 1000 {
+		rt.log.Warn(fields, "Startup")
+	} else {
+		rt.log.Info(fields, "Startup")
+	}
+}

--- a/internal/app/startup.go
+++ b/internal/app/startup.go
@@ -38,9 +38,15 @@ type startupWork struct {
 	gatedIDs     map[uint32]struct{}
 	gatedNames   map[string]struct{}
 	mu           sync.Mutex
-	pending      map[string]*startupCall
+	pending      map[startupCallKey]*startupCall
+	heldBytes    int64
 	launched     time.Time
 	prefetchDone <-chan struct{}
+}
+
+type startupCallKey struct {
+	window string
+	callID string
 }
 
 type startupCall struct {
@@ -60,7 +66,7 @@ func newStartupWork() *startupWork {
 		ctx:      ctx,
 		cancel:   cancel,
 		done:     make(chan struct{}),
-		pending:  make(map[string]*startupCall),
+		pending:  make(map[startupCallKey]*startupCall),
 		launched: time.Now(),
 	}
 }
@@ -174,6 +180,57 @@ func (s *startupWork) needsWait(options application.CallOptions) bool {
 	return ok
 }
 
+func requestWindowKey(r *http.Request) string {
+	if id := r.Header.Get("x-wails-window-id"); id != "" {
+		return "id:" + id
+	}
+	return "name:" + r.Header.Get("x-wails-window-name")
+}
+
+func requestCallKey(r *http.Request, callID string) startupCallKey {
+	return startupCallKey{window: requestWindowKey(r), callID: callID}
+}
+
+func (s *startupWork) holdRuntimeBody(n int64) (int64, bool) {
+	if n < 0 || n > maxRuntimeBodyBytes {
+		n = maxRuntimeBodyBytes
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if n == 0 {
+		return 0, true
+	}
+	if s.heldBytes+n > maxRuntimeBodyBytes {
+		return 0, false
+	}
+	s.heldBytes += n
+	return n, true
+}
+
+func (s *startupWork) releaseRuntimeBody(n int64) {
+	s.replaceRuntimeBody(n, 0)
+}
+
+func (s *startupWork) replaceRuntimeBody(from, to int64) bool {
+	if to < 0 {
+		to = 0
+	}
+	if to > maxRuntimeBodyBytes {
+		to = maxRuntimeBodyBytes
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	next := s.heldBytes - from + to
+	if next > maxRuntimeBodyBytes {
+		return false
+	}
+	if next < 0 {
+		next = 0
+	}
+	s.heldBytes = next
+	return true
+}
+
 func (s *startupWork) middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/wails/runtime" {
@@ -199,10 +256,33 @@ func (s *startupWork) middleware(next http.Handler) http.Handler {
 			)
 			return
 		}
+
+		held, ok := s.holdRuntimeBody(r.ContentLength)
+		if !ok {
+			http.Error(
+				w,
+				"Application maintenance is still running; retry after startup",
+				http.StatusServiceUnavailable,
+			)
+			return
+		}
+		defer func() { s.releaseRuntimeBody(held) }()
+
 		body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxRuntimeBodyBytes))
 		if err != nil {
 			http.Error(w, "Unable to read runtime request", http.StatusRequestEntityTooLarge)
 			return
+		}
+		if actual := int64(len(body)); actual != held {
+			if !s.replaceRuntimeBody(held, actual) {
+				http.Error(
+					w,
+					"Application maintenance is still running; retry after startup",
+					http.StatusServiceUnavailable,
+				)
+				return
+			}
+			held = actual
 		}
 		r.Body = io.NopCloser(bytes.NewReader(body))
 		var request struct {
@@ -223,9 +303,10 @@ func (s *startupWork) middleware(next http.Handler) http.Handler {
 			return
 		}
 
+		key := requestCallKey(r, request.Args.CallID)
 		if *request.Object == wailsCancelCallObject {
 			s.mu.Lock()
-			call := s.pending[request.Args.CallID]
+			call := s.pending[key]
 			if call != nil {
 				call.cancel()
 			}
@@ -250,16 +331,16 @@ func (s *startupWork) middleware(next http.Handler) http.Handler {
 			windowName: r.Header.Get("x-wails-window-name"),
 		}
 		s.mu.Lock()
-		if s.pending[request.Args.CallID] != nil {
+		if s.pending[key] != nil {
 			s.mu.Unlock()
 			http.Error(w, "Ambiguous runtime call ID", http.StatusUnprocessableEntity)
 			return
 		}
-		s.pending[request.Args.CallID] = call
+		s.pending[key] = call
 		s.mu.Unlock()
 		err = s.wait(ctx)
 		s.mu.Lock()
-		delete(s.pending, request.Args.CallID)
+		delete(s.pending, key)
 		s.mu.Unlock()
 		if err != nil || ctx.Err() != nil {
 			http.Error(w, "Startup request cancelled", http.StatusServiceUnavailable)

--- a/internal/app/startup.go
+++ b/internal/app/startup.go
@@ -367,7 +367,7 @@ func (rt *runtime) runStartupWork(ctx context.Context) {
 	})
 	rt.runStartupSteps(ctx, []startupStep{
 		{"bisect-recovery", rt.tools.RecoverBisects},
-		{"compression", rt.mod.StartCompression},
+		{"compression", rt.runCompressionMaintenance},
 		{"persist-watcher", rt.tools.StartPersistWatcher},
 	})
 	if ctx.Err() != nil {
@@ -389,6 +389,16 @@ func (rt *runtime) runStartupWork(ctx context.Context) {
 		}
 	}()
 	rt.tools.StartWuwaAutoUpdateCheck()
+}
+
+// runCompressionMaintenance starts continuous reconciliation and waits for the
+// initial pass, so the readiness gate cannot open while mod files are being
+// rewritten.
+func (rt *runtime) runCompressionMaintenance(ctx context.Context) error {
+	if err := rt.mod.StartCompression(ctx); err != nil {
+		return err
+	}
+	return rt.mod.WaitCompressionPass(ctx)
 }
 
 func (rt *runtime) runStartupSteps(ctx context.Context, steps []startupStep) {

--- a/internal/app/startup_test.go
+++ b/internal/app/startup_test.go
@@ -26,22 +26,23 @@ func TestStartupWorkStopsBeforeReleasingDependencies(t *testing.T) {
 	s := newStartupWork()
 	started := make(chan struct{})
 	finish := make(chan struct{})
+	t.Cleanup(func() { closeFinish(finish) })
 	s.start(func(ctx context.Context) {
 		close(started)
 		<-ctx.Done()
 		<-finish
 	})
-	<-started
+	waitClosed(t, started, finish, "startup work did not start")
 	stopped := make(chan struct{})
 	go func() { s.stop(); close(stopped) }()
-	<-s.ctx.Done()
+	waitClosed(t, s.ctx.Done(), finish, "shutdown did not cancel maintenance")
 	select {
 	case <-stopped:
 		t.Fatal("shutdown returned while maintenance still owned dependencies")
 	default:
 	}
-	close(finish)
-	<-stopped
+	closeFinish(finish)
+	waitClosed(t, stopped, nil, "shutdown did not finish after maintenance released dependencies")
 	s.stop()
 	if !errors.Is(s.wait(context.Background()), context.Canceled) {
 		t.Fatal("stopped startup released a waiting operation")
@@ -60,6 +61,7 @@ func TestStartupPrefetchDoesNotHoldReadinessButIsJoinedOnStop(t *testing.T) {
 	s := newStartupWork()
 	finish := make(chan struct{})
 	prefetchDone := make(chan struct{})
+	t.Cleanup(func() { closeFinish(finish) })
 	s.start(func(ctx context.Context) {
 		s.prefetchDone = prefetchDone
 		go func() {
@@ -68,19 +70,17 @@ func TestStartupPrefetchDoesNotHoldReadinessButIsJoinedOnStop(t *testing.T) {
 			<-finish
 		}()
 	})
-	if err := s.wait(context.Background()); err != nil {
-		t.Fatal(err)
-	}
+	waitStartupReady(t, s, finish)
 	stopped := make(chan struct{})
 	go func() { s.stop(); close(stopped) }()
-	<-s.ctx.Done()
+	waitClosed(t, s.ctx.Done(), finish, "shutdown did not cancel prefetch")
 	select {
 	case <-stopped:
 		t.Fatal("shutdown did not join release prefetch")
 	default:
 	}
-	close(finish)
-	<-stopped
+	closeFinish(finish)
+	waitClosed(t, stopped, nil, "shutdown did not finish after prefetch released dependencies")
 }
 
 func TestRuntimeInitDefersBisectRecovery(t *testing.T) {
@@ -189,7 +189,7 @@ func TestStartupMiddlewareProtectsFileServices(t *testing.T) {
 		handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/wails/runtime", strings.NewReader(body)))
 		close(done)
 	}()
-	waitStartupPending(t, rt.startup, "startup-toggle")
+	waitStartupPending(t, rt.startup, "", "startup-toggle")
 	if calls.Load() != 0 {
 		t.Fatal("file operation ran before maintenance")
 	}
@@ -234,15 +234,14 @@ func TestStartupMiddlewareCancellationDoesNotRunQueuedActions(t *testing.T) {
 			response := httptest.NewRecorder()
 			done := make(chan struct{})
 			go func() { handler.ServeHTTP(response, request); close(done) }()
-			waitStartupPending(t, rt.startup, "cancel-me")
+			waitStartupPending(t, rt.startup, "7", "cancel-me")
 			switch kind {
 			case "call":
-				handler.ServeHTTP(
-					httptest.NewRecorder(),
-					httptest.NewRequest(http.MethodPost, "/wails/runtime", strings.NewReader(
-						`{"object":10,"method":0,"args":{"call-id":"cancel-me"}}`,
-					)),
-				)
+				cancel := httptest.NewRequest(http.MethodPost, "/wails/runtime", strings.NewReader(
+					`{"object":10,"method":0,"args":{"call-id":"cancel-me"}}`,
+				))
+				cancel.Header.Set("x-wails-window-id", "7")
+				handler.ServeHTTP(httptest.NewRecorder(), cancel)
 			case "window":
 				rt.startup.cancelWindow(7, "main")
 			case "request":
@@ -263,12 +262,21 @@ func TestStartupMiddlewareCancellationDoesNotRunQueuedActions(t *testing.T) {
 	}
 }
 
-func waitStartupPending(t *testing.T, s *startupWork, id string) {
+func windowRequest(windowID string) *http.Request {
+	request := httptest.NewRequest(http.MethodPost, "/wails/runtime", nil)
+	if windowID != "" {
+		request.Header.Set("x-wails-window-id", windowID)
+	}
+	return request
+}
+
+func waitStartupPending(t *testing.T, s *startupWork, window, id string) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
+	key := requestCallKey(windowRequest(window), id)
 	for time.Now().Before(deadline) {
 		s.mu.Lock()
-		pending := s.pending[id] != nil
+		pending := s.pending[key] != nil
 		s.mu.Unlock()
 		if pending {
 			return
@@ -276,6 +284,196 @@ func waitStartupPending(t *testing.T, s *startupWork, id string) {
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatal("request did not enter startup gate")
+}
+
+func waitClosed(t *testing.T, ch <-chan struct{}, finish chan struct{}, msg string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		closeFinish(finish)
+		t.Fatal(msg)
+	}
+}
+
+func waitStartupReady(t *testing.T, s *startupWork, finish chan struct{}) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := s.wait(ctx); err != nil {
+		closeFinish(finish)
+		t.Fatal(err)
+	}
+}
+
+func closeFinish(ch chan struct{}) {
+	if ch == nil {
+		return
+	}
+	select {
+	case <-ch:
+	default:
+		close(ch)
+	}
+}
+
+func TestStartupMiddlewareRejectsWhenBodyBudgetExhausted(t *testing.T) {
+	t.Parallel()
+	s := newStartupWork()
+	t.Cleanup(s.stop)
+	var calls int
+	handler := s.middleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { calls++ }))
+	s.mu.Lock()
+	s.heldBytes = maxRuntimeBodyBytes
+	s.mu.Unlock()
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/wails/runtime", strings.NewReader(
+		`{"object":6,"method":0,"args":{}}`,
+	)))
+	if calls != 0 || response.Code != http.StatusServiceUnavailable {
+		t.Fatal("request ran after startup body budget was exhausted")
+	}
+	s.mu.Lock()
+	s.heldBytes = 0
+	s.mu.Unlock()
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/wails/runtime", strings.NewReader(
+		`{"object":6,"method":0,"args":{}}`,
+	)))
+	if calls != 1 {
+		t.Fatal("request stayed blocked after startup body budget was released")
+	}
+}
+
+func TestStartupMiddlewareScopesCallIDsByWindow(t *testing.T) {
+	application.New(application.Options{Name: "startup-call-id-scope-test"})
+	rt := newRuntime()
+	t.Cleanup(rt.startup.stop)
+	if err := rt.configureStartupBindings(); err != nil {
+		t.Fatal(err)
+	}
+	var calls atomic.Int32
+	handler := rt.startup.middleware(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) { calls.Add(1) }),
+	)
+	startGated := func(windowID, callID string) (<-chan struct{}, *httptest.ResponseRecorder) {
+		request := httptest.NewRequest(http.MethodPost, "/wails/runtime", strings.NewReader(
+			`{"object":0,"method":0,"args":{"methodName":"nahida.live/desktop/internal/mod.Mod.Toggle","call-id":"`+
+				callID+`","args":["mod"]}}`,
+		))
+		request.Header.Set("x-wails-window-id", windowID)
+		response := httptest.NewRecorder()
+		done := make(chan struct{})
+		go func() { handler.ServeHTTP(response, request); close(done) }()
+		waitStartupPending(t, rt.startup, windowID, callID)
+		return done, response
+	}
+	doneA, responseA := startGated("1", "shared")
+	doneB, _ := startGated("2", "shared")
+
+	cancel := httptest.NewRequest(http.MethodPost, "/wails/runtime", strings.NewReader(
+		`{"object":10,"method":0,"args":{"call-id":"shared"}}`,
+	))
+	cancel.Header.Set("x-wails-window-id", "1")
+	handler.ServeHTTP(httptest.NewRecorder(), cancel)
+	select {
+	case <-doneA:
+	case <-time.After(2 * time.Second):
+		t.Fatal("same-window cancel did not release the queued call")
+	}
+	if responseA.Code != http.StatusServiceUnavailable {
+		t.Fatal("cancelled call reached the service")
+	}
+	rt.startup.mu.Lock()
+	otherPending := rt.startup.pending[requestCallKey(windowRequest("2"), "shared")] != nil
+	rt.startup.mu.Unlock()
+	if !otherPending {
+		t.Fatal("cancel from another window released the queued call")
+	}
+
+	rt.startup.start(func(context.Context) {})
+	select {
+	case <-doneB:
+	case <-time.After(2 * time.Second):
+		t.Fatal("other window's call was not released after maintenance")
+	}
+	if calls.Load() != 1 {
+		t.Fatal("expected only the uncancelled window's call to run")
+	}
+}
+
+func TestStartupMiddlewareWindowIDAndNameDoNotShareCallKeys(t *testing.T) {
+	application.New(application.Options{Name: "startup-call-id-namespace-test"})
+	rt := newRuntime()
+	t.Cleanup(rt.startup.stop)
+	if err := rt.configureStartupBindings(); err != nil {
+		t.Fatal(err)
+	}
+	var calls atomic.Int32
+	handler := rt.startup.middleware(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) { calls.Add(1) }),
+	)
+	startGated := func(setHeader func(*http.Request), window, callID string) <-chan struct{} {
+		request := httptest.NewRequest(http.MethodPost, "/wails/runtime", strings.NewReader(
+			`{"object":0,"method":0,"args":{"methodName":"nahida.live/desktop/internal/mod.Mod.Toggle","call-id":"`+
+				callID+`","args":["mod"]}}`,
+		))
+		setHeader(request)
+		done := make(chan struct{})
+		go func() { handler.ServeHTTP(httptest.NewRecorder(), request); close(done) }()
+		waitStartupPending(t, rt.startup, window, callID)
+		return done
+	}
+	doneID := startGated(func(r *http.Request) { r.Header.Set("x-wails-window-id", "1") }, "1", "shared")
+	named := httptest.NewRequest(http.MethodPost, "/wails/runtime", strings.NewReader(
+		`{"object":0,"method":0,"args":{"methodName":"nahida.live/desktop/internal/mod.Mod.Toggle","call-id":"shared","args":["mod"]}}`,
+	))
+	named.Header.Set("x-wails-window-name", "1")
+	doneName := make(chan struct{})
+	go func() { handler.ServeHTTP(httptest.NewRecorder(), named); close(doneName) }()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		rt.startup.mu.Lock()
+		pending := rt.startup.pending[requestCallKey(named, "shared")] != nil
+		rt.startup.mu.Unlock()
+		if pending {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	rt.startup.mu.Lock()
+	idPending := rt.startup.pending[requestCallKey(windowRequest("1"), "shared")] != nil
+	namePending := rt.startup.pending[requestCallKey(named, "shared")] != nil
+	rt.startup.mu.Unlock()
+	if !idPending || !namePending {
+		t.Fatal("window ID 1 and window name 1 must not share a call key")
+	}
+
+	cancel := httptest.NewRequest(http.MethodPost, "/wails/runtime", strings.NewReader(
+		`{"object":10,"method":0,"args":{"call-id":"shared"}}`,
+	))
+	cancel.Header.Set("x-wails-window-id", "1")
+	handler.ServeHTTP(httptest.NewRecorder(), cancel)
+	select {
+	case <-doneID:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ID-scoped cancel did not release the ID-keyed call")
+	}
+	rt.startup.mu.Lock()
+	namePending = rt.startup.pending[requestCallKey(named, "shared")] != nil
+	rt.startup.mu.Unlock()
+	if !namePending {
+		t.Fatal("cancelling window ID 1 cancelled a call keyed by window name 1")
+	}
+
+	rt.startup.start(func(context.Context) {})
+	select {
+	case <-doneName:
+	case <-time.After(2 * time.Second):
+		t.Fatal("name-keyed call was not released after maintenance")
+	}
+	if calls.Load() != 1 {
+		t.Fatal("expected only the name-keyed call to run")
+	}
 }
 
 func TestStartupMiddlewareDoesNotForwardUninspectableSubmissions(t *testing.T) {

--- a/internal/app/startup_test.go
+++ b/internal/app/startup_test.go
@@ -1,0 +1,329 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+
+	"nahida.live/desktop/internal/db"
+	"nahida.live/desktop/internal/infra"
+)
+
+func TestStartupWorkStopsBeforeReleasingDependencies(t *testing.T) {
+	t.Parallel()
+	s := newStartupWork()
+	started := make(chan struct{})
+	finish := make(chan struct{})
+	s.start(func(ctx context.Context) {
+		close(started)
+		<-ctx.Done()
+		<-finish
+	})
+	<-started
+	stopped := make(chan struct{})
+	go func() { s.stop(); close(stopped) }()
+	<-s.ctx.Done()
+	select {
+	case <-stopped:
+		t.Fatal("shutdown returned while maintenance still owned dependencies")
+	default:
+	}
+	close(finish)
+	<-stopped
+	s.stop()
+	if !errors.Is(s.wait(context.Background()), context.Canceled) {
+		t.Fatal("stopped startup released a waiting operation")
+	}
+}
+
+func TestStartupWorkCanStopBeforeApplicationStarted(t *testing.T) {
+	t.Parallel()
+	s := newStartupWork()
+	s.stop()
+	s.start(func(context.Context) { t.Error("maintenance ran after startup was abandoned") })
+}
+
+func TestStartupPrefetchDoesNotHoldReadinessButIsJoinedOnStop(t *testing.T) {
+	t.Parallel()
+	s := newStartupWork()
+	finish := make(chan struct{})
+	prefetchDone := make(chan struct{})
+	s.start(func(ctx context.Context) {
+		s.prefetchDone = prefetchDone
+		go func() {
+			defer close(prefetchDone)
+			<-ctx.Done()
+			<-finish
+		}()
+	})
+	if err := s.wait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	stopped := make(chan struct{})
+	go func() { s.stop(); close(stopped) }()
+	<-s.ctx.Done()
+	select {
+	case <-stopped:
+		t.Fatal("shutdown did not join release prefetch")
+	default:
+	}
+	close(finish)
+	<-stopped
+}
+
+func TestRuntimeInitDefersBisectRecovery(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	path := filepath.Join(root, "data.db")
+	store, err := infra.OpenStore(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	modRoot := filepath.Join(root, "mods")
+	if err := os.Mkdir(modRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DB.GamePaths.Insert(
+		context.Background(),
+		db.GamePathRow{Game: "test", ModFolderPath: modRoot},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	original := filepath.Join(modRoot, "mod.ini")
+	disabled := original + ".mod-bisect-disabled"
+	if err := os.WriteFile(disabled, []byte("restore"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rt := newRuntime()
+	t.Cleanup(func() { _ = rt.Close() })
+	if err := rt.Init(context.Background(), path, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(disabled); err != nil {
+		t.Fatal("Init ran recovery before the application could create a window")
+	}
+	rt.startup.start(func(ctx context.Context) {
+		if err := rt.tools.RecoverBisects(ctx); err != nil {
+			t.Error(err)
+		}
+	})
+	if err := rt.startup.wait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if content, err := os.ReadFile(original); err != nil || string(content) != "restore" {
+		t.Fatalf("deferred recovery = %q, %v", content, err)
+	}
+}
+
+func TestStartupMiddlewareProtectsFileServices(t *testing.T) {
+	// Wails' binding registry uses the application singleton; do not parallelise.
+	application.New(application.Options{Name: "startup-binding-test"})
+	rt := newRuntime()
+	t.Cleanup(rt.startup.stop)
+	if err := rt.configureStartupBindings(); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		method string
+		wait   bool
+	}{
+		{"mod.Mod.Toggle", true},
+		{"tools.Tools.BisectStart", true},
+		{"xxmi.XXMI.StartGame", true},
+		{"drive.Drive.StartDownload", true},
+		{"transfer.Transfer.Create", true},
+		{"platform.FS.Mkdir", true},
+		{"platform.Shell.Trash", true},
+		{"setting.Setting.SetPersistToggles", true},
+		{"setting.Setting.Set", true},
+		{"setting.Setting.ClearImageCache", true},
+		{"setting.Setting.Get", false},
+		{"platform.Shell.GetAppStatus", false},
+		{"platform.Shell.OpenExternal", false},
+		{"auth.Auth.GetSession", false},
+		{"app.Window.SyncRoute", false},
+	} {
+		options := application.CallOptions{MethodName: "nahida.live/desktop/internal/" + tc.method}
+		if got := rt.startup.needsWait(options); got != tc.wait {
+			t.Errorf("%s gate = %v, want %v", tc.method, got, tc.wait)
+		}
+		binding := rt.startup.bindings.Get(&options)
+		if binding != nil && rt.startup.needsWait(application.CallOptions{MethodID: binding.ID}) != tc.wait {
+			t.Errorf("numeric ID for %s has a different gate", tc.method)
+		}
+	}
+
+	method := rt.startup.bindings.Get(
+		&application.CallOptions{MethodName: "nahida.live/desktop/internal/mod.Mod.Toggle"},
+	)
+	if method == nil {
+		t.Fatal("missing Mod.Toggle binding")
+	}
+	body := fmt.Sprintf(
+		`{"object":0,"method":0,"args":{"methodID":%d,"call-id":"startup-toggle","args":["mod"]}}`,
+		method.ID,
+	)
+	var calls atomic.Int32
+	handler := rt.startup.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		_, _ = io.Copy(w, r.Body)
+	}))
+	response := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/wails/runtime", strings.NewReader(body)))
+		close(done)
+	}()
+	waitStartupPending(t, rt.startup, "startup-toggle")
+	if calls.Load() != 0 {
+		t.Fatal("file operation ran before maintenance")
+	}
+	// Runtime/window controls and assets cannot be held behind recovery.
+	for _, path := range []string{"/wails/runtime", "/wails/runtime.js", "/"} {
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, path,
+			strings.NewReader(`{"object":6,"method":0,"args":{}}`)))
+	}
+	if calls.Load() != 3 {
+		t.Fatal("window or asset request was blocked")
+	}
+	rt.startup.start(func(context.Context) {})
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("file operation was not released after maintenance")
+	}
+	if response.Body.String() != body || calls.Load() != 4 {
+		t.Fatal("queued request body was not forwarded intact")
+	}
+}
+
+func TestStartupMiddlewareCancellationDoesNotRunQueuedActions(t *testing.T) {
+	application.New(application.Options{Name: "startup-cancel-test"})
+	for _, kind := range []string{"call", "window", "request", "shutdown"} {
+		t.Run(kind, func(t *testing.T) {
+			rt := newRuntime()
+			t.Cleanup(rt.startup.stop)
+			if err := rt.configureStartupBindings(); err != nil {
+				t.Fatal(err)
+			}
+			var calls atomic.Int32
+			handler := rt.startup.middleware(
+				http.HandlerFunc(func(http.ResponseWriter, *http.Request) { calls.Add(1) }),
+			)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			request := httptest.NewRequest(http.MethodPost, "/wails/runtime", strings.NewReader(
+				`{"object":0,"method":0,"args":{"methodName":"nahida.live/desktop/internal/mod.Mod.Toggle","call-id":"cancel-me","args":["mod"]}}`,
+			)).WithContext(ctx)
+			request.Header.Set("x-wails-window-id", "7")
+			response := httptest.NewRecorder()
+			done := make(chan struct{})
+			go func() { handler.ServeHTTP(response, request); close(done) }()
+			waitStartupPending(t, rt.startup, "cancel-me")
+			switch kind {
+			case "call":
+				handler.ServeHTTP(
+					httptest.NewRecorder(),
+					httptest.NewRequest(http.MethodPost, "/wails/runtime", strings.NewReader(
+						`{"object":10,"method":0,"args":{"call-id":"cancel-me"}}`,
+					)),
+				)
+			case "window":
+				rt.startup.cancelWindow(7, "main")
+			case "request":
+				cancel()
+			case "shutdown":
+				rt.startup.stop()
+			}
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("cancelled request remained queued")
+			}
+			rt.startup.start(func(context.Context) {})
+			if calls.Load() != 0 || response.Code != http.StatusServiceUnavailable {
+				t.Fatal("cancelled file operation reached the service")
+			}
+		})
+	}
+}
+
+func waitStartupPending(t *testing.T, s *startupWork, id string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		s.mu.Lock()
+		pending := s.pending[id] != nil
+		s.mu.Unlock()
+		if pending {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("request did not enter startup gate")
+}
+
+func TestStartupMiddlewareDoesNotForwardUninspectableSubmissions(t *testing.T) {
+	t.Parallel()
+	s := newStartupWork()
+	t.Cleanup(s.stop)
+	var calls int
+	handler := s.middleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { calls++ }))
+	chunk := httptest.NewRequest(http.MethodPost, "/wails/runtime", strings.NewReader("partial JSON"))
+	chunk.Header.Set("x-wails-chunk-id", "large-call")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, chunk)
+	if calls != 0 || response.Code != http.StatusServiceUnavailable {
+		t.Fatal("chunked call bypassed maintenance")
+	}
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/wails/runtime?object=0&method=0", nil))
+	if calls != 0 || response.Code != http.StatusServiceUnavailable {
+		t.Fatal("query-string call bypassed maintenance")
+	}
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/wails/runtime", strings.NewReader("{not json")))
+	if calls != 0 || response.Code != http.StatusServiceUnavailable {
+		t.Fatal("malformed envelope bypassed maintenance")
+	}
+	s.start(func(context.Context) {})
+	if err := s.wait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	handler.ServeHTTP(httptest.NewRecorder(), chunk)
+	if calls != 1 {
+		t.Fatal("chunked transport remained blocked after startup")
+	}
+}
+
+func TestFileMutatingServicesAreBound(t *testing.T) {
+	t.Parallel()
+	rt := newRuntime()
+	bound := map[reflect.Type]bool{}
+	for _, service := range rt.services() {
+		bound[reflect.TypeOf(service.Instance())] = true
+	}
+	if len(rt.fileMutatingServices()) == 0 {
+		t.Fatal("file-mutating services are empty")
+	}
+	for _, service := range rt.fileMutatingServices() {
+		if !bound[reflect.TypeOf(service.Instance())] {
+			t.Errorf("file-mutating %T is not registered in services()", service.Instance())
+		}
+	}
+}

--- a/internal/mod/compression.go
+++ b/internal/mod/compression.go
@@ -109,6 +109,18 @@ func (m *Mod) StartCompression(ctx context.Context) error {
 	return nil
 }
 
+// WaitCompressionPass waits for the reconciliation run started by
+// StartCompression to stop before returning. Startup uses it to keep
+// file-mutating calls gated while mod files are being rewritten.
+//
+//wails:ignore
+func (m *Mod) WaitCompressionPass(ctx context.Context) error {
+	if m == nil || m.compression == nil {
+		return nil
+	}
+	return m.compression.waitForRun(ctx)
+}
+
 func (m *Mod) GetCompressionState(ctx context.Context) (CompressionState, error) {
 	if m == nil || m.compression == nil {
 		return CompressionState{}, errors.New("mod compression is not configured")
@@ -367,6 +379,23 @@ func (c *compressionCoordinator) run(ctx context.Context, done chan struct{}, wo
 		c.deriveCapabilitiesLocked()
 		c.mu.Unlock()
 		c.publish()
+	}
+}
+
+// waitForRun blocks until the reconciliation run that is active when it is
+// called stops. Runs started later by watcher events are not awaited.
+func (c *compressionCoordinator) waitForRun(ctx context.Context) error {
+	c.mu.Lock()
+	done := c.done
+	c.mu.Unlock()
+	if done == nil {
+		return nil
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/internal/mod/compression_coordinator_test.go
+++ b/internal/mod/compression_coordinator_test.go
@@ -810,6 +810,85 @@ func TestCompressionWatcherMergesMultipleModScopes(t *testing.T) {
 	t.Fatal("watcher did not process every changed mod scope")
 }
 
+type blockingReconcileImporterSource struct {
+	inner   compressionImporterSource
+	mu      sync.Mutex
+	calls   int
+	once    sync.Once
+	started chan struct{}
+	release chan struct{}
+}
+
+// GetEnabledImporters lets the first call (watcher setup) through and blocks
+// the second one (the reconcile pass) until the test releases it.
+func (s *blockingReconcileImporterSource) GetEnabledImporters(
+	ctx context.Context,
+) ([]xxmi.EnabledImporter, error) {
+	s.mu.Lock()
+	s.calls++
+	blocking := s.calls > 1
+	s.mu.Unlock()
+	if !blocking {
+		return s.inner.GetEnabledImporters(ctx)
+	}
+	s.once.Do(func() { close(s.started) })
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-s.release:
+	}
+	return s.inner.GetEnabledImporters(ctx)
+}
+
+func TestWaitCompressionPassWaitsForInitialReconcile(t *testing.T) {
+	ctx := context.Background()
+	base := t.TempDir()
+	settings, err := setting.Open(ctx, filepath.Join(base, "compression.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	importer := filepath.Join(base, "Importer")
+	if err := os.MkdirAll(filepath.Join(importer, "Mods"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := &blockingReconcileImporterSource{
+		inner:   compressionImporterSource{{Key: "A", ImporterFolder: importer}},
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	m := NewWithOptions(Options{Settings: settings, XXMI: source})
+	m.UseClient(settings.Client())
+	t.Cleanup(func() {
+		_ = m.ServiceShutdown()
+		_ = settings.Close()
+	})
+	if err := m.StartCompression(ctx); err != nil {
+		t.Fatal(err)
+	}
+	awaitZstdSignal(t, source.started)
+
+	waited := make(chan error, 1)
+	go func() { waited <- m.WaitCompressionPass(ctx) }()
+	select {
+	case err := <-waited:
+		t.Fatalf("wait returned before reconciliation finished: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	if err := m.WaitCompressionPass(canceled); !errors.Is(err, context.Canceled) {
+		t.Fatalf("wait with canceled context = %v", err)
+	}
+	close(source.release)
+	if err := awaitZstdResult(t, waited); err != nil {
+		t.Fatal(err)
+	}
+	if state := m.compression.snapshot(); state.Status != "idle" {
+		t.Fatalf("state = %+v", state)
+	}
+}
+
 func waitForCompression(t *testing.T, coordinator *compressionCoordinator) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)

--- a/internal/tools/fixer_4001.go
+++ b/internal/tools/fixer_4001.go
@@ -225,20 +225,6 @@ func (t *Tools) FourThousandOneFixerUpdateReleases(ctx context.Context) error {
 	return err
 }
 
-// Start4001ReleasePrefetch mirrors the Electron service constructor's
-// best-effort release warmup without delaying application startup.
-//
-//wails:ignore
-func (t *Tools) Start4001ReleasePrefetch() {
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		if err := t.FourThousandOneFixerUpdateReleases(ctx); err != nil && t.log != nil {
-			t.log.Warn("Automatic XXMI libs release prefetch failed: "+err.Error(), "4001Fixer:updateReleases")
-		}
-	}()
-}
-
 func (t *Tools) FourThousandOneFixerGetBuildToolsPath(ctx context.Context) (string, error) {
 	value, err := t.getAppState(ctx, fixer4001VSDevCmdPathKey)
 	if err != nil || value == nil {
@@ -785,6 +771,9 @@ func (t *Tools) CleanupStaleD3DBuilds(ctx context.Context) error {
 	}
 	root := filepath.Join(os.TempDir(), d3dBuildTempDirName)
 	for _, state := range states {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		id := strings.TrimPrefix(state.Key, d3dBuildStatePrefix)
 		if d3dBuildIDRE.MatchString(id) {
 			t.reportCleanup(os.RemoveAll(filepath.Join(root, id)), "CleanupStaleD3DBuilds")

--- a/internal/tools/mod_bisect.go
+++ b/internal/tools/mod_bisect.go
@@ -104,6 +104,12 @@ func (t *Tools) BisectValidateExcludePath(ctx context.Context, game, inputPath s
 func (t *Tools) BisectStart(ctx context.Context, game string, excludePaths []string) (BisectSnapshot, error) {
 	t.bisectMu.Lock()
 	defer t.bisectMu.Unlock()
+	if t.bisectRecovering {
+		//nolint:staticcheck // Electron contract text.
+		return BisectSnapshot{}, errors.New(
+			"Cannot start a bisect session while recovery is running.",
+		)
+	}
 	if t.bisect != nil && t.bisect.finalBadPath == nil {
 		//nolint:staticcheck // Electron contract text.
 		return BisectSnapshot{}, errors.New(
@@ -381,29 +387,33 @@ func (t *Tools) BisectCancel(ctx context.Context) (BisectSnapshot, error) {
 }
 
 func (t *Tools) BisectRecover(ctx context.Context, game string) (int, error) {
-	t.bisectMu.Lock()
-	defer t.bisectMu.Unlock()
-	if t.bisect != nil {
+	if err := t.beginBisectRecovery(); err != nil {
 		//nolint:staticcheck // Electron contract text.
 		return 0, errors.New(
 			"Cannot recover while a bisect session is active.",
 		)
 	}
+	defer t.endBisectRecovery()
 	config, err := t.requireBisectGame(ctx, game)
 	if err != nil {
 		return 0, err
 	}
-	paths, err := listBisectOrphans(config.ModFolderPath)
+	paths, err := listBisectOrphans(ctx, config.ModFolderPath)
 	if err != nil {
 		return 0, err
 	}
-	return t.recoverINIs(paths), nil
+	return t.recoverINIs(ctx, paths), ctx.Err()
 }
 
 // RecoverBisects restores interrupted sessions for every configured non-NTE game.
 //
 //wails:ignore
 func (t *Tools) RecoverBisects(ctx context.Context) error {
+	if err := t.beginBisectRecovery(); err != nil {
+		return err
+	}
+	defer t.endBisectRecovery()
+
 	client, err := t.requireClient()
 	if err != nil {
 		return err
@@ -413,19 +423,38 @@ func (t *Tools) RecoverBisects(ctx context.Context) error {
 		return err
 	}
 	for _, game := range games {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		if game.ModFolderPath == "" || game.Importer != nil && *game.Importer == "NTE" {
 			continue
 		}
 		if err := t.recoverD3dxBackupLocked(ctx, game); err != nil {
 			t.logError(err, "ModBisect:d3dxRecover")
 		}
-		orphans, err := listBisectOrphans(game.ModFolderPath)
+		orphans, err := listBisectOrphans(ctx, game.ModFolderPath)
 		if err != nil {
 			return err
 		}
-		t.recoverINIs(orphans)
+		t.recoverINIs(ctx, orphans)
 	}
+	return ctx.Err()
+}
+
+func (t *Tools) beginBisectRecovery() error {
+	t.bisectMu.Lock()
+	defer t.bisectMu.Unlock()
+	if t.bisect != nil || t.bisectRecovering {
+		return errors.New("cannot recover while a bisect session is active")
+	}
+	t.bisectRecovering = true
 	return nil
+}
+
+func (t *Tools) endBisectRecovery() {
+	t.bisectMu.Lock()
+	t.bisectRecovering = false
+	t.bisectMu.Unlock()
 }
 
 func (t *Tools) requireBisectGame(ctx context.Context, game string) (db.GamePathRow, error) {
@@ -487,9 +516,12 @@ func (t *Tools) shutdownBisect() error {
 	return t.cancelBisectLocked()
 }
 
-func (t *Tools) recoverINIs(paths []string) int {
+func (t *Tools) recoverINIs(ctx context.Context, paths []string) int {
 	restored := 0
 	for _, original := range paths {
+		if ctx.Err() != nil {
+			break
+		}
 		disabled := bisectDisabledPath(original)
 		if _, err := os.Stat(original); err == nil {
 			if err := os.Remove(disabled); err == nil || errors.Is(err, os.ErrNotExist) {
@@ -753,9 +785,12 @@ func keepBisectINIDisabled(originalPath, style string) error {
 	return nil
 }
 
-func listBisectOrphans(root string) ([]string, error) {
+func listBisectOrphans(ctx context.Context, root string) ([]string, error) {
 	var paths []string
 	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		if err != nil {
 			return err
 		}

--- a/internal/tools/mod_bisect_d3dx.go
+++ b/internal/tools/mod_bisect_d3dx.go
@@ -198,6 +198,9 @@ func (t *Tools) recoverD3dxBackupLocked(ctx context.Context, game db.GamePathRow
 		} else if err != nil {
 			return err
 		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		if err := os.WriteFile(path, backup, 0o600); err != nil {
 			return err
 		}

--- a/internal/tools/model_viewer_cleanup.go
+++ b/internal/tools/model_viewer_cleanup.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -15,17 +16,20 @@ const legacyModelViewerTempPrefix = "nhd-model-viewer-"
 // can retain old directories in the Windows temp root.
 //
 //wails:ignore
-func (t *Tools) CleanupStaleModelViewerDirs() error {
-	return cleanupStaleModelViewerDirs(os.TempDir())
+func (t *Tools) CleanupStaleModelViewerDirs(ctx context.Context) error {
+	return cleanupStaleModelViewerDirs(ctx, os.TempDir())
 }
 
-func cleanupStaleModelViewerDirs(tempRoot string) error {
+func cleanupStaleModelViewerDirs(ctx context.Context, tempRoot string) error {
 	entries, err := os.ReadDir(tempRoot)
 	if err != nil {
 		return fmt.Errorf("read model viewer temp root: %w", err)
 	}
 	var cleanupErrs []error
 	for _, entry := range entries {
+		if ctx.Err() != nil {
+			return errors.Join(ctx.Err(), errors.Join(cleanupErrs...))
+		}
 		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), legacyModelViewerTempPrefix) {
 			continue
 		}

--- a/internal/tools/model_viewer_cleanup_test.go
+++ b/internal/tools/model_viewer_cleanup_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,7 +26,7 @@ func TestCleanupStaleModelViewerDirsOnlyRemovesMatchingDirectories(t *testing.T)
 		t.Fatal(err)
 	}
 
-	if err := cleanupStaleModelViewerDirs(root); err != nil {
+	if err := cleanupStaleModelViewerDirs(context.Background(), root); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(stale); !os.IsNotExist(err) {

--- a/internal/tools/startup_test.go
+++ b/internal/tools/startup_test.go
@@ -1,0 +1,63 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCancelledBisectRecoveryLeavesOrphansForNextLaunch(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	service, _, _ := newBisectTestService(t, root)
+	original := filepath.Join(root, "mod.ini")
+	disabled := bisectDisabledPath(original)
+	if err := os.WriteFile(disabled, []byte("preserve"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := listBisectOrphans(ctx, root); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled directory walk = %v", err)
+	}
+	if restored := service.recoverINIs(ctx, []string{original}); restored != 0 {
+		t.Fatal("cancelled recovery changed files")
+	}
+	if _, err := os.Stat(disabled); err != nil {
+		t.Fatal("cancelled recovery lost the pending INI")
+	}
+	if err := service.RecoverBisects(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if content, err := os.ReadFile(original); err != nil || string(content) != "preserve" {
+		t.Fatalf("next launch did not restore INI: %q, %v", content, err)
+	}
+}
+
+func TestBisectStartRejectedDuringRecovery(t *testing.T) {
+	t.Parallel()
+	service, _, _ := newBisectTestService(t, t.TempDir())
+	service.bisectRecovering = true
+	if _, err := service.BisectStart(context.Background(), "test", nil); err == nil {
+		t.Fatal("bisect started while recovery was marked in progress")
+	}
+}
+
+func TestCancelledTempCleanupPreservesPendingDirectory(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	stale := filepath.Join(root, legacyModelViewerTempPrefix+"old")
+	if err := os.Mkdir(stale, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := cleanupStaleModelViewerDirs(ctx, root); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled cleanup = %v", err)
+	}
+	if _, err := os.Stat(stale); err != nil {
+		t.Fatal("cancelled cleanup removed a directory")
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -75,9 +75,10 @@ type Tools struct {
 	runMu sync.Mutex
 	run   *toolRun
 
-	bisectMu sync.Mutex
-	bisect   *bisectSession
-	d3dx     *d3dxGuard
+	bisectMu         sync.Mutex
+	bisect           *bisectSession
+	bisectRecovering bool
+	d3dx             *d3dxGuard
 
 	fixerMu       sync.Mutex
 	fixerTask     *string
@@ -212,9 +213,6 @@ func (t *Tools) UseClient(client *db.Client) {
 //wails:ignore
 func (t *Tools) UseAppData(data *appdata.Store) {
 	t.appData = data
-	if err := t.zzmiCleanupAbandonedStaging(); err != nil {
-		t.logError(err, "ZZMIFixerCleanup")
-	}
 }
 
 func (t *Tools) appDataPath(relative string) (string, error) {

--- a/internal/tools/zzmi_mod_fixer.go
+++ b/internal/tools/zzmi_mod_fixer.go
@@ -951,7 +951,8 @@ func secureSessionOriginal(target, candidate string) (string, error) {
 	return candidateAbs, nil
 }
 
-func (t *Tools) zzmiCleanupAbandonedStaging() error {
+//wails:ignore
+func (t *Tools) CleanupZZMIAbandonedStaging(ctx context.Context) error {
 	if t == nil || t.appData == nil {
 		return nil
 	}
@@ -967,6 +968,9 @@ func (t *Tools) zzmiCleanupAbandonedStaging() error {
 		return err
 	}
 	for _, target := range targets {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		if !target.IsDir() || target.Type()&os.ModeSymlink != 0 {
 			continue
 		}
@@ -975,6 +979,9 @@ func (t *Tools) zzmiCleanupAbandonedStaging() error {
 			return readErr
 		}
 		for _, entry := range sessions {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			if !entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
 				continue
 			}
@@ -1008,6 +1015,7 @@ func (t *Tools) zzmiCleanupAbandonedStaging() error {
 	}
 	return nil
 }
+
 func writeSyncFile(path string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err

--- a/internal/tools/zzmi_mod_fixer_test.go
+++ b/internal/tools/zzmi_mod_fixer_test.go
@@ -165,7 +165,7 @@ func TestZZMICleanupMarksInterruptedSessionPartial(t *testing.T) {
 	if err := writeZZMISession(dir, session); err != nil {
 		t.Fatal(err)
 	}
-	if err := service.zzmiCleanupAbandonedStaging(); err != nil {
+	if err := service.CleanupZZMIAbandonedStaging(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "staging")); !os.IsNotExist(err) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added coordinated startup readiness for maintenance, recovery, and compression tasks.
  - File-changing operations now wait until required startup work is ready.
  - Startup request handling now enforces a 64 MiB body limit.

- **Bug Fixes**
  - Canceled startup and recovery operations stop safely without partial writes.
  - Requests canceled during startup are no longer executed.
  - Bisect recovery prevents overlapping operations and can resume cleanly later.

- **Tests**
  - Added coverage for startup sequencing, cancellation, request gating, cleanup, and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->